### PR TITLE
cclient: Implement get_balances

### DIFF
--- a/cclient/iota_api.c
+++ b/cclient/iota_api.c
@@ -268,7 +268,36 @@ iota_api_result_t iota_api_get_balances(
     const iota_http_service_t* const service,
     const get_balances_req_t* const req, get_balances_res_t* res) {
   iota_api_result_t result = {0};
-  // TODO
+
+  char_buffer_t* res_buff = char_buffer_new();
+  char_buffer_t* req_buff = char_buffer_new();
+  if (req_buff == NULL || res_buff == NULL) {
+    result.error = RC_CCLIENT_OOM;
+    goto done;
+  }
+
+  result.error = service->serializer.vtable.get_balances_serialize_request(
+      &service->serializer, req, req_buff);
+  if (result.error != RC_OK) {
+    goto done;
+  }
+
+  result = iota_service_query(service, req_buff, res_buff);
+  if (result.error != RC_OK) {
+    goto done;
+  }
+
+  result.error = service->serializer.vtable.get_balances_deserialize_response(
+      &service->serializer, res_buff->data, res);
+
+done:
+  if (req_buff) {
+    char_buffer_free(req_buff);
+  }
+  if (res_buff) {
+    char_buffer_free(res_buff);
+  }
+
   return result;
 }
 

--- a/cclient/request/get_balances.c
+++ b/cclient/request/get_balances.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "get_balances.h"
+
+get_balances_req_t* get_balances_req_new() {
+  get_balances_req_t* req =
+      (get_balances_req_t*)malloc(sizeof(get_balances_req_t));
+  utarray_new(req->addresses, &ut_str_icd);
+  utarray_new(req->tips, &ut_str_icd);
+
+  return req;
+}
+
+void get_balances_req_free(get_balances_req_t* req) {
+  if (req) {
+    utarray_free(req->addresses);
+    utarray_free(req->tips);
+    free(req);
+    req = NULL;
+  }
+}
+
+void get_balances_req_add_address(get_balances_req_t* req, char* addr) {
+  utarray_push_back(req->addresses, &addr);
+}
+
+void get_balances_req_add_tips(get_balances_req_t* req, char* tips) {
+  utarray_push_back(req->tips, &tips);
+}

--- a/cclient/request/get_balances.c
+++ b/cclient/request/get_balances.c
@@ -21,7 +21,6 @@ void get_balances_req_free(get_balances_req_t* req) {
     utarray_free(req->addresses);
     utarray_free(req->tips);
     free(req);
-    req = NULL;
   }
 }
 

--- a/cclient/request/get_balances.h
+++ b/cclient/request/get_balances.h
@@ -18,13 +18,22 @@ typedef struct {
   /**
    * List of addresses you want to get the confirmed balance for.
    */
-  address_array addresses;
+  UT_array* addresses;
   /**
    * Transactions with any of these tags will be returned
    */
   size_t threshold;
-
+  /**
+   * List of hashes, if present calculate the balance of addresses
+   * from the PoV of these transactions, can be used to chain bundles.
+   */
+  UT_array* tips;
 } get_balances_req_t;
+
+get_balances_req_t* get_balances_req_new();
+void get_balances_req_free(get_balances_req_t* req);
+void get_balances_req_add_address(get_balances_req_t* req, char* addr);
+void get_balances_req_add_tips(get_balances_req_t* req, char* tips);
 
 #ifdef __cplusplus
 }

--- a/cclient/response/get_balances.c
+++ b/cclient/response/get_balances.c
@@ -1,0 +1,39 @@
+#include "get_balances.h"
+
+get_balances_res_t* get_balances_res_new() {
+  get_balances_res_t* res =
+      (get_balances_res_t*)malloc(sizeof(get_balances_res_t));
+
+  res->balances = int_array_new();
+  utarray_new(res->milestone, &ut_str_icd);
+
+  return res;
+}
+
+void get_balances_res_free(get_balances_res_t* res) {
+  if (res) {
+    int_array_free(res->balances);
+    utarray_free(res->milestone);
+    utarray_free(res->milestone);
+
+    free(res);
+  }
+}
+
+int get_balances_res_balances_at(get_balances_res_t* in, int index) {
+  if (in->balances->size > index) {
+    return *(in->balances->array + index);
+  }
+  return NULL;
+}
+
+char* get_balances_res_milestone_at(get_balances_res_t* in, int index) {
+  if (utarray_len(in->milestone) > index) {
+    char** p = NULL;
+    p = (char**)utarray_eltptr(in->milestone, index);
+    if (p) {
+      return *p;
+    }
+  }
+  return '\0';
+}

