### PR TITLE
common/trinary: fix byte_to_trits gives wrong results

### DIFF
--- a/common/trinary/BUILD
+++ b/common/trinary/BUILD
@@ -52,6 +52,7 @@ cc_library(
     deps = [
         ":bytes",
         ":trits",
+        "//utils:macros",
     ],
 )
 

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -78,13 +78,13 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
       bytes_to_trits(((byte_t *)flex_trits + i + 1), 1, ((trit_t *)trits + 5),
                      5);
     }
-    to_flex_trits[j] = trits_to_byte(trits + offset, 0, 4);
+    to_flex_trits[j] = trits_to_byte(trits + offset, 0, 5);
   }
   // There is a risk of noise after the last trit so we need to clean up
   uint8_t residual = num_trits % 5U;
   if (residual) {
     to_flex_trits[num_bytes - 1] =
-        trits_to_byte(trits + offset, 0, residual - 1);
+        trits_to_byte(trits + offset, 0, residual);
   }
 #endif
   return num_bytes;
@@ -232,7 +232,7 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
       num_trits -= max_trits;
       offset += max_trits;
     }
-    trits_for_byte = MIN(4, (offset - 1));
+    trits_for_byte = MIN(5, offset);
     bytes[j] = trits_to_byte(shifter.trits, 0, trits_for_byte);
 #if BYTE_ORDER == LITTLE_ENDIAN
     shifter.val = shifter.val >> 40;
@@ -248,8 +248,8 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
   if (residual) {
     trit_t last_byte[5] = {0};
     size_t index = num_bytes - 1;
-    byte_to_trits(flex_trits[index], last_byte, 4);
-    bytes[index] = trits_to_byte(last_byte, 0, residual - 1);
+    byte_to_trits(flex_trits[index], last_byte, 5);
+    bytes[index] = trits_to_byte(last_byte, 0, residual);
   }
 #endif
   return num_trits;
@@ -278,7 +278,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
   for (int i = 0, j = 0; num_trits; j++) {
     max_trits = MIN(5, num_trits);
     if (offset < NUM_TRITS_PER_FLEX_TRIT) {
-      byte_to_trits(bytes[i], shifter.trits + offset, max_trits - 1);
+      byte_to_trits(bytes[i], shifter.trits + offset, max_trits);
       offset += max_trits;
       i++;
     }
@@ -296,8 +296,8 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
   if (residual) {
     trit_t last_byte[5] = {0};
     size_t index = num_bytes - 1;
-    byte_to_trits(bytes[index], last_byte, 4);
-    to_flex_trits[index] = trits_to_byte(last_byte, 0, residual - 1);
+    byte_to_trits(bytes[index], last_byte, 5);
+    to_flex_trits[index] = trits_to_byte(last_byte, 0, residual);
   }
 #endif
   return num_trits;

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -83,8 +83,7 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
   // There is a risk of noise after the last trit so we need to clean up
   uint8_t residual = num_trits % 5U;
   if (residual) {
-    to_flex_trits[num_bytes - 1] =
-        trits_to_byte(trits + offset, 0, residual);
+    to_flex_trits[num_bytes - 1] = trits_to_byte(trits + offset, 0, residual);
   }
 #endif
   return num_bytes;

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -124,7 +124,7 @@ static inline trit_t flex_trits_at(flex_trit_t const *const flex_trits,
   uint8_t tindex = index % 5U;
   // Find out the index of the byte in the array
   index = index / 5U;
-  byte_to_trits(*(flex_trits + index), trits, 4);
+  byte_to_trits(*(flex_trits + index), trits, 5);
   return trits[tindex];
 #endif
 }
@@ -163,9 +163,9 @@ static inline uint8_t flex_trits_set_at(flex_trit_t *const flex_trits,
   uint8_t tindex = index % 5U;
   // Find out the index of the byte in the array
   index = index / 5U;
-  byte_to_trits(*(flex_trits + index), trits, 4);
+  byte_to_trits(*(flex_trits + index), trits, 5);
   trits[tindex] = trit;
-  flex_trits[index] = trits_to_byte(trits, 0, 4);
+  flex_trits[index] = trits_to_byte(trits, 0, 5);
 #endif
   return 1;
 }

--- a/common/trinary/tests/test_trit_byte.c
+++ b/common/trinary/tests/test_trit_byte.c
@@ -33,11 +33,28 @@ void test_to_from_byte(void) {
   TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, sizeof(trits));
 }
 
