### PR TITLE
common: make trit_encoding a build parameter

### DIFF
--- a/common/model/BUILD
+++ b/common/model/BUILD
@@ -12,78 +12,12 @@ cc_library(
 )
 
 cc_library(
-    name = "transaction_3",
-    srcs = ["transaction.c"],
-    hdrs = ["transaction.h"],
-    deps = [
-        "//common/curl-p:digest",
-        "//common/trinary:trit_array_3",
-        "//common/trinary:trit_long",
-    ],
-)
-
-cc_library(
-    name = "transaction_4",
-    srcs = ["transaction.c"],
-    hdrs = ["transaction.h"],
-    deps = [
-        "//common/curl-p:digest",
-        "//common/trinary:trit_array_4",
-        "//common/trinary:trit_long",
-    ],
-)
-
-cc_library(
-    name = "transaction_5",
-    srcs = ["transaction.c"],
-    hdrs = ["transaction.h"],
-    deps = [
-        "//common/curl-p:digest",
-        "//common/trinary:trit_array_5",
-        "//common/trinary:trit_long",
-    ],
-)
-
-cc_library(
     name = "tryte_transaction",
     srcs = ["tryte_transaction.cc"],
     hdrs = ["tryte_transaction.h"],
     deps = [
         "//common/model:transaction",
         "//common/trinary:trit_array",
-        "//common/trinary:trit_long",
-    ],
-)
-
-cc_library(
-    name = "tryte_transaction_3",
-    srcs = ["tryte_transaction.cc"],
-    hdrs = ["tryte_transaction.h"],
-    deps = [
-        "//common/model:transaction_3",
-        "//common/trinary:trit_array_3",
-        "//common/trinary:trit_long",
-    ],
-)
-
-cc_library(
-    name = "tryte_transaction_4",
-    srcs = ["tryte_transaction.cc"],
-    hdrs = ["tryte_transaction.h"],
-    deps = [
-        "//common/model:transaction_4",
-        "//common/trinary:trit_array_4",
-        "//common/trinary:trit_long",
-    ],
-)
-
-cc_library(
-    name = "tryte_transaction_5",
-    srcs = ["tryte_transaction.cc"],
-    hdrs = ["tryte_transaction.h"],
-    deps = [
-        "//common/model:transaction_5",
-        "//common/trinary:trit_array_5",
         "//common/trinary:trit_long",
     ],
 )

--- a/common/model/tests/BUILD
+++ b/common/model/tests/BUILD
@@ -9,70 +9,10 @@ cc_test(
 )
 
 cc_test(
-    name = "test_transaction_3",
-    srcs = ["test_transaction.c"],
-    deps = [
-        "//common/model:transaction_3",
-        "//common/trinary:trit_tryte",
-        "@unity",
-    ],
-)
-
-cc_test(
-    name = "test_transaction_4",
-    srcs = ["test_transaction.c"],
-    deps = [
-        "//common/model:transaction_4",
-        "//common/trinary:trit_tryte",
-        "@unity",
-    ],
-)
-
-cc_test(
-    name = "test_transaction_5",
-    srcs = ["test_transaction.c"],
-    deps = [
-        "//common/model:transaction_5",
-        "//common/trinary:trit_tryte",
-        "@unity",
-    ],
-)
-
-cc_test(
     name = "test_tryte_transaction",
     srcs = ["test_tryte_transaction.cc"],
     deps = [
         "//common/model:tryte_transaction",
-        "//common/trinary:trit_tryte",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "test_tryte_transaction_3",
-    srcs = ["test_tryte_transaction.cc"],
-    deps = [
-        "//common/model:tryte_transaction_3",
-        "//common/trinary:trit_tryte",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "test_tryte_transaction_4",
-    srcs = ["test_tryte_transaction.cc"],
-    deps = [
-        "//common/model:tryte_transaction_4",
-        "//common/trinary:trit_tryte",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "test_tryte_transaction_5",
-    srcs = ["test_tryte_transaction.cc"],
-    deps = [
-        "//common/model:tryte_transaction_5",
         "//common/trinary:trit_tryte",
         "@com_google_googletest//:gtest_main",
     ],

--- a/common/trinary/BUILD
+++ b/common/trinary/BUILD
@@ -104,10 +104,47 @@ cc_library(
     ],
 )
 
+config_setting(
+    name = "trit_encoding_1",
+    values = {"define": "trit_encoding=1"},
+)
+
+config_setting(
+    name = "trit_encoding_3",
+    values = {"define": "trit_encoding=3"},
+)
+
+config_setting(
+    name = "trit_encoding_4",
+    values = {"define": "trit_encoding=4"},
+)
+
+config_setting(
+    name = "trit_encoding_5",
+    values = {"define": "trit_encoding=5"},
+)
+
 cc_library(
     name = "trit_array",
+    deps = select({
+        ":trit_encoding_1": [":trit_array_1"],
+        ":trit_encoding_3": [":trit_array_3"],
+        ":trit_encoding_4": [":trit_array_4"],
+        ":trit_encoding_5": [":trit_array_5"],
+        "//conditions:default": [":trit_array_3"],
+    }),
+)
+
+cc_library(
+    name = "trit_array_1",
+    srcs = ["trit_array.c"],
+    hdrs = ["trit_array.h"],
+    defines = ["TRIT_ARRAY_ENCODING_1_TRIT_PER_BYTE"],
     deps = [
-        ":trit_array_3",
+        ":trit_byte",
+        ":trit_tryte",
+        ":trits",
+        "//common:stdint",
     ],
 )
 

--- a/common/trinary/tests/BUILD
+++ b/common/trinary/tests/BUILD
@@ -64,74 +64,11 @@ cc_test(
 )
 
 cc_test(
-    name = "test_trit_array_3",
-    srcs = ["test_trit_array.c"],
-    deps = [
-        "//common/trinary:trit_array_3",
-        "//common/trinary:trit_byte",
-        "//common/trinary:trit_tryte",
-        "@unity",
-    ],
-)
-
-cc_test(
-    name = "test_trit_array_4",
-    srcs = ["test_trit_array.c"],
-    deps = [
-        "//common/trinary:trit_array_4",
-        "//common/trinary:trit_byte",
-        "//common/trinary:trit_tryte",
-        "@unity",
-    ],
-)
-
-cc_test(
-    name = "test_trit_array_5",
-    srcs = ["test_trit_array.c"],
-    deps = [
-        "//common/trinary:trit_array_5",
-        "//common/trinary:trit_byte",
-        "//common/trinary:trit_tryte",
-        "@unity",
-    ],
-)
-
-cc_test(
     name = "test_flex_trit_array",
     srcs = ["test_flex_trit_array.cc"],
     deps = [
         "//common/trinary:flex_trit_array",
         "//common/trinary:trit_array",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "test_flex_trit_array_3",
-    srcs = ["test_flex_trit_array.cc"],
-    deps = [
-        "//common/trinary:flex_trit_array_3",
-        "//common/trinary:trit_array_3",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "test_flex_trit_array_4",
-    srcs = ["test_flex_trit_array.cc"],
-    deps = [
-        "//common/trinary:flex_trit_array_4",
-        "//common/trinary:trit_array_4",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "test_flex_trit_array_5",
-    srcs = ["test_flex_trit_array.cc"],
-    deps = [
-        "//common/trinary:flex_trit_array_5",
-        "//common/trinary:trit_array_5",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
This allows the user to specify the internal trit-memory encoding that entangled should use at build time.

Defaults to trytes if not specified.
Once merged, we'll add build targets for each encoding type to CI

# Test Plan:
Tests run.