--- a/cclient/response/get_balances.c
+++ b/cclient/response/get_balances.c
@@ -4,7 +4,7 @@ get_balances_res_t* get_balances_res_new() {
   get_balances_res_t* res =
       (get_balances_res_t*)malloc(sizeof(get_balances_res_t));
 
-  res->balances = int_array_new();
+  res->balances = int_array_array_new();
   utarray_new(res->milestone, &ut_str_icd);
 
   return res;
@@ -12,7 +12,7 @@ get_balances_res_t* get_balances_res_new() {
 
 void get_balances_res_free(get_balances_res_t* res) {
   if (res) {
-    int_array_free(res->balances);
+    int_array_array_free(res->balances);
     utarray_free(res->milestone);
     utarray_free(res->milestone);
 
@@ -20,9 +20,9 @@ void get_balances_res_free(get_balances_res_t* res) {
   }
 }
 
-int get_balances_res_balances_at(get_balances_res_t* in, int index) {
+char* get_balances_res_balances_at(get_balances_res_t* in, int index) {
   if (in->balances->size > index) {
-    return *(in->balances->array + index);
+    return int_array_to_string(in->balances->array + index);
   }
   return NULL;
 }

--- a/cclient/response/get_balances.h
+++ b/cclient/response/get_balances.h
@@ -15,14 +15,14 @@ extern "C" {
 #include "types/types.h"
 
 typedef struct {
-  int_array* balances;
+  int_array_array* balances;
   int milestoneIndex;
   UT_array* milestone;
 } get_balances_res_t;
 
 get_balances_res_t* get_balances_res_new();
 void get_balances_res_free(get_balances_res_t* res);
-int get_balances_res_balances_at(get_balances_res_t* in, int index);
+char* get_balances_res_balances_at(get_balances_res_t* in, int index);
 char* get_balances_res_milestone_at(get_balances_res_t* in, int index);
 
 #ifdef __cplusplus

--- a/cclient/response/get_balances.h
+++ b/cclient/response/get_balances.h
@@ -15,11 +15,15 @@ extern "C" {
 #include "types/types.h"
 
 typedef struct {
-  int_array balances;
+  int_array* balances;
   int milestoneIndex;
-  const address_t milestone;
-
+  UT_array* milestone;
 } get_balances_res_t;
+
+get_balances_res_t* get_balances_res_new();
+void get_balances_res_free(get_balances_res_t* res);
+int get_balances_res_balances_at(get_balances_res_t* in, int index);
+char* get_balances_res_milestone_at(get_balances_res_t* in, int index);
 
 #ifdef __cplusplus
 }

--- a/cclient/serialization/BUILD
+++ b/cclient/serialization/BUILD
@@ -33,7 +33,10 @@ cc_library(
 
 cc_test(
     name = "test_json",
-    srcs = ["tests/test_json.c"],
+    srcs = [
+        "tests/test_json.c",
+        "tests/test_json.h",
+    ],
     deps = [
         ":serializer_base",
         ":serializer_json",

--- a/cclient/serialization/json/json_serializer.c
+++ b/cclient/serialization/json/json_serializer.c
@@ -49,17 +49,17 @@ retcode_t utarray_to_json_array(UT_array* ut, cJSON* json_root,
   return RC_OK;
 }
 
-retcode_t json_array_to_int_array(cJSON* obj, const char* obj_name,
-                                  int_array* in) {
+retcode_t json_array_to_int_array_array(cJSON* obj, const char* obj_name,
+                                  int_array_array* in) {
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (cJSON_IsArray(json_item)) {
     cJSON* current_obj = NULL;
-    int_array_allocate(in, cJSON_GetArraySize(json_item));
+    int_array_array_allocate(in, cJSON_GetArraySize(json_item));
     
     int i = 0;
     cJSON_ArrayForEach(current_obj, json_item) {
       if (current_obj->valuestring != NULL) {
-        *(in->array + i) = atoi(current_obj->valuestring);
+        *(in->array + i) = *string_to_int_array(current_obj->valuestring);
         i++;
       }
     }
@@ -281,7 +281,7 @@ retcode_t json_get_balances_deserialize_response(const serializer_t* const s,
     return RC_CCLIENT_JSON_PARSE;
   }
 
-  ret = json_array_to_int_array(json_obj, "balances", out->balances);
+  ret = json_array_to_int_array_array(json_obj, "balances", out->balances);
   if (ret != RC_OK) {
     goto end;
   }

--- a/cclient/serialization/json/json_serializer.c
+++ b/cclient/serialization/json/json_serializer.c
@@ -55,12 +55,12 @@ retcode_t json_array_to_int_array(cJSON* obj, const char* obj_name,
   if (cJSON_IsArray(json_item)) {
     cJSON* current_obj = NULL;
     int_array_allocate(in, cJSON_GetArraySize(json_item));
-    int* in_arr_p = in->array;
-
+    
+    int i = 0;
     cJSON_ArrayForEach(current_obj, json_item) {
       if (current_obj->valuestring != NULL) {
-        *in_arr_p = atoi(current_obj->valuestring);
-        in_arr_p++;
+        *(in->array + i) = atoi(current_obj->valuestring);
+        i++;
       }
     }
   } else {

--- a/cclient/serialization/json/json_serializer.c
+++ b/cclient/serialization/json/json_serializer.c
@@ -49,6 +49,44 @@ retcode_t utarray_to_json_array(UT_array* ut, cJSON* json_root,
   return RC_OK;
 }
 
+retcode_t json_array_to_int_array(cJSON* obj, const char* obj_name,
+                                  int_array* in) {
+  cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
+  if (cJSON_IsArray(json_item)) {
+    cJSON* current_obj = NULL;
+    int_array_allocate(in, cJSON_GetArraySize(json_item));
+    int* in_arr_p = in->array;
+
+    cJSON_ArrayForEach(current_obj, json_item) {
+      if (current_obj->valuestring != NULL) {
+        *in_arr_p = atoi(current_obj->valuestring);
+        in_arr_p++;
+      }
+    }
+  } else {
+    cJSON_Delete(obj);
+    return RC_CCLIENT_JSON_PARSE;
+  }
+  return RC_OK;
+}
+
+retcode_t int_array_to_json_array(int_array* in, cJSON* json_root,
+                                  const char* obj_name) {
+  if (in->size > 0) {
+    cJSON* array_obj = cJSON_CreateArray();
+    if (array_obj == NULL) {
+      return RC_CCLIENT_JSON_CREATE;
+    }
+    cJSON_AddItemToObject(json_root, obj_name, array_obj);
+    char** p = NULL;
+    for (int i = 0; i < in->size; i++) {
+      sprintf(*p, "%d", *(in->array + i));
+      cJSON_AddItemToArray(array_obj, cJSON_CreateString(*p));
+    }
+  }
+  return RC_OK;
+}
+
 retcode_t json_get_size(const cJSON* json_obj, const char* obj_name,
                         size_t* num) {
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
@@ -180,13 +218,90 @@ retcode_t json_find_transactions_deserialize_response(
 }
 
 // get_balances_response
-void json_get_balances_serialize_request(const serializer_t* const s,
+retcode_t json_get_balances_serialize_request(const serializer_t* const s,
                                          const get_balances_req_t* const obj,
-                                         char* out) {}
+                                         char_buffer_t* out) {
+  retcode_t ret = RC_OK;
+  const char* json_text = NULL;
+  size_t len = 0;
+  cJSON* json_root = cJSON_CreateObject();
+  if (json_root == NULL) {
+    return RC_CCLIENT_JSON_CREATE;
+  }
 
-void json_get_balances_deserialize_response(const serializer_t* const s,
+  cJSON_AddItemToObject(json_root, "command",
+                        cJSON_CreateString("getBalances"));
+
+  ret = utarray_to_json_array(obj->addresses, json_root, "addresses");
+  if (ret != RC_OK) {
+    goto err;
+  }
+
+  cJSON_AddItemToObject(json_root, "threshold",
+                        cJSON_CreateNumber(obj->threshold));
+
+  ret = utarray_to_json_array(obj->tips, json_root, "tips");
+  if (ret != RC_OK) {
+    goto err;
+  }
+  json_text = cJSON_PrintUnformatted(json_root);
+  if (json_text) {
+    len = strlen(json_text);
+    ret = char_buffer_allocate(out, len);
+    if (ret == RC_OK) {
+      strncpy(out->data, json_text, len);
+    }
+    cJSON_free((void*)json_text);
+  }
+
+  cJSON_Delete(json_root);
+  return ret;
+
+err:
+  cJSON_Delete(json_root);
+  return ret;
+}
+
+retcode_t json_get_balances_deserialize_response(const serializer_t* const s,
                                             const char* const obj,
-                                            get_balances_res_t* out) {}
+                                            get_balances_res_t* out) {
+  retcode_t ret = RC_OK;
+  cJSON* json_obj = cJSON_Parse(obj);
+  cJSON* json_item = NULL;
+
+  if (json_obj == NULL) {
+    cJSON_Delete(json_obj);
+    return RC_CCLIENT_JSON_PARSE;
+  }
+
+  json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
+  if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
+    // TODO log the error message from response.
+    cJSON_Delete(json_obj);
+    return RC_CCLIENT_JSON_PARSE;
+  }
+
+  ret = json_array_to_int_array(json_obj, "balances", out->balances);
+  if (ret != RC_OK) {
+    goto end;
+  }
+
+  ret = json_array_to_utarray(json_obj, "references", out->milestone);
+  if (ret != RC_OK) {
+    printf("get balances ERROR \n");
+    goto end;
+  }
+
+  ret = json_get_int(json_obj, "milestoneIndex", &out->milestoneIndex);
+  if (ret != RC_OK) {
+    goto end;
+  }
+
+end:
+
+  cJSON_Delete(json_obj);
+  return ret;
+}
 
 // get_inclusion_state_response
 void json_get_inclusion_state_serialize_request(

--- a/cclient/serialization/json/json_serializer.h
+++ b/cclient/serialization/json/json_serializer.h
@@ -25,11 +25,11 @@ retcode_t json_find_transactions_deserialize_response(
     find_transactions_res_t* out);
 
 // get_balances_response
-void json_get_balances_serialize_request(const serializer_t* const,
+retcode_t json_get_balances_serialize_request(const serializer_t* const,
                                          const get_balances_req_t* const obj,
-                                         char* out);
+                                         char_buffer_t* out);
 
-void json_get_balances_deserialize_response(const serializer_t* const,
+retcode_t json_get_balances_deserialize_response(const serializer_t* const,
                                             const char* const obj,
                                             get_balances_res_t* out);
 

--- a/cclient/serialization/serializer.h
+++ b/cclient/serialization/serializer.h
@@ -29,11 +29,11 @@ typedef struct {
       find_transactions_res_t* out);
 
   // get_balances_response
-  void (*get_balances_serialize_request)(const serializer_t* const,
+  retcode_t (*get_balances_serialize_request)(const serializer_t* const,
                                          const get_balances_req_t* const obj,
-                                         char* out);
+                                         char_buffer_t* out);
 
-  void (*get_balances_deserialize_response)(const serializer_t* const,
+  retcode_t (*get_balances_deserialize_response)(const serializer_t* const,
                                             const char* const obj,
                                             get_balances_res_t* out);
 

--- a/cclient/serialization/tests/test_json.c
+++ b/cclient/serialization/tests/test_json.c
@@ -455,7 +455,7 @@ void test_deserialize_get_balances(void) {
   serializer.vtable.get_balances_deserialize_response(&serializer, json_text,
                                                       deserialize_get_bal);
 
-  TEST_ASSERT_EQUAL_INT(atoi(GET_BALANCES_DESERIALIZE_BALANCE),
+  TEST_ASSERT_EQUAL_STRING(GET_BALANCES_DESERIALIZE_BALANCE,
                         get_balances_res_balances_at(deserialize_get_bal, 0));
   TEST_ASSERT_EQUAL_STRING(
       GET_BALANCES_DESERIALIZE_REFERENCE,

--- a/cclient/serialization/tests/test_json.c
+++ b/cclient/serialization/tests/test_json.c
@@ -5,11 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <unity/unity.h>
-
-#include "serializer/json/json_serializer.h"
+#include "test_json.h"
 
 void test_serialize_find_transactions(void) {
   serializer_t serializer;
@@ -423,8 +419,8 @@ void test_serialize_get_balances(void) {
   init_json_serializer(&serializer);
   const char* json_text =
       "{\"command\":\"getBalances\",\"addresses\":["
-      "\"HBBYKAKTILIPVUKFOTSLHGENPTXYBNKXZFQFR9VQFWNBMTQNRV"
-      "OUKPVPRNBSZVVILMAFBKOTBLGLWLOHQ\"]"
+      "\"" GET_BALANCES_SERIALIZE_ADDRESS
+      "\"]"
       ",\"threshold\":100}";
 
   char_buffer_t* serializer_out = char_buffer_new();
@@ -448,23 +444,24 @@ void test_deserialize_get_balances(void) {
   init_json_serializer(&serializer);
   const char* json_text =
       "{\"balances\": "
-      "[\"114544444\"], "
+      "[\"" GET_BALANCES_DESERIALIZE_BALANCE
+      "\"], "
       "\"references\": "
-      "[\"INRTUYSZCWBHGFGGXXPWRWBZACYAFGVRRP9VYEQJOHYD9URME"
-      "LKWAFYFMNTSP9MCHLXRGAFMBOZPZ9999\"], "
-      "\"milestoneIndex\": 128}";
+      "[\"" GET_BALANCES_DESERIALIZE_REFERENCE
+      "\"], "
+      "\"milestoneIndex\":" GET_BALANCES_DESERIALIZE_MILESTONEINDEX "}";
 
   get_balances_res_t* deserialize_get_bal = get_balances_res_new();
   serializer.vtable.get_balances_deserialize_response(&serializer, json_text,
                                                       deserialize_get_bal);
 
-  TEST_ASSERT_EQUAL_INT(114544444,
+  TEST_ASSERT_EQUAL_INT(atoi(GET_BALANCES_DESERIALIZE_BALANCE),
                         get_balances_res_balances_at(deserialize_get_bal, 0));
-  TEST_ASSERT_EQUAL_INT(128, deserialize_get_bal->milestoneIndex);
   TEST_ASSERT_EQUAL_STRING(
-      "INRTUYSZCWBHGFGGXXPWRWBZACYAFGVRRP9VYEQJOHYD9URMELKWAFYFMNTSP9MCHLXRGAFM"
-      "BOZPZ9999",
+      GET_BALANCES_DESERIALIZE_REFERENCE,
       get_balances_res_milestone_at(deserialize_get_bal, 0));
+  TEST_ASSERT_EQUAL_INT(atoi(GET_BALANCES_DESERIALIZE_MILESTONEINDEX),
+                        deserialize_get_bal->milestoneIndex);
 }
 
 void test_serialize_get_transactions_to_approve(void) {

--- a/cclient/serialization/tests/test_json.c
+++ b/cclient/serialization/tests/test_json.c
@@ -419,11 +419,52 @@ void test_deserialize_get_inclusion_states(void) {
 }
 
 void test_serialize_get_balances(void) {
-  // TODO
+  serializer_t serializer;
+  init_json_serializer(&serializer);
+  const char* json_text =
+      "{\"command\":\"getBalances\",\"addresses\":["
+      "\"HBBYKAKTILIPVUKFOTSLHGENPTXYBNKXZFQFR9VQFWNBMTQNRV"
+      "OUKPVPRNBSZVVILMAFBKOTBLGLWLOHQ\"]"
+      ",\"threshold\":100}";
+
+  char_buffer_t* serializer_out = char_buffer_new();
+  get_balances_req_t* get_bal = get_balances_req_new();
+  get_balances_req_add_address(get_bal,
+                               "HBBYKAKTILIPVUKFOTSLHGENPTXYBNKXZFQFR9"
+                               "VQFWNBMTQNRVOUKPVPRNBSZVVILMAFBKOTBLGL"
+                               "WLOHQ");
+  get_bal->threshold = 100;
+  serializer.vtable.get_balances_serialize_request(&serializer, get_bal,
+                                                   serializer_out);
+
+  TEST_ASSERT_EQUAL_STRING(json_text, serializer_out->data);
+
+  char_buffer_free(serializer_out);
+  get_balances_req_free(get_bal);
 }
 
 void test_deserialize_get_balances(void) {
-  // TODO
+  serializer_t serializer;
+  init_json_serializer(&serializer);
+  const char* json_text =
+      "{\"balances\": "
+      "[\"114544444\"], "
+      "\"references\": "
+      "[\"INRTUYSZCWBHGFGGXXPWRWBZACYAFGVRRP9VYEQJOHYD9URME"
+      "LKWAFYFMNTSP9MCHLXRGAFMBOZPZ9999\"], "
+      "\"milestoneIndex\": 128}";
+
+  get_balances_res_t* deserialize_get_bal = get_balances_res_new();
+  serializer.vtable.get_balances_deserialize_response(&serializer, json_text,
+                                                      deserialize_get_bal);
+
+  TEST_ASSERT_EQUAL_INT(114544444,
+                        get_balances_res_balances_at(deserialize_get_bal, 0));
+  TEST_ASSERT_EQUAL_INT(128, deserialize_get_bal->milestoneIndex);
+  TEST_ASSERT_EQUAL_STRING(
+      "INRTUYSZCWBHGFGGXXPWRWBZACYAFGVRRP9VYEQJOHYD9URMELKWAFYFMNTSP9MCHLXRGAFM"
+      "BOZPZ9999",
+      get_balances_res_milestone_at(deserialize_get_bal, 0));
 }
 
 void test_serialize_get_transactions_to_approve(void) {

--- a/cclient/serialization/tests/test_json.h
+++ b/cclient/serialization/tests/test_json.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef CCLIENT_TEST_JSON_H
+#define CCLIENT_TEST_JSON_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <unity/unity.h>
+
+#include "serializer/json/json_serializer.h"
+
+#define GET_BALANCES_SERIALIZE_ADDRESS                                         \
+  "HBBYKAKTILIPVUKFOTSLHGENPTXYBNKXZFQFR9VQFWNBMTQNRVOUKPVPRNBSZVVILMAFBKOTBL" \
+  "GLWLOHQ"
+#define GET_BALANCES_DESERIALIZE_BALANCE "114544444"
+#define GET_BALANCES_DESERIALIZE_REFERENCE                                     \
+  "INRTUYSZCWBHGFGGXXPWRWBZACYAFGVRRP9VYEQJOHYD9URMELKWAFYFMNTSP9MCHLXRGAFMBO" \
+  "ZPZ9999"
+#define GET_BALANCES_DESERIALIZE_MILESTONEINDEX "128"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CCLIENT_TEST_JSON_H

--- a/cclient/types/types.c
+++ b/cclient/types/types.c
@@ -59,3 +59,52 @@ void int_array_free(int_array* in) {
     free(in);
   }
 }
+
+int_array_array* int_array_array_new(){
+  int_array_array* out = (int_array_array*)malloc(sizeof(int_array_array));
+  out->size = 0;
+  out->array = NULL;
+  return out;
+}
+
+retcode_t int_array_array_allocate(int_array_array* in, size_t n) {
+  if (in->size != 0) {
+    return RC_OK;
+  }
+  in->array = (int_array*)malloc(sizeof(int_array) * (n + 1));
+  if (in->array == NULL) {
+    return RC_CCLIENT_OOM;
+  }
+  in->size = n;
+  return RC_OK;
+}
+
+void int_array_array_free(int_array_array* in) {
+  if (in) {
+    for (int i = 0; i < in->size; i++) {
+      int_array_free(in->array + i);
+    }
+    free(in);
+  }
+}
+
+char* int_array_to_string(int_array* in) {
+  int len = in->size;
+  char* str = (char*)malloc(sizeof(char) * len);
+
+  for (int i = 0; i < len; i++) {
+    sprintf(str + i, "%d", *(in->array + i));
+  }
+  return str;
+}
+
+int_array* string_to_int_array(char* in) {
+  int len = strlen(in);
+  int_array* in_arr = int_array_new();
+  int_array_allocate(in_arr, len);
+  
+  for (int i = 0; i < len; i++) {
+    *(in_arr->array + i) = atoi(in + i);
+  }
+  return in_arr;
+}

--- a/cclient/types/types.c
+++ b/cclient/types/types.c
@@ -44,14 +44,18 @@ retcode_t int_array_allocate(int_array* in, size_t n) {
     return RC_OK;
   }
   in->array = (int*)malloc(sizeof(int) * (n + 1));
-  if (in->array == NULL) return RC_CCLIENT_OOM;
+  if (in->array == NULL) {
+    return RC_CCLIENT_OOM;
+  }
   in->size = n;
   return RC_OK;
 }
 
 void int_array_free(int_array* in) {
   if (in) {
-    if (in->array) free(in->array);
+    if (in->array) {
+      free(in->array);
+    }
     free(in);
   }
 }

--- a/cclient/types/types.c
+++ b/cclient/types/types.c
@@ -31,3 +31,27 @@ void char_buffer_free(char_buffer_t* in) {
     free(in);
   }
 }
+
+int_array* int_array_new(){
+  int_array* out = (int_array*)malloc(sizeof(int_array));
+  out->size = 0;
+  out->array = NULL;
+  return out;
+}
+
+retcode_t int_array_allocate(int_array* in, size_t n) {
+  if (in->size != 0) {
+    return RC_OK;
+  }
+  in->array = (int*)malloc(sizeof(int) * (n + 1));
+  if (in->array == NULL) return RC_CCLIENT_OOM;
+  in->size = n;
+  return RC_OK;
+}
+
+void int_array_free(int_array* in) {
+  if (in) {
+    if (in->array) free(in->array);
+    free(in);
+  }
+}

--- a/cclient/types/types.h
+++ b/cclient/types/types.h
@@ -45,6 +45,11 @@ typedef struct {
 
 typedef struct {
   size_t size;
+  int_array* array;
+} int_array_array;
+
+typedef struct {
+  size_t size;
   trit_array_p* array;
 } trit_array_array;
 
@@ -70,6 +75,13 @@ void char_buffer_free(char_buffer_t* in);
 int_array* int_array_new();
 retcode_t int_array_allocate(int_array* in, size_t n);
 void int_array_free(int_array* in);
+
+int_array_array* int_array_array_new();
+retcode_t int_array_array_allocate(int_array_array* in, size_t n);
+void int_array_array_free(int_array_array* in);
+
+char* int_array_to_string(int_array* in);
+int_array* string_to_int_array(char* in);
 
 #ifdef __cplusplus
 }

--- a/cclient/types/types.h
+++ b/cclient/types/types.h
@@ -67,6 +67,10 @@ char_buffer_t* char_buffer_new();
 retcode_t char_buffer_allocate(char_buffer_t* in, size_t n);
 void char_buffer_free(char_buffer_t* in);
 
+int_array* int_array_new();
+retcode_t int_array_allocate(int_array* in, size_t n);
+void int_array_free(int_array* in);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Implement iota api get_balances
json_serializer.h:
        json_get_balances_serialize_request()
        json_get_balances_deserialize_response()

iota_api.c:
        iota_api_get_balances()

Implement int_array related functions.
json_serializer.c:
        json_array_to_int_array()
        int_array_to_json_array()

type.h: int_array_new()
        int_array_allocate()
        int_array_free()

request/get_balances.h:
        get_balances_req_free()
        get_balances_req_add_address()
        get_balances_req_add_tip()

response/get_blanaces.h:
        get_balances_res_free()
        get_balances_res_balances_at()
        get_balances_res_milestone_at()



# Test Plan:
CI must pass
