### PR TITLE
tools: fix bazel 0.17.1 and Android r17c NDK build compatibility

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,5 +1,5 @@
 build --cxxopt='-std=c++1z'
-build --fat_apk_cpu='armeabi,armeabi-v7a,arm64-v8a,x86,x86_64'
+build --fat_apk_cpu='armeabi-v7a,arm64-v8a,x86,x86_64'
 
 test --copt='-ggdb3'
 


### PR DESCRIPTION
Remove `armeabi` from fat apk targets

# Test Plan:
CI builds