### PR TITLE
common/trinary: bytes/flex_trits conversion, optimisations

### DIFF
--- a/common/trinary/BUILD
+++ b/common/trinary/BUILD
@@ -153,6 +153,7 @@ cc_library(
         ":trit_byte",
         ":trit_tryte",
         ":trits",
+        "//utils:macros",
         "//common:stdint",
     ],
 )
@@ -166,6 +167,7 @@ cc_library(
         ":trit_byte",
         ":trit_tryte",
         ":trits",
+        "//utils:macros",
         "//common:stdint",
     ],
 )
@@ -179,6 +181,7 @@ cc_library(
         ":trit_byte",
         ":trit_tryte",
         ":trits",
+        "//utils:macros",
         "//common:stdint",
     ],
 )
@@ -192,6 +195,7 @@ cc_library(
         ":trit_byte",
         ":trit_tryte",
         ":trits",
+        "//utils:macros",
         "//common:stdint",
     ],
 )

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -10,77 +10,81 @@
 
 #include "common/trinary/flex_trit.h"
 #include "common/trinary/trit_byte.h"
-
+#include "utils/macros.h"
 size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
                         flex_trit_t const *const flex_trits, size_t const len,
                         size_t const start, size_t const num_trits) {
   // Bounds checking
-  if (num_trits > to_len || (start + num_trits) > len) {
+  if (num_trits == 0 || num_trits > to_len || (start + num_trits) > len) {
     return 0;
   }
   size_t num_bytes = num_flex_trits_for_trits(num_trits);
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
-  memcpy(to_flex_trits, flex_trits + start, num_trits);
+  // num_bytes == num_trits in a 1:1 scheme
+  memcpy(to_flex_trits, flex_trits + start, num_bytes);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
   trit_t trits[6];
   size_t index = start / 3U;
   size_t offset = start % 3U;
-  size_t end_index = (start + num_trits - 1) / 3U;
-  size_t i, j, tlen = 3;
-  for (i = index, j = 0; i < index + num_bytes; i++, j++) {
+  size_t i, j;
+  size_t end_index = num_flex_trits_for_trits(len) - 1;
+  for (i = index, j = 0; j < num_bytes; i++, j++) {
     trytes_to_trits(&flex_trits[i], trits, 1);
-    if (i < end_index) {
-      if (offset) {
-        trytes_to_trits(&flex_trits[i + 1], trits + 3, 1);
-      }
-    } else if (num_bytes * 3 > num_trits) {
-      tlen = (num_trits - num_bytes * 3 + 3);
+    if (offset && i < end_index) {
+      trytes_to_trits(&flex_trits[i + 1], trits + 3, 1);
     }
-    trits_to_trytes(trits + offset, to_flex_trits + j, tlen);
+    trits_to_trytes(trits + offset, to_flex_trits + j, 3);
+  }
+  // There is a risk of noise after the last trit so we need to clean up
+  uint8_t residual = num_trits % 3U;
+  if (residual) {
+    // size_t tlen = (num_trits - num_bytes * 3 + 3);
+    trits_to_trytes(trits + offset, to_flex_trits + num_bytes - 1, residual);
   }
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
-  uint8_t buffer;
+  uint8_t buffer = 0;
   uint8_t tshift = (start & 3) << 1U;
-  uint8_t rshift = (8U - tshift) % 8U;
+  uint8_t rshift = (8U - tshift) & 7;
   size_t index = start >> 2U;
-  size_t end_index = index + num_bytes - 1;
   size_t i, j;
-  size_t total_bytes = num_flex_trits_for_trits(len);
+  size_t end_index = num_flex_trits_for_trits(len) - 1;
   // Calculate the number of bytes to copy over
-  for (i = index, j = 0; i <= end_index; i++, j++) {
+  for (i = index, j = 0; j < num_bytes; i++, j++) {
     buffer = flex_trits[i];
     buffer = buffer >> tshift;
-    if (rshift && i < total_bytes - 1) {
+    if (rshift && i < end_index) {
       buffer |= (flex_trits[i + 1] << rshift);
-    }
-    if (i == end_index) {
-      uint8_t residual = (num_trits & 3);
-      if (residual) {
-        uint8_t shift = (4 - residual) << 1U;
-        buffer <<= shift;
-        buffer >>= shift;
-      }
     }
     to_flex_trits[j] = buffer;
   }
   // There is a risk of noise after the last trit so we need to clean up
+  uint8_t residual = (num_trits & 3);
+  if (residual) {
+    uint8_t shift = (4 - residual) << 1U;
+    buffer <<= shift;
+    buffer >>= shift;
+    to_flex_trits[num_bytes - 1] = buffer;
+  }
 #elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
   trit_t trits[10] = {0};
   size_t index = start / 5U;
   size_t offset = start % 5U;
-  size_t end_index = (start + num_trits - 1) / 5U;
-  size_t i, j, tlen = 5;
-  for (i = index, j = 0; i < index + num_bytes; i++, j++) {
+  size_t i, j;
+  size_t end_index = num_flex_trits_for_trits(len) - 1;
+  for (i = index, j = 0; j < num_bytes; i++, j++) {
     bytes_to_trits(((byte_t *)flex_trits + i), 1, trits, 5);
-    if (i < end_index) {
-      if (offset) {
-        bytes_to_trits(((byte_t *)flex_trits + i + 1), 1, ((trit_t *)trits + 5),
-                       5);
-      }
-    } else if (num_bytes * 5 > num_trits) {
-      tlen = (num_trits - num_bytes * 5 + 5);
+    if (offset && i < end_index) {
+      bytes_to_trits(((byte_t *)flex_trits + i + 1), 1, ((trit_t *)trits + 5),
+                     5);
     }
-    to_flex_trits[j] = trits_to_byte(trits + offset, 0, tlen - 1);
+    to_flex_trits[j] = trits_to_byte(trits + offset, 0, 4);
+  }
+  // There is a risk of noise after the last trit so we need to clean up
+  uint8_t residual = num_trits % 5U;
+  if (residual) {
+    to_flex_trits[num_bytes - 1] =
+        trits_to_byte(trits + offset, 0, residual - 1);
   }
 #endif
   return num_bytes;
@@ -90,13 +94,18 @@ size_t flex_trits_insert(flex_trit_t *const to_flex_trits, size_t const to_len,
                          flex_trit_t const *const flex_trits, size_t const len,
                          size_t const start, size_t const num_trits) {
   // Bounds checking
-  if (num_trits > len || num_trits > to_len) {
+  if (num_trits == 0 || num_trits > len || num_trits > to_len ||
+      start >= to_len || (start + num_trits) >= to_len) {
     return 0;
   }
+#if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+  memcpy(to_flex_trits + start, flex_trits, num_trits);
+#else
   for (size_t i = 0; i < num_trits; i++) {
     flex_trits_set_at(to_flex_trits, to_len, start + i,
                       flex_trits_at(flex_trits, len, i));
   }
+#endif
   return num_trits;
 }
 
@@ -104,11 +113,13 @@ size_t flex_trits_to_trits(trit_t *const trits, size_t const to_len,
                            flex_trit_t const *const flex_trits,
                            size_t const len, size_t const num_trits) {
   // Bounds checking
-  if (num_trits > len || num_trits > to_len) {
+  if (num_trits == 0 || num_trits > len || num_trits > to_len) {
     return 0;
   }
   size_t num_bytes = num_flex_trits_for_trits(num_trits);
+  memset(trits, 0, to_len);
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+  // num_bytes == num_trits in a 1:1 scheme
   memcpy(trits, flex_trits, num_bytes);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
   trytes_to_trits(flex_trits, trits, num_bytes);
@@ -129,13 +140,13 @@ size_t flex_trits_from_trits(flex_trit_t *const to_flex_trits,
   if (num_trits > len || num_trits > to_len) {
     return 0;
   }
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+  // num_bytes == num_trits in a 1:1 scheme
   memcpy(to_flex_trits, trits, num_trits);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
-  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
   trits_to_trytes(trits, to_flex_trits, num_trits);
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
-  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
   for (size_t i = 0; i < num_trits; i++) {
     flex_trits_set_at(to_flex_trits, to_len, i, trits[i]);
   }
@@ -173,7 +184,7 @@ size_t flex_trits_from_trytes(flex_trit_t *to_flex_trits, size_t to_len,
   if (num_trytes > len || num_trytes * 3 > to_len) {
     return 0;
   }
-  memset(to_flex_trits, 0, num_flex_trits_for_trits(to_len));
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   trytes_to_trits((tryte_t *)trytes, to_flex_trits, num_trytes);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
@@ -186,4 +197,108 @@ size_t flex_trits_from_trytes(flex_trit_t *to_flex_trits, size_t to_len,
   flex_trits_from_trits(to_flex_trits, to_len, trits, to_len, to_len);
 #endif
   return num_trytes;
+}
+
+size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
+                           const flex_trit_t *flex_trits, size_t len,
+                           size_t num_trits) {
+  // Bounds checking
+  if (num_trits > len || num_trits > to_len) {
+    return 0;
+  }
+  memset(bytes, 0, min_bytes(to_len));
+#if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+  trits_to_bytes((trit_t *)flex_trits, bytes, num_trits);
+#elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE) || \
+    defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
+  union _shifter {
+    uint64_t val;
+    trit_t trits[8];
+  };
+  union _shifter shifter = {0};
+  size_t offset = 0;
+  size_t max_trits, trits_for_byte;
+  for (int i = 0, j = 0; num_trits; i++, j++) {
+    max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, num_trits);
+    flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i],
+                        max_trits, max_trits);
+    num_trits -= max_trits;
+    offset += max_trits;
+    if (offset < 5 && num_trits) {
+      i++;
+      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, num_trits);
+      flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i],
+                          max_trits, max_trits);
+      num_trits -= max_trits;
+      offset += max_trits;
+    }
+    trits_for_byte = MIN(4, (offset - 1));
+    bytes[j] = trits_to_byte(shifter.trits, 0, trits_for_byte);
+#if BYTE_ORDER == LITTLE_ENDIAN
+    shifter.val = shifter.val >> 40;
+#elif BYTE_ORDER == BIG_ENDIAN
+    shifter.val = shifter.val << 40;
+#endif
+    offset -= 5;
+  }
+#elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
+  size_t num_bytes = min_bytes(num_trits);
+  memcpy(bytes, flex_trits, num_bytes);
+  size_t residual = num_trits % 5;
+  if (residual) {
+    trit_t last_byte[5] = {0};
+    size_t index = num_bytes - 1;
+    byte_to_trits(flex_trits[index], last_byte, 4);
+    bytes[index] = trits_to_byte(last_byte, 0, residual - 1);
+  }
+#endif
+  return num_trits;
+}
+
+size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
+                             const byte_t *bytes, size_t len,
+                             size_t num_trits) {
+  // Bounds checking
+  if (num_trits > len || num_trits > to_len) {
+    return 0;
+  }
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
+#if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+  size_t num_bytes = min_bytes(num_trits);
+  bytes_to_trits(bytes, num_bytes, to_flex_trits, num_trits);
+#elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE) || \
+    defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
+  union _shifter {
+    uint64_t val;
+    trit_t trits[8];
+  };
+  union _shifter shifter = {0};
+  size_t offset = 0;
+  size_t max_trits, trits_for_byte;
+  for (int i = 0, j = 0; num_trits; j++) {
+    max_trits = MIN(5, num_trits);
+    if (offset < NUM_TRITS_PER_FLEX_TRIT) {
+      byte_to_trits(bytes[i], shifter.trits + offset, max_trits - 1);
+      offset += max_trits;
+      i++;
+    }
+    trits_for_byte = MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
+    flex_trits_from_trits(&to_flex_trits[j], num_trits, shifter.trits,
+                          trits_for_byte, trits_for_byte);
+    num_trits -= trits_for_byte;  // MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
+    shifter.val = shifter.val >> (trits_for_byte << 3);
+    offset -= trits_for_byte;
+  }
+#elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
+  size_t num_bytes = min_bytes(num_trits);
+  memcpy(to_flex_trits, bytes, num_bytes);
+  size_t residual = num_trits % 5;
+  if (residual) {
+    trit_t last_byte[5] = {0};
+    size_t index = num_bytes - 1;
+    byte_to_trits(bytes[index], last_byte, 4);
+    to_flex_trits[index] = trits_to_byte(last_byte, 0, residual - 1);
+  }
+#endif
+  return num_trits;
 }

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -24,7 +24,6 @@ extern "C" {
 
 #include "common/trinary/trit_byte.h"
 #include "common/trinary/trit_tryte.h"
-#include "common/trinary/trits.h"
 
 typedef int8_t flex_trit_t;
 
@@ -35,6 +34,16 @@ typedef int8_t flex_trit_t;
 #define FLEX_TRIT_NULL_VALUE '9'
 #else
 #define FLEX_TRIT_NULL_VALUE 0
+#endif
+
+#if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+#define NUM_TRITS_PER_FLEX_TRIT 1
+#elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
+#define NUM_TRITS_PER_FLEX_TRIT 3
+#elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
+#define NUM_TRITS_PER_FLEX_TRIT 4
+#elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
+#define NUM_TRITS_PER_FLEX_TRIT 5
 #endif
 
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
@@ -194,7 +203,7 @@ size_t flex_trits_insert(flex_trit_t *const to_flex_trits, size_t const to_len,
 /// @param[in] flex_trits - the array of packed trits
 /// @param[in] len - the number of trits the flex_trits array stores
 /// @param[in] num_trits - the number of trits to extract
-/// @return size_t - the number of trits extracted
+/// @return size_t - the number of trits encoded
 size_t flex_trits_to_trits(trit_t *const trits, size_t const to_len,
                            flex_trit_t const *const flex_trits,
                            size_t const len, size_t const num_trits);
@@ -205,7 +214,7 @@ size_t flex_trits_to_trits(trit_t *const trits, size_t const to_len,
 /// @param[in] trits - an array of individual trits
 /// @param[in] len - the number of trits the trits array contains
 /// @param[in] num_trits - the number of trits to pack
-/// @return size_t - the number of trits packed
+/// @return size_t - the number of trits decoded
 size_t flex_trits_from_trits(flex_trit_t *const to_flex_trits,
                              size_t const to_len, trit_t const *const trits,
                              size_t const len, size_t const num_trits);
@@ -216,7 +225,7 @@ size_t flex_trits_from_trits(flex_trit_t *const to_flex_trits,
 /// @param[in] flex_trits - the array of packed trits
 /// @param[in] len - the number of trits the flex_trits array contains
 /// @param[in] num_trits - the number of trits to pack
-/// @return size_t - the number of trits decoded
+/// @return size_t - the number of trits encoded
 size_t flex_trits_to_trytes(tryte_t *trytes, size_t to_len,
                             const flex_trit_t *flex_trits, size_t len,
                             size_t num_trits);
@@ -231,6 +240,27 @@ size_t flex_trits_to_trytes(tryte_t *trytes, size_t to_len,
 size_t flex_trits_from_trytes(flex_trit_t *to_flex_trits, size_t to_len,
                               const tryte_t *trytes, size_t len,
                               size_t num_trytes);
+
+/// Returns an array of bytes.
+/// @param[in] bytes - an array to store bytes
+/// @param[in] to_len - the number of trits the bytes array contains
+/// @param[in] flex_trits - the array of packed trits
+/// @param[in] len - the number of trits the flex_trits array contains
+/// @param[in] num_trits - the number of trits to pack
+/// @return size_t - the number of trits encoded
+size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
+                           const flex_trit_t *flex_trits, size_t len,
+                           size_t num_trits);
+
+/// Returns an array of flex_trits.
+/// @param[in] to_flex_trits - the array of packed trits
+/// @param[in] to_len - the number of trits in the to_flex_trits array
+/// @param[in] bytes - an array of bytes
+/// @param[in] len - the number of trits in the bytes array
+/// @param[in] num_trits - the number of trits to unpack
+/// @return size_t - the number of trits decoded
+size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
+                             const byte_t *bytes, size_t len, size_t num_trits);
 
 #endif
 #ifdef __cplusplus

--- a/common/trinary/tests/test_flex_trit.c
+++ b/common/trinary/tests/test_flex_trit.c
@@ -21,29 +21,90 @@
 #endif
 #define TRYTES "HJSBDB"
 #define TRITS_OUT -1, 0, 1, 1, 0, 1, 1, 0, -1, -1, 1, 0, 1, 1, 0, -1, 1, 0
+#define BYTES 0x23, 0x98, 0x25, 0x02
 #define NUM_TRITS 18
 
-void test_flex_trit_to_trytes(void) {
-  flex_trit_t trits[] = {TRITS_IN};
-  tryte_t trytes[] = {TRYTES};
-  trit_t trytes_out[6];
-  flex_trits_to_trytes(trytes_out, 6, trits, NUM_TRITS, NUM_TRITS);
-  TEST_ASSERT_EQUAL_MEMORY(trytes, trytes_out, 6);
+void test_flex_trits_to_trits(void) {
+  flex_trit_t ftrits[] = {TRITS_IN};
+  trit_t trits[] = {TRITS_OUT};
+  trit_t trits_out[18];
+  flex_trits_to_trits(trits_out, 18, ftrits, 18, 18);
+  TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, sizeof(trits_out));
 }
 
-void test_flex_trit_from_trytes(void) {
+void test_flex_trits_from_trits(void) {
+  flex_trit_t ftrits[] = {TRITS_IN};
+  trit_t trits[] = {TRITS_OUT};
+  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  flex_trit_t trits_out[num_trits];
+  flex_trits_from_trits(trits_out, 18, trits, 18, 18);
+  TEST_ASSERT_EQUAL_MEMORY(ftrits, trits_out, num_trits);
+}
+
+void test_flex_trits_to_trytes(void) {
   flex_trit_t trits[] = {TRITS_IN};
   tryte_t trytes[] = {TRYTES};
-  trit_t trits_out[NUM_TRITS];
+  tryte_t trytes_out[6];
+  flex_trits_to_trytes(trytes_out, 6, trits, NUM_TRITS, NUM_TRITS);
+  TEST_ASSERT_EQUAL_MEMORY(trytes, trytes_out, sizeof(trytes_out));
+}
+
+void test_flex_trits_from_trytes(void) {
+  flex_trit_t trits[] = {TRITS_IN};
+  tryte_t trytes[] = {TRYTES};
+  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  flex_trit_t trits_out[num_trits];
   flex_trits_from_trytes(trits_out, NUM_TRITS, trytes, 6, 6);
-  TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, sizeof(trits));
+  TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, num_trits);
+}
+
+void test_flex_trits_to_bytes(void) {
+  flex_trit_t trits[] = {TRITS_IN};
+  byte_t bytes[] = {BYTES};
+  byte_t bytes_out[4];
+  flex_trits_to_bytes(bytes_out, NUM_TRITS, trits, NUM_TRITS, NUM_TRITS);
+  TEST_ASSERT_EQUAL_MEMORY(bytes, bytes_out, 4);
+}
+
+void test_flex_trits_from_bytes(void) {
+  flex_trit_t trits[] = {TRITS_IN};
+  byte_t bytes[] = {BYTES};
+  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  flex_trit_t trits_out[num_trits];
+  flex_trits_from_bytes(trits_out, NUM_TRITS, bytes, NUM_TRITS, NUM_TRITS);
+  TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, num_trits);
+}
+
+void test_flex_trits_slice(void) {
+  flex_trit_t trits[] = {TRITS_IN};
+  trit_t all_trits[] = {TRITS_OUT};
+  trit_t partial_trits[18];
+  trit_t sliced_trits[18];
+  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  flex_trit_t trits_out[num_trits];
+  for (int start = 0; start < NUM_TRITS; start++) {
+    for (int len = 0; len < NUM_TRITS - start; len++) {
+      memset(sliced_trits, 0, 18);
+      memset(partial_trits, 0, 18);
+      memset(trits_out, FLEX_TRIT_NULL_VALUE, num_trits);
+      memcpy(partial_trits, all_trits + start, len);
+      flex_trits_slice(trits_out, 18, trits, 18, start, len);
+      flex_trits_to_trits(sliced_trits, 18, trits_out, 18, 18);
+      TEST_ASSERT_EQUAL_MEMORY(partial_trits, sliced_trits, 18);
+    }
+  }
 }
 
 int main(void) {
   UNITY_BEGIN();
 
-  RUN_TEST(test_flex_trit_to_trytes);
-  RUN_TEST(test_flex_trit_from_trytes);
+  RUN_TEST(test_flex_trits_to_trits);
+  RUN_TEST(test_flex_trits_from_trits);
+  RUN_TEST(test_flex_trits_to_trytes);
+  RUN_TEST(test_flex_trits_from_trytes);
+  RUN_TEST(test_flex_trits_to_bytes);
+  RUN_TEST(test_flex_trits_from_bytes);
+  RUN_TEST(test_flex_trits_slice);
 
   return UNITY_END();
 }


### PR DESCRIPTION
This PR provides conversion functions between bytes and flex_trits - Issue #166.
Also, some optimisations to other conversion functions based work done in PR#310

# Test Plan:
Test plan as usual