### PR TITLE
Normalize hash trits

### DIFF
--- a/common/sign/BUILD
+++ b/common/sign/BUILD
@@ -4,5 +4,8 @@ cc_library(
     name = "normalize",
     srcs = ["normalize.c"],
     hdrs = ["normalize.h"],
-    deps = ["//common/trinary:flex_trit"],
+    deps = [
+        "//common/trinary:flex_trit",
+        "//common/trinary:trit_long",
+    ],
 )

--- a/common/sign/normalize.c
+++ b/common/sign/normalize.c
@@ -6,6 +6,7 @@
  */
 
 #include "common/sign/normalize.h"
+#include "common/trinary/trit_long.h"
 
 void normalize_hash(flex_trit_t const *const hash,
                     byte_t *const normalized_hash) {
@@ -43,5 +44,15 @@ void normalize_hash(flex_trit_t const *const hash,
         }
       }
     }
+  }
+}
+
+void normalize_hash_trits(flex_trit_t const *const hash,
+                          trit_t *const normalized_hash) {
+  byte_t normalized_bundle_bytes[NUM_TRYTES_HASH];
+
+  normalize_hash(hash, normalized_bundle_bytes);
+  for (int c = 0; c < NUM_TRYTES_HASH; ++c) {
+    long_to_trits(normalized_bundle_bytes[c], &normalized_hash[c * RADIX]);
   }
 }

--- a/common/sign/normalize.h
+++ b/common/sign/normalize.h
@@ -22,8 +22,10 @@
 extern "C" {
 #endif
 
-extern void normalize_hash(flex_trit_t const *const hash,
-                           byte_t *const normalized_hash);
+void normalize_hash(flex_trit_t const *const hash,
+                    byte_t *const normalized_hash);
+void normalize_hash_trits(flex_trit_t const *const hash,
+                          trit_t *const normalized_hash);
 
 #ifdef __cplusplus
 }

--- a/consensus/bundle_validator/bundle_validator.c
+++ b/consensus/bundle_validator/bundle_validator.c
@@ -87,7 +87,6 @@ retcode_t bundle_validate(const tangle_t* const tangle, trit_array_p tail_hash,
     if (curr_tx->current_index == last_index) {
       flex_trit_t bundle_hash_calculated[FLEX_TRIT_SIZE_243];
       trit_t normalized_bundle_trits[NUM_TRITS_HASH];
-      byte_t normalized_bundle_bytes[NUM_TRYTES_HASH];
 
       calculate_bundle_hash(bundle, bundle_hash_calculated);
       if (memcmp(bundle_hash, bundle_hash_calculated, FLEX_TRIT_SIZE_243) !=
@@ -98,11 +97,7 @@ retcode_t bundle_validate(const tangle_t* const tangle, trit_array_p tail_hash,
         break;
       }
 
-      normalize_hash(bundle_hash_calculated, normalized_bundle_bytes);
-      for (int c = 0; c < NUM_TRYTES_HASH; ++c) {
-        long_to_trits(normalized_bundle_bytes[c],
-                      &normalized_bundle_trits[c * RADIX]);
-      }
+      normalize_hash_trits(bundle_hash_calculated, normalized_bundle_trits);
 
       res = validate_signature(bundle, normalized_bundle_trits, is_valid);
       if (res || !(*is_valid)) {

--- a/consensus/milestone_tracker/milestone_tracker.c
+++ b/consensus/milestone_tracker/milestone_tracker.c
@@ -30,7 +30,6 @@ static retcode_t validate_coordinator(milestone_tracker_t* const mt,
                                       iota_transaction_t tx2, bool* valid) {
   trit_t signature_trits[NUM_TRITS_SIGNATURE];
   trit_t siblings_trits[NUM_TRITS_SIGNATURE];
-  byte_t normalized_trunk[TRYTE_HASH_LENGTH];
   trit_t normalized_trunk_trits[HASH_LENGTH];
   trit_t sig_digest[HASH_LENGTH];
   trit_t root[HASH_LENGTH];
@@ -47,10 +46,7 @@ static retcode_t validate_coordinator(milestone_tracker_t* const mt,
                       NUM_TRITS_SIGNATURE);
   curl.type = CURL_P_27;
   init_curl(&curl);
-  normalize_hash(tx1->trunk, normalized_trunk);
-  for (int c = 0; c < TRYTE_HASH_LENGTH; ++c) {
-    long_to_trits(normalized_trunk[c], &normalized_trunk_trits[c * RADIX]);
-  }
+  normalize_hash_trits(tx1->trunk, normalized_trunk_trits);
   iss_curl_sig_digest(sig_digest, normalized_trunk_trits, signature_trits,
                       NUM_TRITS_SIGNATURE, &curl);
   curl_reset(&curl);


### PR DESCRIPTION
This PR adds a handy way to get a normalized hash in trits

# Test Plan:
CI must pass
