### PR TITLE
tanglescope: use of nonstd::optional to compile on OS X

### DIFF
--- a/tanglescope/common/tangledb.cpp
+++ b/tanglescope/common/tangledb.cpp
@@ -9,7 +9,7 @@ TangleDB& TangleDB::instance() {
   return db;
 }
 
-std::optional<TangleDB::TXRecord> TangleDB::find(const std::string& hash) {
+nonstd::optional<TangleDB::TXRecord> TangleDB::find(const std::string& hash) {
   std::shared_lock<std::shared_mutex> lock(mutex_);
   auto tx = _txs.find(hash);
   if (tx != _txs.end()) {

--- a/tanglescope/common/tangledb.hpp
+++ b/tanglescope/common/tangledb.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <chrono>
-#include <optional>
+#include <nonstd/optional.hpp>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -16,7 +16,7 @@ class TangleDB {
     TXRecord() = default;
   };
 
-  std::optional<TXRecord> find(const std::string& hash);
+  nonstd::optional<TXRecord> find(const std::string& hash);
 
   void put(const TXRecord& tx);
   void removeAgedTxs(uint32_t ageInSeconds);


### PR DESCRIPTION
Use of nonstd::optional to compile on OS X

Fixes #86 

# Test Plan:
Usual tests