### PR TITLE
Feat/mss util

### DIFF
--- a/utils/signer/BUILD
+++ b/utils/signer/BUILD
@@ -1,0 +1,30 @@
+cc_binary(
+    name = "mssign",
+    srcs = ["mssign.c"],
+    data = [],
+    deps = 
+        [
+          "@com_github_gflags_gflags//:gflags",
+          "//common/sign/v2:iss_curl",
+          "//common/curl-p:trit",
+          "//common/kerl:kerl",
+          "//common/kerl:hash",
+          "//common/trinary:trit_tryte",
+          "//mam/v1:merkle",
+        ],
+)
+
+cc_binary(
+    name = "msstree",
+    srcs = ["msstree.c"],
+    data = [],
+    deps = 
+        [
+          "@com_github_gflags_gflags//:gflags",
+          "//common/sign/v2:iss_curl",
+          "//common/curl-p:trit",
+          "//common/kerl:kerl",
+          "//common/trinary:trit_tryte",
+          "//mam/v1:merkle",
+        ],
+)

--- a/utils/signer/BUILD
+++ b/utils/signer/BUILD
@@ -1,4 +1,20 @@
 cc_binary(
+    name = "mssverify",
+    srcs = ["mssverify.c"],
+    data = [],
+    deps = 
+        [
+          "@com_github_gflags_gflags//:gflags",
+          "//common/sign/v2:iss_curl",
+          "//common/curl-p:trit",
+          "//common/kerl:kerl",
+          "//common/kerl:hash",
+          "//common/trinary:trit_tryte",
+          "//mam/v1:merkle",
+        ],
+)
+
+cc_binary(
     name = "mssign",
     srcs = ["mssign.c"],
     data = [],

--- a/utils/signer/mssign.c
+++ b/utils/signer/mssign.c
@@ -1,0 +1,181 @@
+#include "common/curl-p/trit.h"
+#include "common/kerl/hash.h"
+#include "common/sign/v2/iss_curl.h"
+#include "common/trinary/trit_tryte.h"
+#include "mam/v1/merkle.h"
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define CHARGS "d:s:i:x:t:"
+
+static struct option long_options[] = {
+    {"message", required_argument, NULL, 'm'},
+    {"seed", required_argument, NULL, 's'},
+    {"index", required_argument, NULL, 'i'},
+    {"sec-level", required_argument, NULL, 'x'},
+    {"tree", required_argument, NULL, 't'},
+    {NULL, 0, NULL, 0}};
+
+typedef struct {
+  int key_i;
+  int64_t offset;
+  size_t sec;
+  trit_t *msg;
+  size_t msg_len;
+  trit_t seed[HASH_LENGTH];
+  trit_t *tree;
+  size_t tree_len;
+  size_t n_leafs;
+} ToSign;
+
+int test_hash(trit_t *hash, size_t security) {
+  size_t i;
+  size_t sum = 0;
+
+  for (i = 0; i < HASH_LENGTH / 3; i++) {
+    sum += hash[i];
+  }
+  if (security == 1 && sum != 0) {
+    return 1;
+  }
+  for (i = HASH_LENGTH / 3; i < 2 * HASH_LENGTH / 3; i++) {
+    sum += hash[i];
+  }
+  if (security == 2 && sum != 0) {
+    return 1;
+  }
+  for (i = 2 * HASH_LENGTH / 3; i < HASH_LENGTH; i++) {
+    sum += hash[i];
+  }
+  return sum != 0;
+}
+
+int increment_trits(trit_t *t, size_t length) {
+  trit_t *end = &t[length];
+  trit_t c = 0;
+  for (; t < end; t++) {
+    (*t) += 1 + c;
+    c = *t > 1;
+    if (c) {
+      *t = -1;
+    } else {
+      break;
+    }
+  }
+  return t == end;
+}
+
+int find_nonce(ToSign *args, trit_t *hash) {
+  trit_t nonce[HASH_LENGTH] = {0};
+  tryte_t nonce_str[(HASH_LENGTH / 9) + 1] = {0};
+  Kerl k, k_copy;
+  init_kerl(&k);
+  kerl_absorb(&k, args->msg, args->msg_len);
+  memcpy(&k_copy, &k, sizeof(Kerl));
+  do {
+    memcpy(&k, &k_copy, sizeof(Kerl));
+    increment_trits(nonce, HASH_LENGTH / 3);
+    kerl_hash(nonce, HASH_LENGTH, hash, &k);
+  } while (test_hash(hash, args->sec));
+  trits_to_trytes(nonce, nonce_str, sizeof(nonce) / sizeof(trit_t));
+  fprintf(stdout, "%s\n", nonce_str);
+  return 0;
+}
+
+int leaf_count(size_t count, size_t depth, size_t acc) {
+  size_t acc_next = acc + (1 << depth);
+  if (acc_next >= count) {
+    return 1 << depth;
+  }
+  return leaf_count(count, depth + 1, acc_next);
+}
+
+void print_siblings(ToSign *args) {
+  size_t depth, sib_length;
+
+  depth = merkle_depth(args->n_leafs);
+  sib_length = (depth - 1) * HASH_LENGTH;
+
+  trit_t sib_branch[sib_length];
+  tryte_t siblings[((depth - 1) * HASH_LENGTH / 3) + 1];
+
+  memset(sib_branch, 0, sizeof(sib_branch));
+  memset(siblings, 0, sizeof(siblings));
+
+  merkle_branch(args->tree, sib_branch, args->tree_len * HASH_LENGTH, depth,
+                args->key_i, args->n_leafs);
+  trits_to_trytes(sib_branch, siblings, sib_length);
+  fprintf(stdout, "%s\n", siblings);
+}
+
+int merkle_sign(ToSign *args) {
+  size_t key_length = ISS_KEY_LENGTH * args->sec;
+  Curl c;
+  c.type = CURL_P_81;
+  init_curl(&c);
+  {
+    trit_t sigkey[key_length];
+    tryte_t signature[(key_length / 3) + 1];
+    trit_t hash[HASH_LENGTH] = {0};
+    find_nonce(args, hash);
+
+    memset(signature, 0, sizeof(signature));
+
+    iss_curl_key(args->seed, sigkey, key_length, &c);
+    curl_reset(&c);
+    iss_curl_signature(sigkey, hash, 0, sigkey, key_length, &c);
+    curl_reset(&c);
+    trits_to_trytes(sigkey, signature, key_length);
+    fprintf(stdout, "%s\n", signature);
+  }
+  print_siblings(args);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  char ch;
+  size_t l;
+  ToSign field = {0};
+  while ((ch = getopt_long(argc, argv, CHARGS, long_options, NULL)) != -1) {
+    // check to see if a single character or long option came through
+    switch (ch) {
+      case 'm':
+        l = strlen(optarg);
+        field.msg_len = l * 3;
+        field.msg = calloc(field.msg_len, sizeof(trit_t));
+        trytes_to_trits((tryte_t *)optarg, field.msg, l);
+        break;
+      case 's':
+        trytes_to_trits((tryte_t *)optarg, field.seed,
+                        strnlen(optarg, HASH_LENGTH / 3));
+        break;
+      case 't':
+        l = strlen(optarg);
+        field.tree_len = l * 3;
+        field.n_leafs = leaf_count(field.tree_len / HASH_LENGTH, 0, 0);
+        field.tree = calloc(field.tree_len, sizeof(trit_t));
+        trytes_to_trits((tryte_t *)optarg, field.tree, l);
+        break;
+      case 'i':
+        field.key_i = strtol(optarg, (char **)NULL, 10);
+        break;
+      case 'x':
+        field.sec = strtol(optarg, (char **)NULL, 10);
+        break;
+      case 'o':
+        field.offset = strtol(optarg, (char **)NULL, 10);
+        break;
+    }
+  }
+  if (field.sec == 0) {
+    field.sec = 1;
+  }
+  if (field.key_i >= field.n_leafs) {
+    printf("key index outside of range\n");
+    exit(1);
+  }
+  return merkle_sign(&field);
+}

--- a/utils/signer/mssign.c
+++ b/utils/signer/mssign.c
@@ -108,7 +108,8 @@ void print_siblings(ToSign *args) {
   merkle_branch(args->tree, sib_branch, args->tree_len * HASH_LENGTH, depth,
                 args->key_i, args->n_leafs);
   trits_to_trytes(sib_branch, siblings, sib_length);
-  fprintf(stdout, "%s\n", siblings);
+  fprintf(stdout, "%d\n", args->key_i);
+  fprintf(stdout, "%s", siblings);
 }
 
 int merkle_sign(ToSign *args) {

--- a/utils/signer/mssign.c
+++ b/utils/signer/mssign.c
@@ -124,6 +124,7 @@ int merkle_sign(ToSign *args) {
 
     memset(signature, 0, sizeof(signature));
 
+    iss_curl_subseed(args->seed, args->seed, args->key_i, &c);
     iss_curl_key(args->seed, sigkey, key_length, &c);
     curl_reset(&c);
     iss_curl_signature(sigkey, hash, 0, sigkey, key_length, &c);

--- a/utils/signer/msstree.c
+++ b/utils/signer/msstree.c
@@ -1,0 +1,68 @@
+#include "common/curl-p/trit.h"
+#include "common/sign/v2/iss_curl.h"
+#include "common/trinary/trit_tryte.h"
+#include "mam/v1/merkle.h"
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define CHARGS "s:l:x:o:"
+
+static struct option long_options[] = {
+    {"seed", required_argument, NULL, 's'},
+    {"leaf-count", required_argument, NULL, 'l'},
+    {"sec-level", required_argument, NULL, 'x'},
+    {"offset", required_argument, NULL, 'o'},
+    {NULL, 0, NULL, 0}};
+
+typedef struct {
+  int n_key;
+  int key_i;
+  int64_t offset;
+  size_t sec;
+  trit_t seed[HASH_LENGTH];
+} ToSign;
+
+int main(int argc, char *argv[]) {
+  char ch;
+  ToSign args = {0};
+  while ((ch = getopt_long(argc, argv, CHARGS, long_options, NULL)) != -1) {
+    // check to see if a single character or long option came through
+    switch (ch) {
+      case 's':
+        trytes_to_trits((tryte_t *)optarg, args.seed,
+                        strnlen(optarg, HASH_LENGTH / 3));
+        break;
+      case 'l':
+        args.n_key = strtol(optarg, (char **)NULL, 10);
+        break;
+      case 'x':
+        args.sec = strtol(optarg, (char **)NULL, 10);
+        break;
+      case 'o':
+        args.offset = strtol(optarg, (char **)NULL, 10);
+        break;
+    }
+  }
+  if (args.sec == 0) {
+    args.sec = 1;
+  }
+  Curl c;
+  size_t size = merkle_size(args.n_key);
+  trit_t tree[HASH_LENGTH * size];
+  tryte_t tree_trytes[HASH_LENGTH * size / 3 + 1];
+
+  c.type = CURL_P_81;
+  init_curl(&c);
+
+  memset(tree, 0, sizeof(tree));
+  memset(tree_trytes, 0, sizeof(tree_trytes));
+
+  merkle_create(tree, args.n_key, args.seed, args.offset, args.sec, &c);
+  trits_to_trytes(tree, tree_trytes, sizeof(tree) / sizeof(trit_t));
+  fprintf(stdout, "%s\n", tree_trytes);
+
+  return 0;
+}

--- a/utils/signer/mssverify.c
+++ b/utils/signer/mssverify.c
@@ -9,10 +9,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#define CHARGS "m:n:s:i:x:"
+#define CHARGS "m:n:s:i:x:f:"
 
 static struct option long_options[] = {
     {"message", required_argument, NULL, 'm'},
+    {"fullsig", required_argument, NULL, 'f'},
     {"nonce", required_argument, NULL, 'n'},
     {"signature", required_argument, NULL, 's'},
     {"index", required_argument, NULL, 'i'},
@@ -21,26 +22,25 @@ static struct option long_options[] = {
 
 typedef struct {
   tryte_t *msg;
-  size_t msg_len;
   tryte_t *nonce;
-  size_t nonce_len;
   tryte_t *sig;
-  size_t sig_len;
   tryte_t *sib;
-  size_t sib_len;
   size_t i;
 } ToVerify;
 
 int merkle_verify(ToVerify *args) {
   trit_t hash[HASH_LENGTH];
   {
+    size_t nonce_len, msg_len;
     Kerl k;
     init_kerl(&k);
-    trit_t nonce[args->nonce_len * 3];
-    trit_t msg[args->msg_len * 3];
-    trytes_to_trits(args->msg, msg, args->msg_len);
+    nonce_len = strlen((char *)args->nonce);
+    msg_len = strlen((char *)args->msg);
+    trit_t nonce[nonce_len * 3];
+    trit_t msg[msg_len * 3];
+    trytes_to_trits(args->msg, msg, msg_len);
     if (args->nonce) {
-      trytes_to_trits(args->nonce, nonce, args->nonce_len);
+      trytes_to_trits(args->nonce, nonce, nonce_len);
       kerl_absorb(&k, msg, sizeof(msg) / sizeof(trit_t));
       kerl_hash(nonce, sizeof(nonce) / sizeof(trit_t), hash, &k);
     } else {
@@ -53,21 +53,22 @@ int merkle_verify(ToVerify *args) {
     c.type = CURL_P_81;
     init_curl(&c);
     {
-      trit_t sig[args->sig_len * 3];
+      size_t sig_len = strlen((char *)args->sig);
+      trit_t sig[sig_len * 3];
 
       memset(sig, 0, sizeof(sig));
 
-      trytes_to_trits(args->sig, sig, args->sig_len);
-      iss_curl_sig_digest(hash, hash, 0, sig, args->sig_len * 3, &c);
+      trytes_to_trits(args->sig, sig, sig_len);
+      iss_curl_sig_digest(hash, hash, 0, sig, sig_len * 3, &c);
       iss_curl_address(hash, hash, HASH_LENGTH, &c);
       curl_reset(&c);
     }
     {
-      trit_t sib[args->sib_len * 3];
+      size_t sib_len = strlen((char *)args->sib);
+      trit_t sib[sib_len * 3];
       tryte_t root[HASH_LENGTH / 3 + 1] = {0};
-      trytes_to_trits(args->sib, sib, args->sib_len);
+      trytes_to_trits(args->sib, sib, sib_len);
 
-      printf("got this far nonco\n");
       merkle_root(hash, sib, sizeof(sib) / HASH_LENGTH, args->i, &c);
       trits_to_trytes(hash, root, HASH_LENGTH);
       fprintf(stdout, "%s\n", root);
@@ -77,35 +78,59 @@ int merkle_verify(ToVerify *args) {
 }
 
 int main(int argc, char *argv[]) {
-  char ch;
+  char ch, *c;
   ToVerify field = {0};
   while ((ch = getopt_long(argc, argv, CHARGS, long_options, NULL)) != -1) {
     // check to see if a single character or long option came through
     switch (ch) {
       case 'm':
-        field.msg_len = strlen(optarg);
         field.msg = (tryte_t *)optarg;
         break;
       case 'n':
-        field.nonce_len = strlen(optarg);
         field.nonce = (tryte_t *)optarg;
         break;
       case 's':
-        field.sig_len = strlen(optarg);
         field.sig = (tryte_t *)optarg;
         break;
       case 'i':
         field.i = strtol(optarg, (char **)NULL, 10);
         break;
       case 'x':
-        field.sib_len = strlen(optarg);
         field.sib = (tryte_t *)optarg;
+        break;
+      case 'f':
+        c = malloc(strlen(optarg));
+        strcat(c, optarg);
+        field.nonce = (tryte_t *)c;
+        c = strchr(c, '\n');
+        if (!c) goto err;
+        *c = 0;
+        c++;
+        field.sig = (tryte_t *)c;
+        c = strchr(c, '\n');
+        if (!c) goto err;
+        *c = 0;
+        c++;
+        field.i = strtol(optarg, (char **)NULL, 10);
+        c = strchr(c, '\n');
+        if (!c) goto err;
+        *c = 0;
+        c++;
+        field.sib = (tryte_t *)c;
+        c = strchr(c, '\n');
+        if (c) {
+          *c = 0;
+        }
         break;
     }
   }
-  if (field.i >= (1 << (field.sib_len * 3 / HASH_LENGTH))) {
+  size_t count = strlen((char *)field.sib) * 3 / HASH_LENGTH;
+  if (field.i >= (1 << count)) {
     fprintf(stderr, "signature index out of range\n");
     exit(1);
   }
   return merkle_verify(&field);
+err:
+  fprintf(stderr, "invalid signature provided\n");
+  exit(1);
 }

--- a/utils/signer/mssverify.c
+++ b/utils/signer/mssverify.c
@@ -1,0 +1,111 @@
+#include "common/curl-p/trit.h"
+#include "common/kerl/hash.h"
+#include "common/sign/v2/iss_curl.h"
+#include "common/trinary/trit_tryte.h"
+#include "mam/v1/merkle.h"
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define CHARGS "m:n:s:i:x:"
+
+static struct option long_options[] = {
+    {"message", required_argument, NULL, 'm'},
+    {"nonce", required_argument, NULL, 'n'},
+    {"signature", required_argument, NULL, 's'},
+    {"index", required_argument, NULL, 'i'},
+    {"siblings", required_argument, NULL, 'x'},
+    {NULL, 0, NULL, 0}};
+
+typedef struct {
+  tryte_t *msg;
+  size_t msg_len;
+  tryte_t *nonce;
+  size_t nonce_len;
+  tryte_t *sig;
+  size_t sig_len;
+  tryte_t *sib;
+  size_t sib_len;
+  size_t i;
+} ToVerify;
+
+int merkle_verify(ToVerify *args) {
+  trit_t hash[HASH_LENGTH];
+  {
+    Kerl k;
+    init_kerl(&k);
+    trit_t nonce[args->nonce_len * 3];
+    trit_t msg[args->msg_len * 3];
+    trytes_to_trits(args->msg, msg, args->msg_len);
+    if (args->nonce) {
+      trytes_to_trits(args->nonce, nonce, args->nonce_len);
+      kerl_absorb(&k, msg, sizeof(msg) / sizeof(trit_t));
+      kerl_hash(nonce, sizeof(nonce) / sizeof(trit_t), hash, &k);
+    } else {
+      kerl_hash(msg, sizeof(msg) / sizeof(trit_t), hash, &k);
+    }
+  }
+
+  {
+    Curl c;
+    c.type = CURL_P_81;
+    init_curl(&c);
+    {
+      trit_t sig[args->sig_len * 3];
+
+      memset(sig, 0, sizeof(sig));
+
+      trytes_to_trits(args->sig, sig, args->sig_len);
+      iss_curl_sig_digest(hash, hash, 0, sig, args->sig_len * 3, &c);
+      iss_curl_address(hash, hash, HASH_LENGTH, &c);
+      curl_reset(&c);
+    }
+    {
+      trit_t sib[args->sib_len * 3];
+      tryte_t root[HASH_LENGTH / 3 + 1] = {0};
+      trytes_to_trits(args->sib, sib, args->sib_len);
+
+      printf("got this far nonco\n");
+      merkle_root(hash, sib, sizeof(sib) / HASH_LENGTH, args->i, &c);
+      trits_to_trytes(hash, root, HASH_LENGTH);
+      fprintf(stdout, "%s\n", root);
+    }
+  }
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  char ch;
+  ToVerify field = {0};
+  while ((ch = getopt_long(argc, argv, CHARGS, long_options, NULL)) != -1) {
+    // check to see if a single character or long option came through
+    switch (ch) {
+      case 'm':
+        field.msg_len = strlen(optarg);
+        field.msg = (tryte_t *)optarg;
+        break;
+      case 'n':
+        field.nonce_len = strlen(optarg);
+        field.nonce = (tryte_t *)optarg;
+        break;
+      case 's':
+        field.sig_len = strlen(optarg);
+        field.sig = (tryte_t *)optarg;
+        break;
+      case 'i':
+        field.i = strtol(optarg, (char **)NULL, 10);
+        break;
+      case 'x':
+        field.sib_len = strlen(optarg);
+        field.sib = (tryte_t *)optarg;
+        break;
+    }
+  }
+  if (field.i >= (1 << (field.sib_len * 3 / HASH_LENGTH))) {
+    fprintf(stderr, "signature index out of range\n");
+    exit(1);
+  }
+  return merkle_verify(&field);
+}


### PR DESCRIPTION
Added two utils: one to generate Curl-P-81 iss v2 merkle tree (as mam uses), and one to sign (v2) a message (must be padded to 81 trytes) whose digest is generated with Kerl.
