### PR TITLE
Fix missing template arguments before '(' token

### DIFF
--- a/cppclient/api_json.cc
+++ b/cppclient/api_json.cc
@@ -272,7 +272,7 @@ IotaJsonAPI::getConfirmedBundlesForAddresses(
                        [address](const Transaction& tx) -> bool {
                          return address == tx.address;
                        }) != b.end()) {
-        confirmedBundlesMap.emplace(std::pair(address, b));
+        confirmedBundlesMap.emplace(std::pair<std::string, Bundle>(address, b));
       }
     }
   }


### PR DESCRIPTION
Error Messege is showed in the following
===================Error Messege==================
cppclient/api_json.cc:275:46:
error: missing template arguments before '(' token
         confirmedBundlesMap.emplace(std::pair(address, b));