+void test_from_byte(void) {
+  trit_t trits[] = {TRITS_IN};
+  byte_t bytes[] = {BYTES_EXP};
+  size_t trits_size = sizeof(trits) / sizeof(trit_t);
+  trit_t trits_out[trits_size];
+  trit_t partial_trits[trits_size];
+  size_t bytes_size = min_bytes(trits_size);
+  for (int len = 0; len <= trits_size; len++) {
+    memset(trits_out, 0, trits_size);
+    memset(partial_trits, 0, trits_size);
+    memcpy(partial_trits, trits, len);
+    bytes_to_trits(bytes, bytes_size, trits_out, len);
+    TEST_ASSERT_EQUAL_MEMORY(partial_trits, trits_out, trits_size);
+  }
+}
+
 int main(void) {
   UNITY_BEGIN();
 
   RUN_TEST(test_trit_to_byte);
   RUN_TEST(test_to_from_byte);
+  RUN_TEST(test_from_byte);
 
   return UNITY_END();
 }

--- a/common/trinary/tests/test_trit_byte.c
+++ b/common/trinary/tests/test_trit_byte.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <unity/unity.h>
 
 #include "common/trinary/trit_byte.h"

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -6,36 +6,35 @@
  */
 
 #include "trit_byte.h"
+#include "utils/macros.h"
+#include <assert.h>
 
 #define NUMBER_OF_TRITS_IN_A_BYTE 5
 #define RADIX 3
 static const byte_t byte_radix[] = {1, 3, 9, 27, 81};
 
