### PR TITLE
Remove VLA from flex_trit/tryte conversion functions

### DIFF
--- a/cclient/types/types.c
+++ b/cclient/types/types.c
@@ -68,7 +68,7 @@ retcode_t flex_hash_to_trytes(const trit_array_p hash, char* trytes) {
   }
 
   trits_len = flex_trits_to_trytes(
-      (signed char*)trytes, num_flex_trits_for_trits(hash->num_trits),
+      (signed char*)trytes, NUM_FLEX_TRITS_FOR_TRITS(hash->num_trits),
       hash->trits, hash->num_trits, hash->num_trits);
 
   if (trits_len == 0) {
@@ -162,7 +162,7 @@ retcode_t flex_hash_to_char_buffer(trit_array_p hash, char_buffer_t* out) {
   }
 
   trits_len = flex_trits_to_trytes(
-      (signed char*)out->data, num_flex_trits_for_trits(hash->num_trits),
+      (signed char*)out->data, NUM_FLEX_TRITS_FOR_TRITS(hash->num_trits),
       hash->trits, hash->num_trits, hash->num_trits);
 
   if (trits_len == 0) {

--- a/common/helpers/checksum.c
+++ b/common/helpers/checksum.c
@@ -64,7 +64,7 @@ IOTA_EXPORT flex_trit_t* iota_flex_checksum(const flex_trit_t* flex_trits,
   kerl_hash(trits, num_trits, trits_hash, &kerl);
   free(trits);
 
-  size_t flex_len = num_flex_trits_for_trits(num_trits);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(num_trits);
   flex_trit_t* checksum_flex_trits =
       (flex_trit_t*)calloc(flex_len, sizeof(flex_trit_t));
   if (!checksum_flex_trits) {

--- a/common/helpers/digest.c
+++ b/common/helpers/digest.c
@@ -55,7 +55,7 @@ IOTA_EXPORT flex_trit_t* iota_flex_digest(flex_trit_t const* const flex_trits,
   curl_digest(trits, num_trits, trits_hash, &curl);
   free(trits);
 
-  size_t flex_len = num_flex_trits_for_trits(num_trits);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(num_trits);
   flex_trit_t* hash_flex_trits =
       (flex_trit_t*)calloc(flex_len, sizeof(flex_trit_t));
   if (!hash_flex_trits) {

--- a/common/helpers/pow.c
+++ b/common/helpers/pow.c
@@ -64,7 +64,7 @@ IOTA_EXPORT flex_trit_t* iota_flex_pow(flex_trit_t const* const flex_trits_in,
   if (!nonce_trits) {
     return NULL;
   }
-  size_t flex_len = num_flex_trits_for_trits(NONCE_LENGTH);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NONCE_LENGTH);
   flex_trit_t* nonce_flex_trits =
       (flex_trit_t*)calloc(flex_len, sizeof(flex_trit_t));
   if (!nonce_flex_trits) {

--- a/common/helpers/sign.c
+++ b/common/helpers/sign.c
@@ -115,7 +115,7 @@ IOTA_EXPORT flex_trit_t* iota_flex_sign_address_gen(
     return NULL;
   }
   address =
-      calloc(num_flex_trits_for_trits(HASH_LENGTH) + 1, sizeof(flex_trit_t));
+      calloc(NUM_FLEX_TRITS_FOR_TRITS(HASH_LENGTH) + 1, sizeof(flex_trit_t));
   if (!address) {
     goto cleanup;
   }
@@ -158,7 +158,7 @@ IOTA_EXPORT flex_trit_t* iota_flex_sign_signature_gen(
     return NULL;
   }
   signature =
-      calloc(num_flex_trits_for_trits(key_length) + 1, sizeof(flex_trit_t));
+      calloc(NUM_FLEX_TRITS_FOR_TRITS(key_length) + 1, sizeof(flex_trit_t));
   if (!signature) {
     goto cleanup;
   }

--- a/common/helpers/tests/test_checksum.cpp
+++ b/common/helpers/tests/test_checksum.cpp
@@ -116,7 +116,7 @@ TEST(ChecksumTest, testFlexChecksumEquality) {
   };
 #endif
   const size_t NUM_TRITS = 243;
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS);
   flex_trit_t *partial = (flex_trit_t *)calloc(flex_len, sizeof(flex_trit_t));
 
   auto checksum = iota_flex_checksum(ADDRESS, NUM_TRITS, 0);
@@ -130,13 +130,13 @@ TEST(ChecksumTest, testFlexChecksumEquality) {
   checksum = iota_flex_checksum(ADDRESS, NUM_TRITS, 9);
   memset(partial, FLEX_TRIT_NULL_VALUE, flex_len);
   flex_trits_slice(partial, NUM_TRITS, CHECKSUM, NUM_TRITS, NUM_TRITS - 9, 9);
-  EXPECT_TRUE(memcmp(checksum, partial, num_flex_trits_for_trits(9)) == 0);
+  EXPECT_TRUE(memcmp(checksum, partial, NUM_FLEX_TRITS_FOR_TRITS(9)) == 0);
   free(checksum);
 
   checksum = iota_flex_checksum(ADDRESS, NUM_TRITS, 27);
   memset(partial, FLEX_TRIT_NULL_VALUE, flex_len);
   flex_trits_slice(partial, NUM_TRITS, CHECKSUM, NUM_TRITS, NUM_TRITS - 27, 27);
-  EXPECT_TRUE(memcmp(checksum, partial, num_flex_trits_for_trits(27)) == 0);
+  EXPECT_TRUE(memcmp(checksum, partial, NUM_FLEX_TRITS_FOR_TRITS(27)) == 0);
   free(checksum);
 
   free(partial);

--- a/common/model/transaction.c
+++ b/common/model/transaction.c
@@ -141,7 +141,7 @@ size_t transaction_serialize_to_flex_trits(const iota_transaction_t transaction,
                                            flex_trit_t *trits) {
   flex_trit_t partial[FLEX_TRIT_SIZE_81];
   size_t offset = 0, long_size;
-  size_t num_bytes = num_flex_trits_for_trits(NUM_TRITS_SERIALIZED_TRANSACTION);
+  size_t num_bytes = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_SERIALIZED_TRANSACTION);
   memset(trits, FLEX_TRIT_NULL_VALUE, num_bytes);
 
   flex_trits_insert(trits, NUM_TRITS_SERIALIZED_TRANSACTION,

--- a/common/model/transfer.c
+++ b/common/model/transfer.c
@@ -492,7 +492,7 @@ void transfer_iterator_next_data_transaction(
   // Length of the message data for the current transaction
   size_t len = data_len - offset;
   len = len > NUM_TRITS_SIGNATURE ? NUM_TRITS_SIGNATURE : len;
-  size_t flex_size = num_flex_trits_for_trits(len);
+  size_t flex_size = NUM_FLEX_TRITS_FOR_TRITS(len);
   flex_trit_t *trits = transaction_message(transfer_iterator->transaction);
   memset(trits, FLEX_TRIT_NULL_VALUE, flex_size);
   flex_trits_slice(trits, flex_size, data, data_len, offset, len);

--- a/common/model/tryte_transaction.cc
+++ b/common/model/tryte_transaction.cc
@@ -14,7 +14,7 @@ TryteTransaction::TryteTransaction() { iota_transaction = transaction_new(); }
 TryteTransaction::TryteTransaction(const std::string &trytes) {
   iota_transaction = transaction_new();
   size_t to_len = trytes.size() * 3;
-  size_t flex_len = num_flex_trits_for_trits(to_len);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(to_len);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, to_len, (const tryte_t *)trytes.data(),
                          trytes.size(), trytes.size());
@@ -33,7 +33,7 @@ std::string TryteTransaction::signature(void) {
 
 // Set the transaction signature (assign)
 void TryteTransaction::setSignature(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_SIGNATURE);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_SIGNATURE);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_SIGNATURE,
                          (const tryte_t *)trytes.data(), NUM_TRYTES_SIGNATURE,
@@ -52,7 +52,7 @@ std::string TryteTransaction::message(void) {
 
 // Set the transaction message (assign)
 void TryteTransaction::setMessage(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_SIGNATURE);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_SIGNATURE);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_SIGNATURE,
                          (const tryte_t *)trytes.data(), NUM_TRYTES_SIGNATURE,
@@ -71,7 +71,7 @@ std::string TryteTransaction::address(void) {
 
 // Set the transaction address (assign)
 void TryteTransaction::setAddress(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_ADDRESS);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_ADDRESS);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_ADDRESS,
                          (const tryte_t *)trytes.data(), NUM_TRYTES_ADDRESS,
@@ -100,7 +100,7 @@ std::string TryteTransaction::obsoleteTag(void) {
 
 // Set the transaction obsolete tag
 void TryteTransaction::setObsoleteTag(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_OBSOLETE_TAG);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_OBSOLETE_TAG);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_OBSOLETE_TAG,
                          (const tryte_t *)trytes.data(),
@@ -149,7 +149,7 @@ std::string TryteTransaction::bundle(void) {
 
 // Set the transaction bundle (assign)
 void TryteTransaction::setBundle(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_BUNDLE);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_BUNDLE);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_BUNDLE,
                          (const tryte_t *)trytes.data(), NUM_TRYTES_BUNDLE,
@@ -168,7 +168,7 @@ std::string TryteTransaction::trunk(void) {
 
 // Set the transaction trunk (assign)
 void TryteTransaction::setTrunk(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_TRUNK);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_TRUNK);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_TRUNK, (const tryte_t *)trytes.data(),
                          NUM_TRYTES_TRUNK, NUM_TRYTES_TRUNK);
@@ -186,7 +186,7 @@ std::string TryteTransaction::branch(void) {
 
 // Set the transaction branch (assign)
 void TryteTransaction::setBranch(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_BRANCH);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_BRANCH);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_BRANCH,
                          (const tryte_t *)trytes.data(), NUM_TRYTES_BRANCH,
@@ -205,7 +205,7 @@ std::string TryteTransaction::tag(void) {
 
 // Set the transaction tag (assign)
 void TryteTransaction::setTag(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_TAG);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_TAG);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_TAG, (const tryte_t *)trytes.data(),
                          NUM_TRYTES_TAG, NUM_TRYTES_TAG);
@@ -253,7 +253,7 @@ std::string TryteTransaction::nonce(void) {
 
 // Set the transaction nonce (assign)
 void TryteTransaction::setNonce(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_NONCE);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_NONCE);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_NONCE, (const tryte_t *)trytes.data(),
                          NUM_TRYTES_NONCE, NUM_TRYTES_NONCE);
@@ -271,7 +271,7 @@ std::string TryteTransaction::hash(void) {
 
 // Set the transaction hash (assign)
 void TryteTransaction::setHash(const std::string &trytes) {
-  size_t flex_len = num_flex_trits_for_trits(NUM_TRITS_HASH);
+  size_t flex_len = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_HASH);
   flex_trit_t trits[flex_len];
   flex_trits_from_trytes(trits, NUM_TRITS_HASH, (const tryte_t *)trytes.data(),
                          NUM_TRYTES_HASH, NUM_TRYTES_HASH);
@@ -279,7 +279,7 @@ void TryteTransaction::setHash(const std::string &trytes) {
 }
 
 std::vector<flex_trit_t> TryteTransaction::serialize(void) {
-  size_t num_bytes = num_flex_trits_for_trits(NUM_TRITS_SERIALIZED_TRANSACTION);
+  size_t num_bytes = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS_SERIALIZED_TRANSACTION);
   std::vector<flex_trit_t> value(num_bytes);
   transaction_serialize_on_flex_trits(iota_transaction, value.data());
   return value;

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -184,13 +184,13 @@ size_t flex_trits_to_trytes(tryte_t *trytes, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t max_trits, trits_for_tryte, n_trits = num_trits;
-  for (int i = 0, j = 0; n_trits || offset; j++) {
+  size_t max_trits, trits_for_tryte, trits_counter = num_trits;
+  for (int i = 0, j = 0; trits_counter || offset; j++) {
     if (offset < 3) {
-      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, n_trits);
+      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, trits_counter);
       flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i++],
                           max_trits, max_trits);
-      n_trits -= max_trits;
+      trits_counter -= max_trits;
       offset += max_trits;
     }
     trits_for_tryte = MIN(3, offset);
@@ -271,19 +271,19 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t max_trits, trits_for_byte, n_trits = num_trits;
-  for (int i = 0, j = 0; n_trits; i++, j++) {
-    max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, n_trits);
+  size_t max_trits, trits_for_byte, trits_counter = num_trits;
+  for (int i = 0, j = 0; trits_counter; i++, j++) {
+    max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, trits_counter);
     flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i],
                         max_trits, max_trits);
-    n_trits -= max_trits;
+    trits_counter -= max_trits;
     offset += max_trits;
-    if (offset < 5 && n_trits) {
+    if (offset < 5 && trits_counter) {
       i++;
-      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, n_trits);
+      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, trits_counter);
       flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i],
                           max_trits, max_trits);
-      n_trits -= max_trits;
+      trits_counter -= max_trits;
       offset += max_trits;
     }
     trits_for_byte = MIN(5, offset);
@@ -328,18 +328,18 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t max_trits, trits_for_byte, n_trits = num_trits;
-  for (int i = 0, j = 0; n_trits; j++) {
-    max_trits = MIN(5, n_trits);
+  size_t max_trits, trits_for_byte, trits_counter = num_trits;
+  for (int i = 0, j = 0; trits_counter; j++) {
+    max_trits = MIN(5, trits_counter);
     if (offset < NUM_TRITS_PER_FLEX_TRIT) {
       byte_to_trits(bytes[i], shifter.trits + offset, max_trits);
       offset += max_trits;
       i++;
     }
     trits_for_byte = MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
-    flex_trits_from_trits(&to_flex_trits[j], n_trits, shifter.trits,
+    flex_trits_from_trits(&to_flex_trits[j], trits_counter, shifter.trits,
                           trits_for_byte, trits_for_byte);
-    n_trits -= trits_for_byte;  // MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
+    trits_counter -= trits_for_byte;  // MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
 #if BYTE_ORDER == LITTLE_ENDIAN
     shifter.val = shifter.val >> (trits_for_byte << 3);
 #elif BYTE_ORDER == BIG_ENDIAN

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -339,7 +339,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
     trits_for_byte = MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
     flex_trits_from_trits(&to_flex_trits[j], trits_counter, shifter.trits,
                           trits_for_byte, trits_for_byte);
-    trits_counter -= trits_for_byte;  // MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
+    trits_counter -= trits_for_byte;
 #if BYTE_ORDER == LITTLE_ENDIAN
     shifter.val = shifter.val >> (trits_for_byte << 3);
 #elif BYTE_ORDER == BIG_ENDIAN

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -177,12 +177,12 @@ size_t flex_trits_to_trytes(tryte_t *trytes, size_t to_len,
   }
   memcpy(trytes, flex_trits, num_bytes);
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE) || \
-      defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
+    defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
   union _shifter {
     uint64_t val;
     trit_t trits[8];
   };
-  union _shifter shifter = { 0 };
+  union _shifter shifter = {0};
   size_t offset = 0;
   size_t max_trits, trits_for_tryte;
   for (int i = 0, j = 0; num_trits || offset; j++) {
@@ -240,7 +240,8 @@ size_t flex_trits_from_trytes(flex_trit_t *to_flex_trits, size_t to_len,
       }
     }
     num_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, offset);
-    flex_trits_from_trits(to_flex_trits + j, num_trits, shifter.trits, num_trits, num_trits);
+    flex_trits_from_trits(to_flex_trits + j, num_trits, shifter.trits,
+                          num_trits, num_trits);
 #if BYTE_ORDER == LITTLE_ENDIAN
     shifter.val = shifter.val >> (num_trits << 3);
 #elif BYTE_ORDER == BIG_ENDIAN

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -184,13 +184,13 @@ size_t flex_trits_to_trytes(tryte_t *trytes, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t max_trits, trits_for_tryte;
-  for (int i = 0, j = 0; num_trits || offset; j++) {
+  size_t max_trits, trits_for_tryte, n_trits = num_trits;
+  for (int i = 0, j = 0; n_trits || offset; j++) {
     if (offset < 3) {
-      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, num_trits);
+      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, n_trits);
       flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i++],
                           max_trits, max_trits);
-      num_trits -= max_trits;
+      n_trits -= max_trits;
       offset += max_trits;
     }
     trits_for_tryte = MIN(3, offset);
@@ -226,16 +226,16 @@ size_t flex_trits_from_trytes(flex_trit_t *to_flex_trits, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t num_trits;
-  for (int i = 0, j = 0; num_trytes || offset; i++, j++) {
-    if (num_trytes) {
+  size_t num_trits, n_trytes = num_trytes;
+  for (int i = 0, j = 0; n_trytes || offset; i++, j++) {
+    if (n_trytes) {
       trytes_to_trits(&trytes[i], shifter.trits + offset, 1);
-      num_trytes -= 1;
+      n_trytes -= 1;
       offset += 3;
-      if (offset < NUM_TRITS_PER_FLEX_TRIT && num_trytes) {
+      if (offset < NUM_TRITS_PER_FLEX_TRIT && n_trytes) {
         i++;
         trytes_to_trits(&trytes[i], shifter.trits + offset, 1);
-        num_trytes -= 1;
+        n_trytes -= 1;
         offset += 3;
       }
     }
@@ -271,19 +271,19 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t max_trits, trits_for_byte;
-  for (int i = 0, j = 0; num_trits; i++, j++) {
-    max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, num_trits);
+  size_t max_trits, trits_for_byte, n_trits = num_trits;
+  for (int i = 0, j = 0; n_trits; i++, j++) {
+    max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, n_trits);
     flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i],
                         max_trits, max_trits);
-    num_trits -= max_trits;
+    n_trits -= max_trits;
     offset += max_trits;
-    if (offset < 5 && num_trits) {
+    if (offset < 5 && n_trits) {
       i++;
-      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, num_trits);
+      max_trits = MIN(NUM_TRITS_PER_FLEX_TRIT, n_trits);
       flex_trits_to_trits(shifter.trits + offset, max_trits, &flex_trits[i],
                           max_trits, max_trits);
-      num_trits -= max_trits;
+      n_trits -= max_trits;
       offset += max_trits;
     }
     trits_for_byte = MIN(5, offset);
@@ -328,18 +328,18 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
   };
   union _shifter shifter = {0};
   size_t offset = 0;
-  size_t max_trits, trits_for_byte;
-  for (int i = 0, j = 0; num_trits; j++) {
-    max_trits = MIN(5, num_trits);
+  size_t max_trits, trits_for_byte, n_trits = num_trits;
+  for (int i = 0, j = 0; n_trits; j++) {
+    max_trits = MIN(5, n_trits);
     if (offset < NUM_TRITS_PER_FLEX_TRIT) {
       byte_to_trits(bytes[i], shifter.trits + offset, max_trits);
       offset += max_trits;
       i++;
     }
     trits_for_byte = MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
-    flex_trits_from_trits(&to_flex_trits[j], num_trits, shifter.trits,
+    flex_trits_from_trits(&to_flex_trits[j], n_trits, shifter.trits,
                           trits_for_byte, trits_for_byte);
-    num_trits -= trits_for_byte;  // MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
+    n_trits -= trits_for_byte;  // MIN(max_trits, NUM_TRITS_PER_FLEX_TRIT);
 #if BYTE_ORDER == LITTLE_ENDIAN
     shifter.val = shifter.val >> (trits_for_byte << 3);
 #elif BYTE_ORDER == BIG_ENDIAN

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -18,8 +18,8 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
   if (num_trits == 0 || num_trits > to_len || (start + num_trits) > len) {
     return 0;
   }
-  size_t num_bytes = num_flex_trits_for_trits(num_trits);
-  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
+  size_t num_bytes = NUM_FLEX_TRITS_FOR_TRITS(num_trits);
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, NUM_FLEX_TRITS_FOR_TRITS(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   // num_bytes == num_trits in a 1:1 scheme
   memcpy(to_flex_trits, flex_trits + start, num_bytes);
@@ -28,7 +28,7 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
   size_t index = start / 3U;
   size_t offset = start % 3U;
   size_t i, j;
-  size_t end_index = num_flex_trits_for_trits(len) - 1;
+  size_t end_index = NUM_FLEX_TRITS_FOR_TRITS(len) - 1;
   for (i = index, j = 0; j < num_bytes; i++, j++) {
     trytes_to_trits(&flex_trits[i], trits, 1);
     if (offset && i < end_index) {
@@ -48,7 +48,7 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
   uint8_t rshift = (8U - tshift) & 7;
   size_t index = start >> 2U;
   size_t i, j;
-  size_t end_index = num_flex_trits_for_trits(len) - 1;
+  size_t end_index = NUM_FLEX_TRITS_FOR_TRITS(len) - 1;
   // Calculate the number of bytes to copy over
   for (i = index, j = 0; j < num_bytes; i++, j++) {
     buffer = flex_trits[i];
@@ -71,7 +71,7 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
   size_t index = start / 5U;
   size_t offset = start % 5U;
   size_t i, j;
-  size_t end_index = num_flex_trits_for_trits(len) - 1;
+  size_t end_index = NUM_FLEX_TRITS_FOR_TRITS(len) - 1;
   for (i = index, j = 0; j < num_bytes; i++, j++) {
     bytes_to_trits(((byte_t *)flex_trits + i), 1, trits, 5);
     if (offset && i < end_index) {
@@ -115,7 +115,7 @@ size_t flex_trits_to_trits(trit_t *const trits, size_t const to_len,
   if (num_trits == 0 || num_trits > len || num_trits > to_len) {
     return 0;
   }
-  size_t num_bytes = num_flex_trits_for_trits(num_trits);
+  size_t num_bytes = NUM_FLEX_TRITS_FOR_TRITS(num_trits);
   memset(trits, 0, to_len);
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   // num_bytes == num_trits in a 1:1 scheme
@@ -139,7 +139,7 @@ size_t flex_trits_from_trits(flex_trit_t *const to_flex_trits,
   if (num_trits > len || num_trits > to_len) {
     return 0;
   }
-  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, NUM_FLEX_TRITS_FOR_TRITS(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   // num_bytes == num_trits in a 1:1 scheme
   memcpy(to_flex_trits, trits, num_trits);
@@ -167,7 +167,7 @@ size_t flex_trits_to_trytes(tryte_t *trytes, size_t to_len,
   trits_to_trytes((trit_t *)flex_trits, trytes, num_trits);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
   uint8_t residual = num_trits % 3U;
-  size_t num_bytes = num_flex_trits_for_trits(num_trits);
+  size_t num_bytes = NUM_FLEX_TRITS_FOR_TRITS(num_trits);
   // There is a risk of noise after the last trit so we need to clean up
   if (residual) {
     trit_t trits[3];
@@ -213,7 +213,7 @@ size_t flex_trits_from_trytes(flex_trit_t *to_flex_trits, size_t to_len,
   if (num_trytes > len || num_trytes * 3 > to_len) {
     return 0;
   }
-  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, NUM_FLEX_TRITS_FOR_TRITS(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   trytes_to_trits((tryte_t *)trytes, to_flex_trits, num_trytes);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
@@ -315,7 +315,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
   if (num_trits > len || num_trits > to_len) {
     return 0;
   }
-  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, num_flex_trits_for_trits(to_len));
+  memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, NUM_FLEX_TRITS_FOR_TRITS(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   size_t num_bytes = min_bytes(num_trits);
   bytes_to_trits(bytes, num_bytes, to_flex_trits, num_trits);

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -80,17 +80,17 @@ typedef int8_t flex_trit_t;
 /// current memory model.
 /// @param[in] num_trits - number of trits to store
 /// @return size_t - the number of flex_trits (bytes) needed
-static inline size_t num_flex_trits_for_trits(size_t const num_trits) {
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
-  return num_trits;
+  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) num_trits
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
-  return num_trytes_for_trits(num_trits);
+  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) \
+  ((num_trits + NUMBER_OF_TRITS_IN_A_TRYTE - 1) / NUMBER_OF_TRITS_IN_A_TRYTE)
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
-  return (num_trits + 3) >> 2U;
+  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) ((num_trits + 3) >> 2U)
 #elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
-  return min_bytes(num_trits);
+  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) \
+  ((num_trits + NUMBER_OF_TRITS_IN_A_BYTE - 1) / NUMBER_OF_TRITS_IN_A_BYTE)
 #endif
-}
 
 /// Returns the trit at a given index in an array of flex_trits
 /// @param[in] flex_trits - an array of flex_trits
@@ -107,7 +107,7 @@ static inline trit_t flex_trits_at(flex_trit_t const *const flex_trits,
   // Straight forward 1 trit per byte
   return flex_trits[index];
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
-  return get_trit_at((tryte_t *)flex_trits, num_flex_trits_for_trits(len),
+  return get_trit_at((tryte_t *)flex_trits, NUM_FLEX_TRITS_FOR_TRITS(len),
                      index);
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
   // Find out the position of the trit in the byte
@@ -145,7 +145,7 @@ static inline uint8_t flex_trits_set_at(flex_trit_t *const flex_trits,
   // Straight forward 1 trit per byte
   flex_trits[index] = trit;
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
-  set_trit_at(flex_trits, num_flex_trits_for_trits(len), index, trit);
+  set_trit_at(flex_trits, NUM_FLEX_TRITS_FOR_TRITS(len), index, trit);
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
   // Calculate the final position of the trit in the byte
   uint8_t shift = (index & 3) << 1U;

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -81,14 +81,14 @@ typedef int8_t flex_trit_t;
 /// @param[in] num_trits - number of trits to store
 /// @return size_t - the number of flex_trits (bytes) needed
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
-  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) num_trits
+#define NUM_FLEX_TRITS_FOR_TRITS(num_trits) num_trits
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
-  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) \
+#define NUM_FLEX_TRITS_FOR_TRITS(num_trits) \
   ((num_trits + NUMBER_OF_TRITS_IN_A_TRYTE - 1) / NUMBER_OF_TRITS_IN_A_TRYTE)
 #elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
-  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) ((num_trits + 3) >> 2U)
+#define NUM_FLEX_TRITS_FOR_TRITS(num_trits) ((num_trits + 3) >> 2U)
 #elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
-  #define NUM_FLEX_TRITS_FOR_TRITS(num_trits) \
+#define NUM_FLEX_TRITS_FOR_TRITS(num_trits) \
   ((num_trits + NUMBER_OF_TRITS_IN_A_BYTE - 1) / NUMBER_OF_TRITS_IN_A_BYTE)
 #endif
 

--- a/common/trinary/flex_trit_array.h
+++ b/common/trinary/flex_trit_array.h
@@ -41,7 +41,7 @@ class FlexTritArray {
   /// @param[in] num_trits - number of trits to store
   /// @return size_t - the number of bytes need
   static size_t numBytesForTrits(size_t num_trits) {
-    return num_flex_trits_for_trits(num_trits);
+    return NUM_FLEX_TRITS_FOR_TRITS(num_trits);
   };
 
   /// Returns a new FlexTritArray from a vector of trits.

--- a/common/trinary/tests/test_flex_trit.c
+++ b/common/trinary/tests/test_flex_trit.c
@@ -35,7 +35,7 @@ void test_flex_trits_to_trits(void) {
 void test_flex_trits_from_trits(void) {
   flex_trit_t ftrits[] = {TRITS_IN};
   trit_t trits[] = {TRITS_OUT};
-  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  size_t num_trits = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS);
   flex_trit_t trits_out[num_trits];
   flex_trits_from_trits(trits_out, 18, trits, 18, 18);
   TEST_ASSERT_EQUAL_MEMORY(ftrits, trits_out, num_trits);
@@ -60,7 +60,7 @@ void test_flex_trits_to_trytes(void) {
 void test_flex_trits_from_trytes(void) {
   flex_trit_t trits[] = {TRITS_IN};
   tryte_t trytes[] = {TRYTES};
-  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  size_t num_trits = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS);
   flex_trit_t trits_out[num_trits];
   flex_trits_from_trytes(trits_out, NUM_TRITS, trytes, 6, 6);
   TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, num_trits);
@@ -77,7 +77,7 @@ void test_flex_trits_to_bytes(void) {
 void test_flex_trits_from_bytes(void) {
   flex_trit_t trits[] = {TRITS_IN};
   byte_t bytes[] = {BYTES};
-  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  size_t num_trits = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS);
   flex_trit_t trits_out[num_trits];
   flex_trits_from_bytes(trits_out, NUM_TRITS, bytes, NUM_TRITS, NUM_TRITS);
   TEST_ASSERT_EQUAL_MEMORY(trits, trits_out, num_trits);
@@ -88,7 +88,7 @@ void test_flex_trits_slice(void) {
   trit_t all_trits[] = {TRITS_OUT};
   trit_t partial_trits[18];
   trit_t sliced_trits[18];
-  size_t num_trits = num_flex_trits_for_trits(NUM_TRITS);
+  size_t num_trits = NUM_FLEX_TRITS_FOR_TRITS(NUM_TRITS);
   flex_trit_t trits_out[num_trits];
   for (int start = 0; start < NUM_TRITS; start++) {
     for (int len = 0; len < NUM_TRITS - start; len++) {

--- a/common/trinary/tests/test_flex_trit.c
+++ b/common/trinary/tests/test_flex_trit.c
@@ -43,10 +43,18 @@ void test_flex_trits_from_trits(void) {
 
 void test_flex_trits_to_trytes(void) {
   flex_trit_t trits[] = {TRITS_IN};
-  tryte_t trytes[] = {TRYTES};
+  trit_t all_trits[] = {TRITS_OUT};
+  trit_t partial_trits[NUM_TRITS];
+  trit_t extracted_trits[NUM_TRITS];
   tryte_t trytes_out[6];
-  flex_trits_to_trytes(trytes_out, 6, trits, NUM_TRITS, NUM_TRITS);
-  TEST_ASSERT_EQUAL_MEMORY(trytes, trytes_out, sizeof(trytes_out));
+  for (int len = 0; len <= NUM_TRITS; len++) {
+    memset(extracted_trits, 0, NUM_TRITS);
+    memset(partial_trits, 0, NUM_TRITS);
+    memcpy(partial_trits, all_trits, len);
+    flex_trits_to_trytes(trytes_out, 6, trits, NUM_TRITS, len);
+    trytes_to_trits(trytes_out, extracted_trits, 6);
+    TEST_ASSERT_EQUAL_MEMORY(partial_trits, extracted_trits, NUM_TRITS);
+  }
 }
 
 void test_flex_trits_from_trytes(void) {

--- a/common/trinary/trit_array.c
+++ b/common/trinary/trit_array.c
@@ -19,7 +19,7 @@
  * Public interface
  ***********************************************************************************************************/
 size_t trit_array_bytes_for_trits(size_t const num_trits) {
-  return num_flex_trits_for_trits(num_trits);
+  return NUM_FLEX_TRITS_FOR_TRITS(num_trits);
 }
 
 /***********************************************************************************************************

--- a/common/trinary/trit_byte.c
+++ b/common/trinary/trit_byte.c
@@ -9,7 +9,6 @@
 #include <assert.h>
 #include "utils/macros.h"
 
-#define NUMBER_OF_TRITS_IN_A_BYTE 5
 #define RADIX 3
 static const byte_t byte_radix[] = {1, 3, 9, 27, 81};
 

--- a/common/trinary/trit_byte.h
+++ b/common/trinary/trit_byte.h
@@ -15,6 +15,8 @@ extern "C" {
 #include "common/trinary/bytes.h"
 #include "common/trinary/trits.h"
 
+#define NUMBER_OF_TRITS_IN_A_BYTE 5
+
 /// Returns the number of bytes needed to pack num_trits trits
 /// @param[in] num_trits - the number of trits to pack
 /// @return size_t - the number of bytes needed

--- a/common/trinary/trit_tryte.c
+++ b/common/trinary/trit_tryte.c
@@ -9,7 +9,6 @@
 
 #include "trit_tryte.h"
 
-#define NUMBER_OF_TRITS_IN_A_TRYTE 3
 #define TRYTE_SPACE 27
 #define TRYTE_STRING "9ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 #define TRITS_TO_TRYTES_MAP                                                 \

--- a/common/trinary/trit_tryte.h
+++ b/common/trinary/trit_tryte.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "common/trinary/tryte.h"
 
 #define RADIX 3
+#define NUMBER_OF_TRITS_IN_A_TRYTE 3
 
 size_t num_trytes_for_trits(size_t num_trits);
 trit_t get_trit_at(tryte_t *const trytes, size_t const length, size_t index);


### PR DESCRIPTION
Remove VLA from flex_trit/tryte conversion functions (fixes #360)
Depends on PR #346 and PR #362 

# Test Plan:
Usual test plan