### PR TITLE
Cclient trits decoding error

### DIFF
--- a/cclient/serialization/json/json_serializer.c
+++ b/cclient/serialization/json/json_serializer.c
@@ -96,7 +96,7 @@ retcode_t flex_hash_array_to_json_array(flex_hash_array_t* head,
     cJSON_AddItemToObject(json_root, obj_name, array_obj);
     LL_FOREACH(head, elt) {
       // flex to trytes;
-      size_t len_trytes = num_flex_trits_for_trits(elt->hash->num_trits);
+      size_t len_trytes = elt->hash->num_trits / 3;
       trit_t trytes_out[len_trytes + 1];
       size_t trits_count =
           flex_trits_to_trytes(trytes_out, len_trytes, elt->hash->trits,
@@ -116,7 +116,7 @@ retcode_t flex_hash_array_to_json_array(flex_hash_array_t* head,
 retcode_t flex_hash_to_json_string(cJSON* json_obj, const char* key,
                                    trit_array_p hash) {
   // flex to trytes;
-  size_t len_trytes = num_flex_trits_for_trits(hash->num_trits);
+  size_t len_trytes = hash->num_trits / 3;
   trit_t trytes_out[len_trytes + 1];
   size_t trits_count = flex_trits_to_trytes(trytes_out, len_trytes, hash->trits,
                                             hash->num_trits, hash->num_trits);

--- a/common/trinary/tests/test_trit_array.c
+++ b/common/trinary/tests/test_trit_array.c
@@ -75,6 +75,13 @@ void test_trit_array_static_to_int8(void) {
   TEST_ASSERT_EQUAL_MEMORY(trits_out, trits, NUM_TRITS);
 }
 
+void test_trytes_to_trit_array(void) {
+  trit_t trits_out[] = {TRITS_IN};
+  trit_array_p out_array = trit_array_new_from_trytes((tryte_t*)TRYTES);
+  TEST_ASSERT_EQUAL_MEMORY(trits_out, out_array->trits, out_array->num_bytes);
+  trit_array_free(out_array);
+}
+
 int main(void) {
   UNITY_BEGIN();
 
@@ -83,6 +90,7 @@ int main(void) {
   RUN_TEST(test_trit_array_static_slice);
   RUN_TEST(test_trit_array_static_insert);
   RUN_TEST(test_trit_array_static_to_int8);
+  RUN_TEST(test_trytes_to_trit_array);
 
   return UNITY_END();
 }


### PR DESCRIPTION
This PR fixed flex_trits decoding error on different trits encode methods in cclient. 

# Test Plan:
CI  must pass with TE cases
