### PR TITLE
common: limited support for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ hs_err_pid*
 /out/
 /lib/
 
+# Visual Studio
+.vs/
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @th0br0 @tsvisabo
+* @th0br0 @tsvisabo @thibault-martinez

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "org_iota_entangled")
 
 git_repository(
     name = "rules_iota",
-    commit = "18179db1ce0be893643de847a4e673f371d89ec8",
+    commit = "3a157b0632e45814c72ea33c2e63cf6650036803",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 

--- a/common/curl-p/BUILD
+++ b/common/curl-p/BUILD
@@ -83,6 +83,9 @@ cc_library(
         "//common/trinary:ptrits",
         "//common/trinary:trit_ptrit",
         "//common/trinary:trits",
+        "//utils:system",
+        "//utils/handles:rw_lock",
+        "//utils/handles:thread",
     ],
 )
 

--- a/common/curl-p/hashcash.c
+++ b/common/curl-p/hashcash.c
@@ -4,6 +4,12 @@
 #include "ptrit.h"
 #include "search.h"
 
+#ifdef _WIN32
+#define CTZLL(x) _tzcnt_u64(x)
+#else
+#define CTZLL(x) __builtin_ctzll(x)
+#endif
+
 short test(PCurl *const curl, unsigned short const mwm) {
   unsigned short i;
   ptrit_s probe = HIGH_BITS;
@@ -13,8 +19,10 @@ short test(PCurl *const curl, unsigned short const mwm) {
   if (probe == 0) {
     return -1;
   }
-  return __builtin_ctzll(probe);
+  return CTZLL(probe);
 }
+
+#undef CTZLL
 
 PearlDiverStatus hashcash(Curl *const ctx, SearchType const type,
                           unsigned short const offset, unsigned short const end,

--- a/common/curl-p/pearl_diver.c
+++ b/common/curl-p/pearl_diver.c
@@ -1,13 +1,14 @@
-#include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
+#include "common/curl-p/ptrit.h"
+#include "common/curl-p/search.h"
 #include "common/trinary/ptrit_incr.h"
 #include "common/trinary/trit_ptrit.h"
-
-#include "ptrit.h"
-#include "search.h"
+#include "utils/handles/rw_lock.h"
+#include "utils/handles/thread.h"
+#include "utils/system.h"
 
 typedef enum { SEARCH_RUNNING, SEARCH_INTERRUPT, SEARCH_FINISHED } SearchStatus;
 
@@ -19,15 +20,15 @@ typedef struct {
   short (*test)(PCurl *, unsigned short);
   unsigned short param;
   SearchStatus *status;
-  pthread_rwlock_t *statusLock;
+  rw_lock_handle_t *statusLock;
 } SearchInstance;
 
 void init_inst(SearchInstance *const inst, SearchStatus *const status,
-               pthread_rwlock_t *const statusLock, unsigned short const index,
+               rw_lock_handle_t *const statusLock, unsigned short const index,
                PCurl *const curl, unsigned short const offset,
                unsigned short const end, unsigned short const param,
                short (*test)(PCurl *const, unsigned short const));
-void pt_start(pthread_t *const tid, SearchInstance *const inst,
+void pt_start(thread_handle_t *const tid, SearchInstance *const inst,
               unsigned short const index);
 void *run_search_thread(void *const data);
 short do_pd_search(short (*test)(PCurl *const, unsigned short const),
@@ -37,16 +38,19 @@ PearlDiverStatus pd_search(Curl *const ctx, unsigned short const offset,
                            unsigned short const end,
                            short (*test)(PCurl *const, unsigned short const),
                            unsigned short const param) {
-  unsigned short found_thread = 0, n_procs = sysconf(_SC_NPROCESSORS_ONLN);
-  intptr_t found_index = -1;
-  SearchInstance inst[n_procs];
-  SearchStatus status = SEARCH_RUNNING;
-  pthread_rwlock_t statusLock;
-  pthread_t tid[n_procs];
+  unsigned short found_thread = 0, n_procs = system_cpu_available();
 
-  if (pthread_rwlock_init(&statusLock, NULL)) {
+  intptr_t found_index = -1;
+  SearchStatus status = SEARCH_RUNNING;
+  rw_lock_handle_t statusLock;
+
+  if (rw_lock_handle_init(&statusLock)) {
+    fprintf(stderr, "init\n");
     return PEARL_DIVER_ERROR;
   }
+
+  SearchInstance *inst = calloc(n_procs, sizeof(SearchInstance));
+  thread_handle_t *tid = calloc(n_procs, sizeof(thread_handle_t));
 
   {
     PCurl curl;
@@ -62,32 +66,42 @@ PearlDiverStatus pd_search(Curl *const ctx, unsigned short const offset,
   for (int i = n_procs; --i >= 0;) {
     if (tid[i] == 0) continue;
 
-    if (found_index < 0) {
-      pthread_join(tid[i], (void *)&found_index);
+    if (found_index == -1) {
+      thread_handle_join(tid[i], (void *)&found_index);
 
-      if (found_index >= 0) {
+      fprintf(stderr, "%d found: %d\n", i, found_index);
+
+      if (found_index != -1) {
+        fprintf(stderr, "gotcha\n");
         found_thread = i;
       }
     } else {
-      pthread_join(tid[i], NULL);
+      thread_handle_join(tid[i], NULL);
     }
   }
 
   switch (found_index) {
     case -1:
+      free(inst);
+      free(tid);
+      fprintf(stderr, "fidx: %d\n", found_index);
+
       return PEARL_DIVER_ERROR;
   }
 
-  pthread_rwlock_destroy(&statusLock);
+  rw_lock_handle_destroy(&statusLock);
 
   ptrits_to_trits(&inst[found_thread].curl.state[offset], &ctx->state[offset],
                   found_index, end - offset);
+
+  free(inst);
+  free(tid);
 
   return PEARL_DIVER_SUCCESS;
 }
 
 void init_inst(SearchInstance *const inst, SearchStatus *const status,
-               pthread_rwlock_t *const statusLock, unsigned short const index,
+               rw_lock_handle_t *const statusLock, unsigned short const index,
                PCurl *const curl, unsigned short const offset,
                unsigned short const end, unsigned short const param,
                short (*test)(PCurl *const, unsigned short const)) {
@@ -106,10 +120,10 @@ void init_inst(SearchInstance *const inst, SearchStatus *const status,
             test);
 }
 
-void pt_start(pthread_t *const tid, SearchInstance *const inst,
+void pt_start(thread_handle_t *const tid, SearchInstance *const inst,
               unsigned short const index) {
-  if (pthread_create(&tid[index], NULL, run_search_thread,
-                     ((void *)&inst[index]))) {
+  if (thread_handle_create(&tid[index], run_search_thread,
+                           ((void *)&inst[index]))) {
     tid[index] = 0;
   }
   if (index == 0) {
@@ -127,7 +141,9 @@ void *run_search_thread(void *const data) {
   for (i = 0; i < inst->index; i++) {
     ptrit_increment(inst->curl.state, inst->offset, HASH_LENGTH);
   }
-  return (void *)(intptr_t)do_pd_search(inst->test, inst, &copy);
+
+  intptr_t ret = do_pd_search(inst->test, inst, &copy);
+  return (void *)ret;
 }
 
 short do_pd_search(short (*test)(PCurl *const, unsigned short const),
@@ -140,17 +156,17 @@ short do_pd_search(short (*test)(PCurl *const, unsigned short const),
     ptrit_transform(copy);
     index = test(copy, inst->param);
     if (index >= 0) {
-      pthread_rwlock_wrlock(inst->statusLock);
+      rw_lock_handle_wrlock(inst->statusLock);
       *inst->status = SEARCH_FINISHED;
-      pthread_rwlock_unlock(inst->statusLock);
+      rw_lock_handle_unlock(inst->statusLock);
 
       return index;
     }
     ptrit_increment(inst->curl.state, inst->offset + 1, HASH_LENGTH);
 
-    pthread_rwlock_rdlock(inst->statusLock);
+    rw_lock_handle_rdlock(inst->statusLock);
     status = *inst->status;
-    pthread_rwlock_unlock(inst->statusLock);
+    rw_lock_handle_unlock(inst->statusLock);
   }
   return -1;
   // return do_pd_search(test, inst, copy);

--- a/common/helpers/BUILD
+++ b/common/helpers/BUILD
@@ -9,16 +9,23 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "helpers.dll",
+    linkshared = 1,
+    linkstatic = 1,
+    deps = [":helpers"],
+)
+
 cc_library(
     name = "sign",
     srcs = ["sign.c"],
     hdrs = ["sign.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":pow",
         "//common/kerl",
         "//common/sign/v1:iss_kerl",
         "//common/trinary:trit_tryte",
+        "//utils:export",
     ],
 )
 
@@ -27,7 +34,10 @@ cc_library(
     srcs = ["pow.c"],
     hdrs = ["pow.h"],
     visibility = ["//visibility:public"],
-    deps = ["//common/pow"],
+    deps = [
+        "//common/pow",
+        "//utils:export",
+    ],
 )
 
 cc_library(
@@ -35,7 +45,10 @@ cc_library(
     srcs = ["digest.c"],
     hdrs = ["digest.h"],
     visibility = ["//visibility:public"],
-    deps = ["//common/curl-p:digest"],
+    deps = [
+        "//common/curl-p:digest",
+        "//utils:export",
+    ],
 )
 
 cc_library(
@@ -48,14 +61,8 @@ cc_library(
         "//common/kerl:hash",
         "//common/sign/v1:iss_kerl",
         "//common/trinary:trit_tryte",
+        "//utils:export",
     ],
-)
-
-cc_library(
-    name = "files",
-    srcs = ["files.c"],
-    hdrs = ["files.h"],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/common/helpers/checksum.c
+++ b/common/helpers/checksum.c
@@ -1,15 +1,17 @@
+#include "common/helpers/checksum.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "checksum.h"
 #include "common/kerl/hash.h"
 #include "common/sign/v1/iss_kerl.h"
 #include "common/trinary/trit_tryte.h"
+#include "utils/export.h"
 
-char* iota_checksum(const char* input, const size_t inputLength,
-                    const size_t checksumLength) {
+IOTA_EXPORT char* iota_checksum(const char* input, const size_t inputLength,
+                                const size_t checksumLength) {
   Kerl kerl;
   init_kerl(&kerl);
 
@@ -17,17 +19,16 @@ char* iota_checksum(const char* input, const size_t inputLength,
     return NULL;
   }
 
-  trit_t inputTrits[sizeof(char) * inputLength * RADIX];
+  trit_t* inputTrits = calloc(inputLength * RADIX, sizeof(trit_t));
   trit_t trits_hash[HASH_LENGTH];
-  char* checksumTrytes;
+  char* checksumTrytes = calloc(checksumLength, sizeof(tryte_t));
 
-  checksumTrytes = calloc(checksumLength, sizeof(tryte_t));
   trytes_to_trits((tryte_t*)input, inputTrits, inputLength);
   kerl_hash(inputTrits, inputLength * RADIX, trits_hash, &kerl);
   trits_to_trytes((trit_t*)(&trits_hash[HASH_LENGTH - checksumLength * RADIX]),
                   (tryte_t*)checksumTrytes, checksumLength * RADIX);
 
+  free(inputTrits);
+
   return checksumTrytes;
 }
-
-#undef RADIX

--- a/common/helpers/checksum.h
+++ b/common/helpers/checksum.h
@@ -1,17 +1,19 @@
-#ifndef __COMMON_CHECKSUM_DEFAULT_H_
-#define __COMMON_CHECKSUM_DEFAULT_H_
+#ifndef __COMMON_HELPERS_CHECKSUM_H_
+#define __COMMON_HELPERS_CHECKSUM_H_
 
 #include <stddef.h>
+
+#include "utils/export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-char* iota_checksum(const char* input, const size_t inputLength,
-                    const size_t checksumLength);
+IOTA_EXPORT char* iota_checksum(const char* input, const size_t inputLength,
+                                const size_t checksumLength);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  //__COMMON_CHECKSUM_DEFAULT_H_
+#endif  //__COMMON_HELPERS_CHECKSUM_H_

--- a/common/helpers/digest.c
+++ b/common/helpers/digest.c
@@ -1,24 +1,30 @@
+#include "common/helpers/digest.h"
+
+#include <stdlib.h>
 #include <string.h>
 
 #include "common/curl-p/digest.h"
 #include "common/trinary/trit_tryte.h"
-#include "digest.h"
+#include "utils/export.h"
 
 #define TRYTE_LENGTH 2673
 
-char* iota_digest(const char* trytes) {
+IOTA_EXPORT char* iota_digest(const char* trytes) {
   Curl curl;
   init_curl(&curl);
   curl.type = CURL_P_81;
 
   size_t length = strnlen(trytes, TRYTE_LENGTH);
-  trit_t input[sizeof(char) * length * 3];
+  trit_t* input = calloc(length * RADIX, sizeof(trit_t));
+
   trytes_to_trits((tryte_t*)trytes, input, length);
 
   trit_t trits_hash[HASH_LENGTH];
   curl_digest(input, length * 3, trits_hash, &curl);
 
-  char* hash = calloc(HASH_LENGTH / 3 + 1, sizeof(char));
+  free(input);
+
+  char* hash = calloc(HASH_LENGTH / 3 + 1, sizeof(trit_t));
   trits_to_trytes((trit_t*)trits_hash, (tryte_t*)hash, HASH_LENGTH);
 
   return hash;

--- a/common/helpers/digest.h
+++ b/common/helpers/digest.h
@@ -1,17 +1,16 @@
-#ifndef __IOTA_DIGEST_H
-#define __IOTA_DIGEST_H
+#ifndef __COMMON_HELPERS_DIGEST_H
+#define __COMMON_HELPERS_DIGEST_H
 
-#include <stddef.h>
-#include <stdlib.h>
+#include "utils/export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-char* iota_digest(char const* const trytes);
+IOTA_EXPORT char* iota_digest(char const* const trytes);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  //__IOTA_DIGEST_H
+#endif  //__COMMON_HELPERS_DIGEST_H

--- a/common/helpers/pow.c
+++ b/common/helpers/pow.c
@@ -1,14 +1,16 @@
+#include "common/helpers/pow.h"
+
 #include <stdlib.h>
 #include <string.h>
 
 #include "common/curl-p/hashcash.h"
 #include "common/pow/pow.h"
 #include "common/trinary/trit_tryte.h"
-#include "pow.h"
+#include "utils/export.h"
 
 #define NONCE_LENGTH 27 * 3
 
-char* iota_pow(char const* const trytes_in, uint8_t const mwm) {
+IOTA_EXPORT char* iota_pow(char const* const trytes_in, uint8_t const mwm) {
   Curl curl;
   init_curl(&curl);
   curl.type = CURL_P_81;

--- a/common/helpers/pow.h
+++ b/common/helpers/pow.h
@@ -1,16 +1,18 @@
-#ifndef ENTANGLED_POW_H
-#define ENTANGLED_POW_H
+#ifndef _COMMON_HELPERS_POW_H
+#define _COMMON_HELPERS_POW_H
 
-#include <stddef.h>
+#include <stdint.h>
+
+#include "utils/export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-char* iota_pow(char const* const trytes, uint8_t const mwm);
+IOTA_EXPORT char* iota_pow(char const* const trytes_in, uint8_t const mwm);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ENTANGLED_POW_H
+#endif  // _COMMON_HELPERS_POW_H

--- a/common/helpers/sign.c
+++ b/common/helpers/sign.c
@@ -3,20 +3,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common/helpers/sign.h"
 #include "common/kerl/kerl.h"
 #include "common/sign/v1/iss_kerl.h"
 #include "common/trinary/trit_tryte.h"
-#include "sign.h"
+#include "utils/export.h"
 
-char* iota_sign_address_gen(char const* const seed, size_t const index,
-                            size_t const security) {
+IOTA_EXPORT char* iota_sign_address_gen(char const* const seed,
+                                        size_t const index,
+                                        size_t const security) {
   if (!(security > 0 && security <= 3)) return NULL;
   const size_t key_length = security * ISS_KEY_LENGTH;
 
   Kerl kerl;
 
   trit_t subseed[HASH_LENGTH];
-  trit_t key[key_length];
+  trit_t* key = calloc(key_length, sizeof(trit_t));
+
   char* address = calloc(1 + (HASH_LENGTH / RADIX), sizeof(tryte_t));
 
   init_kerl(&kerl);
@@ -35,6 +38,8 @@ char* iota_sign_address_gen(char const* const seed, size_t const index,
   trits_to_trytes(key, (tryte_t*)address, HASH_LENGTH);
   memset(key, 0, key_length * sizeof(trit_t));
 
+  free(key);
+
   return address;
 }
 
@@ -47,7 +52,7 @@ char* iota_sign_signature_gen(char const* const seed, size_t const index,
 
   trit_t hash[HASH_LENGTH];
   trit_t subseed[HASH_LENGTH];
-  trit_t key[key_length];
+  trit_t* key = calloc(key_length, sizeof(trit_t));
   tryte_t* signature = calloc(1 + key_length / RADIX, sizeof(tryte_t));
 
   init_kerl(&kerl);
@@ -61,6 +66,8 @@ char* iota_sign_signature_gen(char const* const seed, size_t const index,
   iss_kerl_signature(key, hash, key, key_length, &kerl);
   trits_to_trytes(key, (tryte_t*)signature, key_length);
   memset(key, 0, key_length * sizeof(trit_t));
+
+  free(key);
 
   return (char*)signature;
 }

--- a/common/helpers/sign.h
+++ b/common/helpers/sign.h
@@ -1,20 +1,24 @@
-#ifndef __COMMON_SIGN_DEFAULT_H_
-#define __COMMON_SIGN_DEFAULT_H_
+#ifndef __COMMON_HELPERS_SIGN_H_
+#define __COMMON_HELPERS_SIGN_H_
 
 #include <stddef.h>
+
+#include "utils/export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-char* iota_sign_address_gen(char const* const seed, size_t const index,
-                            size_t const security);
-char* iota_sign_signature_gen(char const* const seed, size_t const index,
-                              size_t const security,
-                              char const* const bundleHash);
+IOTA_EXPORT char* iota_sign_address_gen(char const* const seed,
+                                        size_t const index,
+                                        size_t const security);
+IOTA_EXPORT char* iota_sign_signature_gen(char const* const seed,
+                                          size_t const index,
+                                          size_t const security,
+                                          char const* const bundleHash);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  //__COMMON_SIGN_DEFAULT_H_
+#endif  //__COMMON_HELPERS_SIGN_H_

--- a/common/storage/sql/sqlite3/tests/BUILD
+++ b/common/storage/sql/sqlite3/tests/BUILD
@@ -6,10 +6,10 @@ cc_test(
     data = [":db_file"],
     visibility = ["//visibility:public"],
     deps = [
-        "//common/helpers:files",
         "//common/storage/sql/sqlite3:sqlite3_storage",
         "//common/storage/tests/helpers",
         "//common/trinary:trit_ptrit",
+        "//utils:files",
         "@unity",
     ],
 )

--- a/common/storage/sql/sqlite3/tests/test_sqlite3.c
+++ b/common/storage/sql/sqlite3/tests/test_sqlite3.c
@@ -9,11 +9,11 @@
 #include <string.h>
 #include <unity/unity.h>
 
-#include "common/helpers/files.h"
 #include "common/storage/connection.h"
 #include "common/storage/sql/defs.h"
 #include "common/storage/storage.h"
 #include "common/storage/tests/helpers/defs.h"
+#include "utils/files.h"
 
 static connection_t conn;
 

--- a/common/trinary/bct.h
+++ b/common/trinary/bct.h
@@ -2,7 +2,6 @@
 #define __COMMON_TRINARY_BCT_H__
 
 #include <stdint.h>
-#include <unistd.h>
 
 #include "common/trinary/trits.h"
 

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -1,6 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "system",
+    srcs = ["system.c"],
+    hdrs = ["system.h"],
+)
+
+cc_library(
+    name = "files",
+    srcs = ["files.c"],
+    hdrs = ["files.h"],
+)
+
+cc_library(
     name = "logger_helper",
     srcs = ["logger_helper.c"],
     hdrs = ["logger_helper.h"],
@@ -9,4 +21,9 @@ cc_library(
         "//utils/handles:lock",
         "@com_github_embear_logger//:logger",
     ],
+)
+
+cc_library(
+    name = "export",
+    hdrs = ["export.h"],
 )

--- a/utils/export.h
+++ b/utils/export.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef __UTILS_EXPORT_H_
+#define __UTILS_EXPORT_H_
+
+#if defined(_MSC_VER)
+#define IOTA_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__)
+#define IOTA_EXPORT __attribute__((visibility("default")))
+#else
+#define IOTA_EXPORT
+#warning Unknown dynamic link import / export semantics.
+#endif
+
+#endif  // __UTILS_EXPORT_H_

--- a/utils/files.c
+++ b/utils/files.c
@@ -1,11 +1,17 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://gitlab.com/iota-foundation/software/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
-#include "common/helpers/files.h"
+#include "utils/files.h"
 
 int copy_file(const char *to, const char *from) {
   int fd_to, fd_from;

--- a/utils/files.h
+++ b/utils/files.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://gitlab.com/iota-foundation/software/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
 #ifndef ENTANGLED_COMMON_FILES_H
 #define ENTANGLED_COMMON_FILES_H
 

--- a/utils/handles/BUILD
+++ b/utils/handles/BUILD
@@ -1,5 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "linux",
+    constraint_values = [
+        "@bazel_tools//platforms:linux",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "cond",
     hdrs = ["cond.h"],
@@ -19,5 +27,8 @@ cc_library(
 cc_library(
     name = "thread",
     hdrs = ["thread.h"],
-    linkopts = ["-lpthread"],
+    linkopts = select({
+        ":linux": ["-pthread"],
+        "//conditions:default": [],
+    }),
 )

--- a/utils/handles/cond.h
+++ b/utils/handles/cond.h
@@ -57,7 +57,7 @@ static inline int cond_handle_destroy(cond_handle_t* const cond) {
   return pthread_cond_destroy(cond);
 }
 #elif defined(_WIN32)
-typedef CONDITION_VARIABLE pthread_cond_t;
+typedef CONDITION_VARIABLE cond_handle_t;
 static inline int cond_handle_init(cond_handle_t* const cond) {
   InitializeConditionVariable(cond);
   return 0;

--- a/utils/handles/cond.h
+++ b/utils/handles/cond.h
@@ -14,7 +14,12 @@
  * effect if not needed by the underlying API
  */
 
+#if !defined(_WIN32) && defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <Windows.h>
+#endif
 
 #include "utils/handles/lock.h"
 
@@ -51,6 +56,34 @@ static inline int cond_handle_timedwait(cond_handle_t* const cond,
 static inline int cond_handle_destroy(cond_handle_t* const cond) {
   return pthread_cond_destroy(cond);
 }
+#elif defined(_WIN32)
+typedef CONDITION_VARIABLE pthread_cond_t;
+static inline int cond_handle_init(cond_handle_t* const cond) {
+  InitializeConditionVariable(cond);
+  return 0;
+}
+static inline int cond_handle_signal(cond_handle_t* const cond) {
+  WakeConditionVariable(cond);
+  return 0;
+}
+static inline int cond_handle_broadcast(cond_handle_t* const cond) {
+  WakeAllConditionVariable(cond);
+  return 0;
+}
+static inline int cond_handle_wait(cond_handle_t* const cond,
+                                   lock_handle_t* const lock) {
+  SleepConditionVariableCS(cond, lock, INFINITE);
+  return 0;
+}
+
+static inline int cond_handle_timedwait(cond_handle_t* const cond,
+                                        lock_handle_t* const lock,
+                                        unsigned int timeout) {
+  if (!SleepConditionVariableCS(cond, lock, timeout * 1000)) return ETIMEDOUT;
+  return 0;
+}
+
+static inline int cond_handle_destroy(cond_handle_t* const cond) { return 0; }
 
 #else
 

--- a/utils/handles/lock.h
+++ b/utils/handles/lock.h
@@ -14,7 +14,12 @@
  * by the underlying API
  */
 
+#if !defined(_WIN32) && defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <Windows.h>
+#endif
 
 #ifdef _POSIX_THREADS
 
@@ -36,6 +41,27 @@ static inline int lock_handle_unlock(lock_handle_t* const lock) {
 
 static inline int lock_handle_destroy(lock_handle_t* const lock) {
   return pthread_mutex_destroy(lock);
+}
+
+#elif defined(_WIN32)
+
+typedef CRITICAL_SECTION lock_handle_t;
+
+static inline int lock_handle_init(lock_handle_t* const lock) {
+  InitializeCriticalSection(lock);
+  return 0;
+}
+static inline int lock_handle_lock(lock_handle_t* const lock) {
+  EnterCriticalSection(lock);
+  return 0;
+}
+static inline int lock_handle_unlock(lock_handle_t* const lock) {
+  LeaveCriticalSection(lock);
+  return 0;
+}
+static inline int lock_handle_destroy(lock_handle_t* const lock) {
+  DeleteCriticalSection(lock);
+  return 0;
 }
 
 #else

--- a/utils/handles/thread.h
+++ b/utils/handles/thread.h
@@ -51,8 +51,8 @@ static inline int thread_handle_join(thread_handle_t thread, void **status) {
   WaitForSingleObject(thread, INFINITE);
 
   if (status) {
-	  return GetExitCodeThread(thread, status);
-  } 
+    return !GetExitCodeThread(thread, status);
+  }
   return 0;
 }
 

--- a/utils/handles/thread.h
+++ b/utils/handles/thread.h
@@ -16,7 +16,12 @@
 
 typedef void *(*thread_routine_t)(void *);
 
+#if !defined(_WIN32) && defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <Windows.h>
+#endif
 
 #ifdef _POSIX_THREADS
 
@@ -31,6 +36,24 @@ static inline int thread_handle_create(thread_handle_t *const thread,
 
 static inline int thread_handle_join(thread_handle_t thread, void **status) {
   return pthread_join(thread, status);
+}
+
+#elif defined(_WIN32)
+typedef HANDLE thread_handle_t;
+
+static inline int thread_handle_create(thread_handle_t *const thread,
+                                       thread_routine_t routine, void *arg) {
+  *thread =
+      CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)routine, arg, 0, NULL);
+  return 0;
+}
+static inline int thread_handle_join(thread_handle_t thread, void **status) {
+  WaitForSingleObject(thread, INFINITE);
+
+  if (status) {
+	  return GetExitCodeThread(thread, status);
+  } 
+  return 0;
 }
 
 #else

--- a/utils/system.c
+++ b/utils/system.c
@@ -1,0 +1,35 @@
+#ifdef _WIN32
+#include <windows.h>
+#elif MACOS
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#else
+#include <unistd.h>
+#endif
+
+int system_cpu_available() {
+#ifdef WIN32
+  SYSTEM_INFO sysinfo;
+  GetSystemInfo(&sysinfo);
+  return sysinfo.dwNumberOfProcessors;
+#elif MACOS
+  int nm[2];
+  size_t len = 4;
+  uint32_t count;
+
+  nm[0] = CTL_HW;
+  nm[1] = HW_AVAILCPU;
+  sysctl(nm, 2, &count, &len, NULL, 0);
+
+  if (count < 1) {
+    nm[1] = HW_NCPU;
+    sysctl(nm, 2, &count, &len, NULL, 0);
+    if (count < 1) {
+      count = 1;
+    }
+  }
+  return count;
+#else
+  return sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+}

--- a/utils/system.h
+++ b/utils/system.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://gitlab.com/iota-foundation/software/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef __UTILS_SYSTEM_H
+#define __UTILS_SYSTEM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Returns the number of available processor cores
+ **/
+size_t system_cpu_available();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __UTILS_SYSTEM_H 


### PR DESCRIPTION
- Changed VLA usage to explicit heap allocation in some spaces thanks to MSVC not supporting VLA.
- Added primitives support for Windows

# Test Plan:
this built on windows & tests ran as well.
hopefully, I didn't break anything on linux :upside_down_face: 
