### PR TITLE
Added toolchain project for cross compiling.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,8 @@
 steps:
   - name: "bazel test opt"
     command: bazel test -c opt --test_output=all //...
+    agents:
+      queue: dev
     plugins:
       docker#v1.3.0:
         image: "th0br0/iota-buildenv:x86_64"
@@ -8,13 +10,17 @@ steps:
           - /conf:/conf
   - name: "bazel test debug"
     command: bazel test -c dbg --test_output=all //...
+    agents:
+      queue: dev
     plugins:
       docker#v1.3.0:
         image: "th0br0/iota-buildenv:x86_64"
         mounts:
           - /conf:/conf
   - name: "bazel test bootlin x86_64 toolchains"
-    command: bazel build --crosstool_top=@iota_toolchains//tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain  //...
+    command: bazel build --crosstool_top=@iota_toolchains//tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1:toolchain --cpu=x86_64 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain  //...
+    agents:
+      queue: dev
     plugins:
       docker#v1.3.0:
         image: "th0br0/iota-buildenv:x86_64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,10 @@ steps:
         image: "th0br0/iota-buildenv:x86_64"
         mounts:
           - /conf:/conf
+  - name: "bazel test i686 toolchains"
+    command: bazel build --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--bleeding-edge-2018.07-1:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain  //...
+    plugins:
+      docker#v1.3.0:
+        image: "th0br0/iota-buildenv:x86_64"
+        mounts:
+          - /conf:/conf

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           - /conf:/conf
 
   - name: "bazel test opt i686"
-    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--stable-2018.02-2:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c opt --test_output=all //...
+    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--bleeding-edge-2018.07-1:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c opt --test_output=all //...
     plugins:
       docker#v1.3.0:
         image: "th0br0/iota-buildenv:x86_64"
@@ -23,7 +23,7 @@ steps:
           - /conf:/conf
 
   - name: "bazel test debug i686"
-    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--stable-2018.02-2:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c dbg --test_output=all //...
+    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--bleeding-edge-2018.07-1:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c dbg --test_output=all //...
     plugins:
       docker#v1.3.0:
         image: "th0br0/iota-buildenv:x86_64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,19 +13,3 @@ steps:
         image: "th0br0/iota-buildenv:x86_64"
         mounts:
           - /conf:/conf
-
-  - name: "bazel test opt i686"
-    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--bleeding-edge-2018.07-1:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c opt --test_output=all //...
-    plugins:
-      docker#v1.3.0:
-        image: "th0br0/iota-buildenv:x86_64"
-        mounts:
-          - /conf:/conf
-
-  - name: "bazel test debug i686"
-    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--bleeding-edge-2018.07-1:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c dbg --test_output=all //...
-    plugins:
-      docker#v1.3.0:
-        image: "th0br0/iota-buildenv:x86_64"
-        mounts:
-          - /conf:/conf

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,19 @@ steps:
         image: "th0br0/iota-buildenv:x86_64"
         mounts:
           - /conf:/conf
+
+  - name: "bazel test opt i686"
+    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--stable-2018.02-2:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c opt --test_output=all //...
+    plugins:
+      docker#v1.3.0:
+        image: "th0br0/iota-buildenv:x86_64"
+        mounts:
+          - /conf:/conf
+
+  - name: "bazel test debug i686"
+    command: bazel test --crosstool_top=@iota_toolchains//tools/x86-i686--glibc--stable-2018.02-2:toolchain --cpu=i686 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain -c dbg --test_output=all //...
+    plugins:
+      docker#v1.3.0:
+        image: "th0br0/iota-buildenv:x86_64"
+        mounts:
+          - /conf:/conf

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,4 +27,5 @@ load("@rules_iota//:defs.bzl", "iota_deps")
 iota_deps()
 
 load("@iota_toolchains//:toolchains.bzl", "setup_toolchains")