-void trits_to_bytes(trit_t *trits, byte_t *bytes, size_t size) {
-  if (size <= 0) {
+void trits_to_bytes(trit_t *trits, byte_t *bytes, size_t num_trits) {
+  if (num_trits == 0) {
     return;
   }
-  size_t end;
-  if (size < NUMBER_OF_TRITS_IN_A_BYTE) {
-    end = size;
-  } else {
-    end = NUMBER_OF_TRITS_IN_A_BYTE;
-  }
-  bytes[0] = trits_to_byte(trits, 0, end - 1);
-  trits_to_bytes(&trits[end], &bytes[1], size - end);
+  size_t end = MIN(num_trits, NUMBER_OF_TRITS_IN_A_BYTE);
+  bytes[0] = trits_to_byte(trits, 0, end);
+  trits_to_bytes(&trits[end], &bytes[1], num_trits - end);
 }
 
-size_t min_bytes(size_t const trits_length) {
-  return (trits_length + NUMBER_OF_TRITS_IN_A_BYTE - 1) /
+size_t min_bytes(size_t const num_trits) {
+  return (num_trits + NUMBER_OF_TRITS_IN_A_BYTE - 1) /
          NUMBER_OF_TRITS_IN_A_BYTE;
 }
 
 byte_t trits_to_byte(trit_t const *const trits, byte_t const cum,
-                     size_t const i) {
-  if (i == 0) {
-    return cum * RADIX + trits[i];
+                     size_t const num_trits) {
+  assert(num_trits <= NUMBER_OF_TRITS_IN_A_BYTE);
+  if (num_trits == 0) {
+    return cum;
   }
-  return trits_to_byte(trits, cum * RADIX + trits[i], i - 1);
+  byte_t byte = cum * RADIX + trits[num_trits - 1];
+  return trits_to_byte(trits, byte, num_trits - 1);
 }
 
 void _byte_to_trits(byte_t byte, trit_t *const trits, size_t const j,
@@ -59,17 +58,21 @@ void _byte_to_trits(byte_t byte, trit_t *const trits, size_t const j,
   _byte_to_trits(byte, trits, j - 1, j == i ? i - 1 : i);
 }
 
-void bytes_to_trits(byte_t const *const byte, size_t const n_bytes,
-                    trit_t *const trit, size_t const n_trits) {
-  if (n_bytes == 0 || n_trits == 0) {
+void bytes_to_trits(byte_t const *const bytes, size_t const num_bytes,
+                    trit_t *const trits, size_t const num_trits) {
+  assert(num_trits <= NUMBER_OF_TRITS_IN_A_BYTE * num_bytes);
+  if (num_bytes == 0 || num_trits == 0) {
     return;
   }
-  size_t end =
-      n_trits < NUMBER_OF_TRITS_IN_A_BYTE ? n_trits : NUMBER_OF_TRITS_IN_A_BYTE;
-  _byte_to_trits(*byte, trit, NUMBER_OF_TRITS_IN_A_BYTE - 1, end - 1);
-  bytes_to_trits(&byte[1], n_bytes - 1, &trit[end], n_trits - end);
+  size_t end = MIN(num_trits, NUMBER_OF_TRITS_IN_A_BYTE);
+  _byte_to_trits(*bytes, trits, NUMBER_OF_TRITS_IN_A_BYTE - 1, end - 1);
+  bytes_to_trits(&bytes[1], num_bytes - 1, &trits[end], num_trits - end);
 }
 
-void byte_to_trits(byte_t byte, trit_t *const trit, size_t const i) {
-  _byte_to_trits(byte, trit, NUMBER_OF_TRITS_IN_A_BYTE - 1, i);
+void byte_to_trits(byte_t byte, trit_t *const trit, size_t const num_trits) {
+  assert(num_trits <= NUMBER_OF_TRITS_IN_A_BYTE);
+  if (num_trits == 0) {
+    return;
+  }
+  _byte_to_trits(byte, trit, NUMBER_OF_TRITS_IN_A_BYTE - 1, num_trits - 1);
 }

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -38,6 +38,26 @@ byte_t trits_to_byte(trit_t const *const trits, byte_t const cum,
   return trits_to_byte(trits, cum * RADIX + trits[i], i - 1);
 }
 
+void _byte_to_trits(byte_t byte, trit_t *const trits, size_t const j, size_t const i) {
+  trit_t trit;
+  if (byte > (byte_radix[j] >> 1)) {
+    byte -= byte_radix[j];
+    trit = 1;
+  } else if (byte < -(byte_radix[j] >> 1)) {
+    byte += byte_radix[j];
+    trit = -1;
+  } else {
+    trit = 0;
+  }
+  if (j == i) {
+    trits[i] = trit;
+  }
+  if (j == 0) {
+    return;
+  }
+  _byte_to_trits(byte, trits, j - 1, j == i ? i - 1 : i);
+}
+
 void bytes_to_trits(byte_t const *const byte, size_t const n_bytes,
                     trit_t *const trit, size_t const n_trits) {
   if (n_bytes == 0 || n_trits == 0) {
@@ -45,22 +65,10 @@ void bytes_to_trits(byte_t const *const byte, size_t const n_bytes,
   }
   size_t end =
       n_trits < NUMBER_OF_TRITS_IN_A_BYTE ? n_trits : NUMBER_OF_TRITS_IN_A_BYTE;
-  byte_to_trits(*byte, trit, end - 1);
+  _byte_to_trits(*byte, trit, NUMBER_OF_TRITS_IN_A_BYTE - 1, end - 1);
   bytes_to_trits(&byte[1], n_bytes - 1, &trit[end], n_trits - end);
 }
 
 void byte_to_trits(byte_t byte, trit_t *const trit, size_t const i) {
-  if (byte > (byte_radix[i] >> 1)) {
-    byte -= byte_radix[i];
-    trit[i] = 1;
-  } else if (byte < -(byte_radix[i] >> 1)) {
-    byte += byte_radix[i];
-    trit[i] = -1;
-  } else {
-    trit[i] = 0;
-  }
-  if (i == 0) {
-    return;
-  }
-  byte_to_trits(byte, trit, i - 1);
+  _byte_to_trits(byte, trit, NUMBER_OF_TRITS_IN_A_BYTE, i);
 }

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -37,25 +37,22 @@ byte_t trits_to_byte(trit_t const *const trits, byte_t const cum,
   return trits_to_byte(trits, byte, num_trits - 1);
 }
 
-void _byte_to_trits(byte_t byte, trit_t *const trits, size_t const j,
-                    size_t const i) {
-  trit_t trit;
-  if (byte > (byte_radix[j] >> 1)) {
-    byte -= byte_radix[j];
-    trit = 1;
-  } else if (byte < -(byte_radix[j] >> 1)) {
-    byte += byte_radix[j];
-    trit = -1;
-  } else {
-    trit = 0;
+void _byte_to_trits(byte_t byte, trit_t *const trits, size_t j, size_t i) {
+  while (j < -1) {
+    trit_t trit = 0;
+    if (byte > (byte_radix[j] >> 1)) {
+      byte -= byte_radix[j];
+      trit = 1;
+    } else if (byte < -(byte_radix[j] >> 1)) {
+      byte += byte_radix[j];
+      trit = -1;
+    }
+    if (j == i) {
+      trits[i] = trit;
+      i -= 1;
+    }
+    j -= 1;
   }
-  if (j == i) {
-    trits[i] = trit;
-  }
-  if (j == 0) {
-    return;
-  }
-  _byte_to_trits(byte, trits, j - 1, j == i ? i - 1 : i);
 }
 
 void bytes_to_trits(byte_t const *const bytes, size_t const num_bytes,

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -6,8 +6,8 @@
  */
 
 #include "trit_byte.h"
-#include "utils/macros.h"
 #include <assert.h>
+#include "utils/macros.h"
 
 #define NUMBER_OF_TRITS_IN_A_BYTE 5
 #define RADIX 3

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -71,5 +71,5 @@ void bytes_to_trits(byte_t const *const byte, size_t const n_bytes,
 }
 
 void byte_to_trits(byte_t byte, trit_t *const trit, size_t const i) {
-  _byte_to_trits(byte, trit, NUMBER_OF_TRITS_IN_A_BYTE, i);
+  _byte_to_trits(byte, trit, NUMBER_OF_TRITS_IN_A_BYTE - 1, i);
 }

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -38,7 +38,8 @@ byte_t trits_to_byte(trit_t const *const trits, byte_t const cum,
   return trits_to_byte(trits, cum * RADIX + trits[i], i - 1);
 }
 
-void _byte_to_trits(byte_t byte, trit_t *const trits, size_t const j, size_t const i) {
+void _byte_to_trits(byte_t byte, trit_t *const trits, size_t const j,
+                    size_t const i) {
   trit_t trit;
   if (byte > (byte_radix[j] >> 1)) {
     byte -= byte_radix[j];

--- a/common/trinary/trit_byte.h
+++ b/common/trinary/trit_byte.h
@@ -15,13 +15,35 @@ extern "C" {
 #include "common/trinary/bytes.h"
 #include "common/trinary/trits.h"
 
-size_t min_bytes(size_t);
+/// Returns the number of bytes needed to pack num_trits trits
+/// @param[in] num_trits - the number of trits to pack
+/// @return size_t - the number of bytes needed
+size_t min_bytes(size_t num_trits);
+/// Packs an array of trits into byte (max 5 packed trits)
+/// @param[in] trits - An array of trits
+/// @param[in] cum - the accumulator, maybe be not 0
+/// @param[in] num_trits - the number of trits to convert
+/// @return byte_t - the num_trits trits packed into a byte
 byte_t trits_to_byte(trit_t const *const trits, byte_t const cum,
-                     size_t const i);
-void trits_to_bytes(trit_t *, byte_t *, size_t);
-void byte_to_trits(byte_t byte, trit_t *const trit, size_t const i);
-void bytes_to_trits(byte_t const *const byte, size_t const n_bytes,
-                    trit_t *const trit, size_t const n_trits);
+                     size_t const num_trits);
+/// Packs an array of trits into an array of bytes
+/// @param[in] trits - An array of trits
+/// @param[in] cum - the accumulator, maybe be not 0
+/// @param[in] num_trits - the number of trits to convert
+/// @return byte_t - the num_trits trits packed into a byte
+void trits_to_bytes(trit_t *trits, byte_t *bytes, size_t num_trits);
+/// Unpacks a byte into an array of trits
+/// @param[in] byte - A byte of packed trits
+/// @param[in] trits - An array of trits
+/// @param[in] num_trits - the number of trits to unpack (max 5)
+void byte_to_trits(byte_t byte, trit_t *const trit, size_t const num_trits);
+/// Unpacks an array of byte into an array of trits
+/// @param[in] bytes - An array bytes (packed trits)
+/// @param[in] n_bytes - the number of bytes in the array
+/// @param[in] trits - An array of trits
+/// @param[in] num_trits - the number of trits to unpack
+void bytes_to_trits(byte_t const *const bytes, size_t const num_bytes,
+                    trit_t *const trits, size_t const num_trits);
 
 #endif
 #ifdef __cplusplus


### PR DESCRIPTION
fix byte_to_trits gives wrong results (issue #361)
Adjust conversion functions to accept actual number of trits to convert instead of num - 1

# Test Plan:
usual test plan
