### PR TITLE
Fix struct initialisation style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Project Guidelines
+
+## Coding Style 
+The majority of the code in this repository adheres to [Google's C++ guidelines](https://google.github.io/styleguide/cppguide.html). Below are additional rules which we adhere to:
+
+### 1. C Struct intialisation
+If you're initialising a struct, please use member designators to identify the individual fields:
+```c
+iota_stor_pack_t pack = {.models = (void **)txs,
+                         .capacity = 5,
+                         .num_loaded = 0,
+                         .insufficient_capacity = false};
+```
+
+You can find more information on the capabilities of C99 in this regard [here](https://en.cppreference.com/w/c/language/struct_initialization).

--- a/common/storage/sql/sqlite3/tests/test_sqlite3.c
+++ b/common/storage/sql/sqlite3/tests/test_sqlite3.c
@@ -107,11 +107,11 @@ void test_stored_transaction(void) {
   TEST_ASSERT(iota_stor_transaction_exist(&conn, NULL, NULL, &exist) == RC_OK);
   TEST_ASSERT(exist == true);
 
-  iota_stor_pack_t pack;
   iota_transaction_t txs[5];
-  pack.models = (void **)txs;
-  pack.num_loaded = 0;
-  pack.capacity = 5;
+  iota_stor_pack_t pack = {.models = (void **)txs,
+                           .capacity = 5,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
 
   for (int i = 0; i < 5; ++i) {
     pack.models[i] = transaction_new();
@@ -172,7 +172,10 @@ void test_stored_milestone(void) {
   milestone.hash[0]++;
   TEST_ASSERT(iota_stor_milestone_store(&conn, &milestone) == RC_OK);
   iota_milestone_t *ms = malloc(sizeof(iota_milestone_t));
-  iota_stor_pack_t ms_pack = {(void **)&ms, 1, 0, false};
+  iota_stor_pack_t ms_pack = {.models = (void **)&ms,
+                              .capacity = 1,
+                              .num_loaded = 0,
+                              .insufficient_capacity = false};
   iota_stor_milestone_load_latest(&conn, &ms_pack);
   TEST_ASSERT_EQUAL_INT(1, ms_pack.num_loaded);
   TEST_ASSERT_EQUAL_INT(ms->index, milestone.index);
@@ -190,11 +193,11 @@ void test_stored_milestone(void) {
   TEST_ASSERT(iota_stor_milestone_exist(&conn, NULL, NULL, &exist) == RC_OK);
   TEST_ASSERT(exist == true);
 
-  iota_stor_pack_t pack;
   iota_milestone_t *milestones[5];
-  pack.models = (void **)milestones;
-  pack.num_loaded = 0;
-  pack.capacity = 5;
+  iota_stor_pack_t pack = {.models = (void **)milestones,
+                           .num_loaded = 0,
+                           .capacity = 5,
+                           .insufficient_capacity = false};
 
   for (int i = 0; i < 5; ++i) {
     pack.models[i] = malloc(sizeof(iota_milestone_t));
@@ -211,10 +214,11 @@ void test_stored_milestone(void) {
 
 void test_stored_load_hashes_by_address(void) {
   trit_array_p hashes[5];
-  iota_stor_pack_t pack;
-  pack.models = (void **)hashes;
-  pack.num_loaded = 0;
-  pack.capacity = 5;
+  iota_stor_pack_t pack = {.models = (void **)hashes,
+                           .capacity = 5,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
+
   for (int i = 0; i < pack.capacity; ++i) {
     pack.models[i] = trit_array_new(NUM_TRITS_ADDRESS);
   }
@@ -235,14 +239,15 @@ void test_stored_load_hashes_by_address(void) {
 
 void test_stored_load_hashes_of_approvers(void) {
   trit_array_p hashes[5];
-  iota_stor_pack_t pack;
-  pack.models = (void **)hashes;
-  pack.num_loaded = 0;
-  pack.capacity = 5;
+  iota_stor_pack_t pack = {.models = (void **)hashes,
+                           .capacity = 5,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
+
   for (int i = 0; i < pack.capacity; ++i) {
     pack.models[i] = trit_array_new(NUM_TRITS_HASH);
   }
-  pack.capacity = 5;
+
   TRIT_ARRAY_DECLARE(key, NUM_TRITS_HASH);
   memcpy(key.trits, TEST_TRANSACTION.address, FLEX_TRIT_SIZE_243);
   TEST_ASSERT(iota_stor_transaction_load_hashes_of_approvers(&conn, key.trits,

--- a/consensus/bundle_validator/bundle_validator.c
+++ b/consensus/bundle_validator/bundle_validator.c
@@ -121,7 +121,10 @@ retcode_t load_bundle_transactions(const tangle_t* const tangle,
   iota_transaction_t curr_tx = &curr_tx_s;
   flex_trit_t bundle_hash[FLEX_TRIT_SIZE_243];
 
-  iota_stor_pack_t pack = {(void**)(&curr_tx), 1, 0, false};
+  iota_stor_pack_t pack = {.models = (void**)(&curr_tx),
+                           .capacity = 1,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
 
   res = iota_tangle_transaction_load(tangle, TRANSACTION_COL_HASH, tail_hash,
                                      &pack);

--- a/consensus/entry_point_selector/entry_point_selector.c
+++ b/consensus/entry_point_selector/entry_point_selector.c
@@ -32,7 +32,10 @@ retcode_t iota_consensus_get_entry_point(entry_point_selector_t *const eps,
   retcode_t ret = RC_OK;
   size_t milestone_index = MAX(eps->mt->latest_milestone_index - depth - 1, 0);
   iota_milestone_t milestone;
-  iota_stor_pack_t pack = {(void **)&milestone, 1, 0, false};
+  iota_stor_pack_t pack = {.models = (void **)&milestone,
+                           .capacity = 1,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
 
   if ((ret = iota_tangle_milestone_load_next(eps->tangle, milestone_index,
                                              &pack))) {

--- a/consensus/exit_probability_randomizer/tests/test_exit_probability_randomizer.c
+++ b/consensus/exit_probability_randomizer/tests/test_exit_probability_randomizer.c
@@ -547,7 +547,10 @@ void test_1_bundle(void) {
   struct _iota_transaction tx;
   iota_transaction_t tx_models = &tx;
 
-  iota_stor_pack_t tx_pack = {(void **)(&tx_models), 1, 0, false};
+  iota_stor_pack_t tx_pack = {.models = (void **)(&tx_models),
+                              .capacity = 1,
+                              .num_loaded = 0,
+                              .insufficient_capacity = false};
 
   TEST_ASSERT(iota_tangle_transaction_load(&tangle, TRANSACTION_COL_HASH, ep,
                                            &tx_pack) == RC_OK);
@@ -686,7 +689,10 @@ void test_2_chained_bundles(void) {
   struct _iota_transaction tx;
   iota_transaction_t tx_models = &tx;
 
-  iota_stor_pack_t tx_pack = {(void **)(&tx_models), 1, 0, false};
+  iota_stor_pack_t tx_pack = {.models = (void **)(&tx_models),
+                              .capacity = 1,
+                              .num_loaded = 0,
+                              .insufficient_capacity = false};
 
   TEST_ASSERT(iota_tangle_transaction_load(&tangle, TRANSACTION_COL_HASH, ep,
                                            &tx_pack) == RC_OK);

--- a/consensus/exit_probability_randomizer/walker.c
+++ b/consensus/exit_probability_randomizer/walker.c
@@ -201,7 +201,10 @@ retcode_t find_tail_if_valid(const ep_randomizer_t *exit_probability_randomizer,
   bool found_approver = false;
   *found_tail = false;
 
-  iota_stor_pack_t tx_pack = {(void **)(&curr_tx), 1, 0, false};
+  iota_stor_pack_t tx_pack = {.models = (void **)(&curr_tx),
+                              .capacity = 1,
+                              .num_loaded = 0,
+                              .insufficient_capacity = false};
 
   res = iota_tangle_transaction_load(exit_probability_randomizer->tangle,
                                      TRANSACTION_COL_HASH, tx_hash, &tx_pack);

--- a/consensus/exit_probability_validator/exit_probability_validator.c
+++ b/consensus/exit_probability_validator/exit_probability_validator.c
@@ -36,7 +36,10 @@ retcode_t iota_consensus_exit_prob_transaction_validator_is_valid(
   struct _iota_transaction tx;
   iota_transaction_t tx_models = &tx;
 
-  iota_stor_pack_t tx_pack = {(void **)(&tx_models), 1, 0, false};
+  iota_stor_pack_t tx_pack = {.models = (void **)(&tx_models),
+                              .capacity = 1,
+                              .num_loaded = 0,
+                              .insufficient_capacity = false};
 
   ret = iota_tangle_transaction_load(ep_validator->tangle, TRANSACTION_COL_HASH,
                                      tx_hash, &tx_pack);

--- a/consensus/milestone_tracker/milestone_tracker.c
+++ b/consensus/milestone_tracker/milestone_tracker.c
@@ -146,7 +146,10 @@ static void* latest_milestone_tracker(void* arg) {
   iota_milestone_t candidate;
   struct _iota_transaction tx;
   iota_transaction_t tx_ptr = &tx;
-  iota_stor_pack_t tx_pack = {(void**)&tx_ptr, 1, 0, false};
+  iota_stor_pack_t tx_pack = {.models = (void**)&tx_ptr,
+                              .num_loaded = 1,
+                              .capacity = 0,
+                              .insufficient_capacity = false};
   uint64_t scan_time, previous_latest_milestone_index;
 
   if (mt == NULL) {
@@ -201,7 +204,10 @@ static retcode_t update_latest_solid_subtangle_milestone(
   iota_milestone_t milestone, latest_milestone;
   iota_milestone_t *milestone_ptr = &milestone,
                    *latest_milestone_ptr = &latest_milestone;
-  iota_stor_pack_t pack = {(void**)&latest_milestone_ptr, 1, 0, false};
+  iota_stor_pack_t pack = {.models = (void**)&latest_milestone_ptr,
+                           .capacity = 1,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
 
   if (mt == NULL) {
     return RC_CONSENSUS_MT_NULL_SELF;

--- a/gossip/components/responder.c
+++ b/gossip/components/responder.c
@@ -30,7 +30,10 @@ static retcode_t regular_transaction_request(
     return RC_RESPONDER_COMPONENT_OOM;
   }
 
-  iota_stor_pack_t pack = {(void **)tx, 1, 0, false};
+  iota_stor_pack_t pack = {.models = (void **)tx,
+                           .capacity = 1,
+                           .num_loaded = 0,
+                           .insufficient_capacity = false};
   if ((ret = iota_tangle_transaction_load(&state->node->core->tangle,
                                           TRANSACTION_COL_HASH, request->hash,
                                           &pack))) {


### PR DESCRIPTION
Adds contribution guidelines and enforces coding style #1 for uses of `iota_stor_pack_t`.

# Test Plan:
CI should pass.