+
 setup_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,12 @@ git_repository(
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 
+git_repository(
+    name = "iota_toolchains",
+    commit = "984a2e58bce68c2b74100d9fa1f3434e96e92d95",
+    remote = "https://github.com/iotaledger/toolchains.git",
+)
+
 android_sdk_repository(
     name = "androidsdk",
     api_level = 19,
@@ -19,3 +25,6 @@ android_ndk_repository(
 load("@rules_iota//:defs.bzl", "iota_deps")
 
 iota_deps()
+
+load("@iota_toolchains//:toolchains.bzl", "setup_toolchains")
+setup_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,13 +8,7 @@ git_repository(
 
 git_repository(
     name = "iota_toolchains",
-    commit = "984a2e58bce68c2b74100d9fa1f3434e96e92d95",
-    remote = "https://github.com/iotaledger/toolchains.git",
-)
-
-git_repository(
-    name = "iota_toolchains",
-    commit = "a273b913ae18ab80a6e0f5c96e254927ee7c9440",
+    commit = "6b501df8e7f3bc3b143c894737fbb1d82e914762",
     remote = "https://github.com/iotaledger/toolchains.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,12 @@ git_repository(
     remote = "https://github.com/iotaledger/toolchains.git",
 )
 
+git_repository(
+    name = "iota_toolchains",
+    commit = "a273b913ae18ab80a6e0f5c96e254927ee7c9440",
+    remote = "https://github.com/iotaledger/toolchains.git",
+)
+
 android_sdk_repository(
     name = "androidsdk",
     api_level = 19,

--- a/common/trinary/trit_array.h
+++ b/common/trinary/trit_array.h
@@ -102,9 +102,9 @@ static inline uint8_t flex_trit_array_set_at(flex_trit_t *const trit_array,
   uint8_t tindex = index % 5U;
   // Find out the index of the byte in the array
   index = index / 5U;
-  bytes_to_trits(((byte_t *)trit_array + index), 1, trits, 5);
+  bytes_to_trits((byte_t *)(trit_array + index), 1, trits, 5);
   trits[tindex] = trit;
-  trit_array[index] = trits_to_byte(trits, buffer, 5);
+  trit_array[index] = trits_to_byte(trits, 0, 5);
 #endif
   return 1;
 }

--- a/cppclient/tests/api_json.cc
+++ b/cppclient/tests/api_json.cc
@@ -56,10 +56,10 @@ TEST_F(IotaJsonAPITest, GetBalances) {
 
   api.response = res;
   EXPECT_CALL(api, post_()).Times(1);
-  EXPECT_EQ(api.request, req);
 
   auto response = api.getBalances(addresses);
 
+  EXPECT_EQ(api.request, req);
   EXPECT_EQ(response, expected);
 }
 

--- a/cppclient/tests/api_json.cc
+++ b/cppclient/tests/api_json.cc
@@ -23,10 +23,16 @@ class IotaJsonAPITest : public ::testing::Test {};
 
 class MockAPI : public IotaJsonAPI {
  public:
-  json req;
-  json res;
+  json request;
+  nonstd::optional<json> response;
 
-  MOCK_METHOD1(post, nonstd::optional<json>(const json&));
+  MOCK_METHOD0(post_, void(void));
+
+  nonstd::optional<json> post(const json& in) {
+    request = in;
+    post_();
+    return response;
+  }
 };
 
 TEST_F(IotaJsonAPITest, GetBalances) {
@@ -47,7 +53,10 @@ TEST_F(IotaJsonAPITest, GetBalances) {
   json res;
   res["balances"] = std::vector<std::string>{"1000"};
 
-  EXPECT_CALL(api, post(req)).Times(1).WillOnce(Return(res));
+
+  api.response = res;
+  EXPECT_CALL(api, post_()).Times(1);
+  EXPECT_EQ(api.request, req);
 
   auto response = api.getBalances(addresses);
 


### PR DESCRIPTION
Fixing #16 
Added default cross toolchains include aarch64(armv8), armv7, x86_64, i686, and a python script to generate bazel toolchain files (CROSSTOOL, BUILDs).

Aarch64 Testing:
`bazel build --crosstool_top=@iota_toolchains//tools/aarch64--glibc--stable-2018.02-2:toolchain --cpu=aarch64 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain --verbose_failures //cclient:api`