### PR TITLE
Add granularity to components API

### DIFF
--- a/ciri/main.c
+++ b/ciri/main.c
@@ -15,6 +15,11 @@ static node_t node_g;
 int main() {
   logger_init(LOG_DEBUG, false, stdout);
 
+  log_info("Initializing cIRI node");
+  if (node_init(&node_g) == false) {
+    return EXIT_FAILURE;
+  }
+
   log_info("Starting cIRI node");
   if (node_start(&node_g) == false) {
     return EXIT_FAILURE;
@@ -24,6 +29,11 @@ int main() {
 
   log_info("Stopping cIRI node");
   if (node_stop(&node_g) == false) {
+    return EXIT_FAILURE;
+  }
+
+  log_info("Destroying cIRI node");
+  if (node_destroy(&node_g) == false) {
     return EXIT_FAILURE;
   }
 

--- a/ciri/node.c
+++ b/ciri/node.c
@@ -8,6 +8,35 @@
 #include "ciri/node.h"
 #include "common/network/logger.h"
 
+bool node_init(node_t* const node) {
+  log_info("Initializing broadcaster component");
+  if (broadcaster_init(&node->broadcaster, node) == false) {
+    log_fatal("Initializing broadcaster component failed");
+    return false;
+  }
+  log_info("Initializing processor component");
+  if (processor_init(&node->processor, node) == false) {
+    log_fatal("Initializing processor component failed");
+    return false;
+  }
+  log_info("Initializing receiver component");
+  if (receiver_init(&node->receiver, node) == false) {
+    log_fatal("Initializing receiver component failed");
+    return false;
+  }
+  log_info("Initializing requester component");
+  if (requester_init(&node->requester, node) == false) {
+    log_fatal("Initializing requester component failed");
+    return false;
+  }
+  log_info("Initializing responder component");
+  if (responder_init(&node->responder, node) == false) {
+    log_fatal("Initializing responder component failed");
+    return false;
+  }
+  return true;
+}
+
 bool node_start(node_t* const node) {
   log_info("Starting broadcaster component");
   if (broadcaster_start(&node->broadcaster) == false) {
@@ -22,11 +51,6 @@ bool node_start(node_t* const node) {
   log_info("Starting receiver component");
   if (receiver_start(&node->receiver) == false) {
     log_fatal("Starting receiver component failed");
-    return false;
-  }
-  log_info("Starting requester component");
-  if (requester_start(&node->requester) == false) {
-    log_fatal("Starting requester component failed");
     return false;
   }
   log_info("Starting responder component");
@@ -55,14 +79,35 @@ bool node_stop(node_t* const node) {
     log_error("Stopping receiver component failed");
     ret = false;
   }
-  log_info("Stopping processor component");
-  if (requester_stop(&node->requester) == false) {
-    log_error("Stopping processor component failed");
-    ret = false;
-  }
   log_info("Stopping responder component");
   if (responder_stop(&node->responder) == false) {
     log_error("Stopping responder component failed");
+    ret = false;
+  }
+  return ret;
+}
+
+bool node_destroy(node_t* const node) {
+  bool ret = true;
+
+  log_info("Destroying broadcaster component");
+  if (broadcaster_destroy(&node->broadcaster) == false) {
+    log_error("Destroying broadcaster component failed");
+    ret = false;
+  }
+  log_info("Destroying processor component");
+  if (processor_destroy(&node->processor) == false) {
+    log_error("Destroying processor component failed");
+    ret = false;
+  }
+  log_info("Destroying processor component");
+  if (requester_destroy(&node->requester) == false) {
+    log_error("Destroying processor component failed");
+    ret = false;
+  }
+  log_info("Destroying responder component");
+  if (responder_destroy(&node->responder) == false) {
+    log_error("Destroying responder component failed");
     ret = false;
   }
   return ret;

--- a/ciri/node.h
+++ b/ciri/node.h
@@ -22,7 +22,9 @@ typedef struct node_s {
   responder_state_t responder;
 } node_t;
 
+bool node_init(node_t* const node);
 bool node_start(node_t* const node);
 bool node_stop(node_t* const node);
+bool node_destroy(node_t* const node);
 
 #endif  // __CIRI_NODE_H__

--- a/common/BUILD
+++ b/common/BUILD
@@ -29,8 +29,10 @@ cc_library(
 
 cc_library(
     name = "logger_helper",
-    hdrs = ["logger_helper.h"],
     srcs = ["logger_helper.c"],
-    deps = ["@com_github_embear_logger//:logger",
-            ":lock_handle"],
+    hdrs = ["logger_helper.h"],
+    deps = [
+        ":lock_handle",
+        "@com_github_embear_logger//:logger",
+    ],
 )

--- a/common/network/components/broadcaster.h
+++ b/common/network/components/broadcaster.h
@@ -12,21 +12,25 @@
 #include "common/thread_handle.h"
 
 typedef concurrent_queue_of_trit_array_p broadcaster_queue_t;
+typedef struct node_s node_t;
 
 typedef struct {
   thread_handle_t thread;
   bool running;
   broadcaster_queue_t *queue;
+  node_t *node;
 } broadcaster_state_t;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+bool broadcaster_init(broadcaster_state_t *const state, node_t *const node);
 bool broadcaster_start(broadcaster_state_t *const state);
 bool broadcaster_on_next(broadcaster_state_t *const state,
                          trit_array_p const hash);
 bool broadcaster_stop(broadcaster_state_t *const state);
+bool broadcaster_destroy(broadcaster_state_t *const state);
 
 #ifdef __cplusplus
 }

--- a/common/network/components/processor.h
+++ b/common/network/components/processor.h
@@ -12,20 +12,24 @@
 #include "common/thread_handle.h"
 
 typedef concurrent_queue_of_trit_array_p processor_queue_t;
+typedef struct node_s node_t;
 
 typedef struct {
   thread_handle_t thread;
   bool running;
   processor_queue_t *queue;
+  node_t *node;
 } processor_state_t;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+bool processor_init(processor_state_t *const state, node_t *const node);
 bool processor_start(processor_state_t *const state);
 bool processor_on_next(processor_state_t *const state, trit_array_p const hash);
 bool processor_stop(processor_state_t *const state);
+bool processor_destroy(processor_state_t *const state);
 
 #ifdef __cplusplus
 }

--- a/common/network/components/receiver.c
+++ b/common/network/components/receiver.c
@@ -18,14 +18,25 @@ static void *receiver_routine(receiver_state_t *const state) {
   return NULL;
 }
 
+bool receiver_init(receiver_state_t *const state, node_t *const node) {
+  if (state == NULL || node == NULL) {
+    return false;
+  }
+  state->running = false;
+  state->node = node;
+  return true;
+}
+
 bool receiver_start(receiver_state_t *const state) {
   if (state == NULL) {
     return false;
   }
   log_info("Spawning receiver thread");
   state->running = true;
-  thread_handle_create(&state->thread, (thread_routine_t)receiver_routine,
-                       state);
+  if (thread_handle_create(&state->thread, (thread_routine_t)receiver_routine,
+                           state) != 0) {
+    return false;
+  }
   return true;
 }
 
@@ -35,6 +46,8 @@ bool receiver_stop(receiver_state_t *const state) {
   }
   log_info("Shutting down receiver thread");
   state->running = false;
-  thread_handle_join(state->thread, NULL);
+  if (thread_handle_join(state->thread, NULL) != 0) {
+    return false;
+  }
   return true;
 }

--- a/common/network/components/receiver.h
+++ b/common/network/components/receiver.h
@@ -12,15 +12,19 @@
 
 #include "common/thread_handle.h"
 
+typedef struct node_s node_t;
+
 typedef struct {
   thread_handle_t thread;
   bool running;
+  node_t *node;
 } receiver_state_t;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+bool receiver_init(receiver_state_t *const state, node_t *const node);
 bool receiver_start(receiver_state_t *const state);
 bool receiver_stop(receiver_state_t *const state);
 

--- a/common/network/components/requester.c
+++ b/common/network/components/requester.c
@@ -7,14 +7,15 @@
 
 #include "common/network/components/requester.h"
 
-bool requester_start(requester_state_t *const state) {
-  if (state == NULL) {
+bool requester_init(requester_state_t *const state, node_t *const node) {
+  if (state == NULL || node == NULL) {
     return false;
   }
   if (INIT_CONCURRENT_QUEUE_OF(trit_array_p, state->queue) !=
       CONCURRENT_QUEUE_SUCCESS) {
     return false;
   }
+  state->node = node;
   return true;
 }
 
@@ -23,8 +24,11 @@ bool request_transaction(requester_state_t *const state,
   if (state == NULL) {
     return false;
   }
-  return state->queue->vtable->push(state->queue, hash) ==
-         CONCURRENT_QUEUE_SUCCESS;
+  if (state->queue->vtable->push(state->queue, hash) !=
+      CONCURRENT_QUEUE_SUCCESS) {
+    return false;
+  }
+  return true;
 }
 
 trit_array_p get_transaction_to_request(requester_state_t *const state) {
@@ -40,7 +44,7 @@ trit_array_p get_transaction_to_request(requester_state_t *const state) {
   return hash;
 }
 
-bool requester_stop(requester_state_t *const state) {
+bool requester_destroy(requester_state_t *const state) {
   if (state == NULL) {
     return false;
   }

--- a/common/network/components/requester.h
+++ b/common/network/components/requester.h
@@ -11,20 +11,22 @@
 #include "common/network/queues/concurrent_queue_trit_array.h"
 
 typedef concurrent_queue_of_trit_array_p requester_queue_t;
+typedef struct node_s node_t;
 
 typedef struct {
   requester_queue_t *queue;
+  node_t *node;
 } requester_state_t;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-bool requester_start(requester_state_t *const state);
+bool requester_init(requester_state_t *const state, node_t *const node);
 bool request_transaction(requester_state_t *const state,
                          trit_array_p const hash);
 trit_array_p get_transaction_to_request(requester_state_t *const state);
-bool requester_stop(requester_state_t *const state);
+bool requester_destroy(requester_state_t *const state);
 
 #ifdef __cplusplus
 }

--- a/common/network/components/responder.h
+++ b/common/network/components/responder.h
@@ -12,21 +12,25 @@
 #include "common/thread_handle.h"
 
 typedef concurrent_queue_of_hash_request_t responder_queue_t;
+typedef struct node_s node_t;
 
 typedef struct {
   thread_handle_t thread;
   bool running;
   responder_queue_t *queue;
+  node_t *node;
 } responder_state_t;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+bool responder_init(responder_state_t *const state, node_t *const node);
 bool responder_start(responder_state_t *const state);
 bool responder_on_next(responder_state_t *const state, trit_array_p const hash,
                        neighbor_t *const neighbor);
 bool responder_stop(responder_state_t *const state);
+bool responder_destroy(responder_state_t *const state);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In this PR I add init/destroy functions to the components API

`init - > start -> stop -> destroy` instead of just `start -> stop`

Motivations:
- start/stop names were misleading as some components don't need to be started/stopped (e.g. requester)
- It was impossible to stop and resume a node while keeping its state