### PR TITLE
common/trinary: fix long_to_trits fails for very large integer values

### DIFF
--- a/common/trinary/tests/test_trit_long.c
+++ b/common/trinary/tests/test_trit_long.c
@@ -16,20 +16,74 @@
   1, 0, -1, -1, 0, -1, 1, 0, -1, 1, -1, 0, 1, 0, 0, -1, 1, 1, 0
 #define TRITS_IN_ENC_LEN 19
 
+#define MAX_LONG_EXP 0x7FFFFFFFFFFFFFFF
+#define MAX_TRITS_IN                                                           \
+  1, -1, 0, 1, -1, 0, -1, 1, 1, 0, -1, 0, -1, 0, 1, 0, 1, 0, -1, 1, 1, -1, -1, \
+      1, 0, 1, -1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, -1, 1, -1, 1
+#define MAX_TRITS_IN_LEN 41
+
+#define MIN_LONG_EXP 0x8000000000000000
+#define MIN_TRITS_IN                                                          \
+  1, 0, 0, -1, 1, 0, 1, -1, -1, 0, 1, 0, 1, 0, -1, 0, -1, 0, 1, -1, -1, 1, 1, \
+      -1, 0, -1, 1, 0, 0, -1, -1, -1, 0, 0, -1, -1, -1, 1, -1, 1, -1
+#define MIN_TRITS_IN_LEN 41
+
 void test_min_trits(void) {
   trit_t trits[] = {TRITS_IN};
   size_t trits_size = sizeof(trits) / sizeof(trit_t);
 
   TEST_ASSERT_EQUAL_INT(trits_size, min_trits(LONG_EXP));
+  TEST_ASSERT_EQUAL_INT(MAX_TRITS_IN_LEN, min_trits(MAX_LONG_EXP));
+  TEST_ASSERT_EQUAL_INT(MIN_TRITS_IN_LEN, min_trits(MIN_LONG_EXP));
 }
 
 void test_trit_to_long(void) {
   trit_t trits[] = {TRITS_IN};
   size_t trits_size = sizeof(trits) / sizeof(trit_t);
-  long long exp = LONG_EXP;
-  long long val = trits_to_long(trits, trits_size);
+  int64_t exp = LONG_EXP;
+  int64_t val = trits_to_long(trits, trits_size);
 
   TEST_ASSERT_EQUAL_INT64(exp, val);
+}
+
+void test_trit_to_max_long(void) {
+  trit_t trits[] = {MAX_TRITS_IN};
+  size_t trits_size = sizeof(trits) / sizeof(trit_t);
+  int64_t exp = MAX_LONG_EXP;
+  int64_t val = trits_to_long(trits, trits_size);
+
+  TEST_ASSERT_EQUAL_INT64(exp, val);
+}
+
+void test_trit_to_min_long(void) {
+  trit_t trits[] = {MIN_TRITS_IN};
+  size_t trits_size = sizeof(trits) / sizeof(trit_t);
+  int64_t exp = MIN_LONG_EXP;
+  int64_t val = trits_to_long(trits, trits_size);
+
+  TEST_ASSERT_EQUAL_INT64(exp, val);
+}
+
+void test_max_long_to_trits(void) {
+  size_t trits_size = min_trits(MAX_LONG_EXP);
+  TEST_ASSERT_EQUAL_INT(MAX_TRITS_IN_LEN, trits_size);
+
+  trit_t trits[trits_size];
+  trit_t exp[] = {MAX_TRITS_IN};
+  long_to_trits(MAX_LONG_EXP, trits);
+
+  TEST_ASSERT_EQUAL_MEMORY(exp, trits, sizeof(trits));
+}
+
+void test_min_long_to_trits(void) {
+  size_t trits_size = min_trits(MIN_LONG_EXP);
+  TEST_ASSERT_EQUAL_INT(MIN_TRITS_IN_LEN, trits_size);
+
+  trit_t trits[trits_size];
+  trit_t exp[] = {MIN_TRITS_IN};
+  long_to_trits(MIN_LONG_EXP, trits);
+
+  TEST_ASSERT_EQUAL_MEMORY(exp, trits, sizeof(trits));
 }
 
 void test_from_long(void) {
@@ -70,8 +124,14 @@ int main(void) {
   UNITY_BEGIN();
 
   RUN_TEST(test_min_trits);
+
   RUN_TEST(test_trit_to_long);
+  RUN_TEST(test_trit_to_max_long);
+  RUN_TEST(test_trit_to_min_long);
+
   RUN_TEST(test_from_long);
+  RUN_TEST(test_max_long_to_trits);
+  RUN_TEST(test_min_long_to_trits);
 
   RUN_TEST(test_encoded_long_length);
   RUN_TEST(test_encoded_long);

--- a/common/trinary/trit_long.c
+++ b/common/trinary/trit_long.c
@@ -48,8 +48,8 @@ size_t min_trits(int64_t const value) {
   // Edge case where value == INT64_MIN. In this case,
   // llabs cannot return a value greater than INT64_MAX
   // so we "force" the (unsigned) value explicitly
-  if (value == 0x8000000000000000LL) {
-    v_abs = 0x8000000000000000ULL;
+  if (value == INT64_MIN) {
+    v_abs = INT64_MAX+1ULL;
   } else {
     v_abs = llabs(value);
   }
@@ -71,8 +71,8 @@ size_t long_to_trits(int64_t const value, trit_t *const trits) {
   // Edge case where value == INT64_MIN. In this case,
   // llabs cannot return a value greater than INT64_MAX
   // so we "force" the (unsigned) value explicitly
-  if (value == 0x8000000000000000LL) {
-    v_abs = 0x8000000000000000ULL;
+  if (value == INT64_MIN) {
+    v_abs = INT64_MAX+1ULL;
   } else {
     v_abs = llabs(value);
   }

--- a/common/trinary/trit_long.c
+++ b/common/trinary/trit_long.c
@@ -49,7 +49,7 @@ size_t min_trits(int64_t const value) {
   // llabs cannot return a value greater than INT64_MAX
   // so we "force" the (unsigned) value explicitly
   if (value == INT64_MIN) {
-    v_abs = INT64_MAX+1ULL;
+    v_abs = INT64_MAX + 1ULL;
   } else {
     v_abs = llabs(value);
   }
@@ -72,7 +72,7 @@ size_t long_to_trits(int64_t const value, trit_t *const trits) {
   // llabs cannot return a value greater than INT64_MAX
   // so we "force" the (unsigned) value explicitly
   if (value == INT64_MIN) {
-    v_abs = INT64_MAX+1ULL;
+    v_abs = INT64_MAX + 1ULL;
   } else {
     v_abs = llabs(value);
   }

--- a/common/trinary/trit_long.c
+++ b/common/trinary/trit_long.c
@@ -29,19 +29,30 @@ static double const pow27LUT[] = {1,
                                   150094635296999136,
                                   4052555153018976256};
 
-int64_t trits_to_long(trit_t const *const trit, size_t const i) {
+int64_t trits_to_long(trit_t const *const trits, size_t const num_trits) {
+  if (num_trits == 0) {
+    return 0;
+  }
   int64_t accum = 0;
-  size_t end = i;
+  size_t end = num_trits;
   while (end-- > 0) {
-    accum = accum * RADIX + trit[end];
+    accum = accum * RADIX + trits[end];
   }
   return accum;
 }
 
 size_t min_trits(int64_t const value) {
   size_t num = 1;
-  int64_t vp = 1;
-  int64_t v_abs = value < 0 ? -value : value;
+  uint64_t vp = 1;
+  uint64_t v_abs;
+  // Edge case where value == INT64_MIN. In this case,
+  // llabs cannot return a value greater than INT64_MAX
+  // so we "force" the (unsigned) value explicitly
+  if (value == 0x8000000000000000LL) {
+    v_abs = 0x8000000000000000ULL;
+  } else {
+    v_abs = llabs(value);
+  }
   while (v_abs > vp) {
     vp = vp * RADIX + 1;
     num++;
@@ -52,11 +63,19 @@ size_t min_trits(int64_t const value) {
 size_t long_to_trits(int64_t const value, trit_t *const trits) {
   trit_t trit;
   size_t i, size;
+  uint64_t v_abs;
   char negative;
 
   negative = value < 0;
   size = min_trits(value);
-  int64_t v_abs = negative ? -value : value;
+  // Edge case where value == INT64_MIN. In this case,
+  // llabs cannot return a value greater than INT64_MAX
+  // so we "force" the (unsigned) value explicitly
+  if (value == 0x8000000000000000LL) {
+    v_abs = 0x8000000000000000ULL;
+  } else {
+    v_abs = llabs(value);
+  }
   memset(trits, 0, RADIX);
   for (i = 0; i < size; i++) {
     if (v_abs == 0) {
@@ -75,19 +94,26 @@ size_t long_to_trits(int64_t const value, trit_t *const trits) {
 
 size_t nearest_greater_multiple_of_three(size_t const value) {
   size_t rem = value % RADIX;
-  if (rem == 0) return value;
+  if (rem == 0) {
+    return value;
+  }
   return value + RADIX - rem;
 }
 
 size_t encoded_length(int64_t const value) {
-  if (value == 0) return sizeof(encoded_zero) / sizeof(trit_t);
+  if (value == 0) {
+    return sizeof(encoded_zero) / sizeof(trit_t);
+  }
   size_t length = nearest_greater_multiple_of_three(min_trits(llabs(value)));
   // trits length + encoding length
   return length + min_trits((1 << (length / RADIX)) - 1);
 }
 
-int encode_long(int64_t const value, trit_t *const trits, size_t const size) {
-  if (size < encoded_length(value)) return -1;
+int encode_long(int64_t const value, trit_t *const trits,
+                size_t const num_trits) {
+  if (num_trits < encoded_length(value)) {
+    return -1;
+  }
   if (value == 0) {
     memcpy(trits, encoded_zero, encoded_length(0));
     return 0;
@@ -113,28 +139,34 @@ int encode_long(int64_t const value, trit_t *const trits, size_t const size) {
   return 0;
 }
 
-int64_t decode_long(trit_t const *const trits, size_t const length,
-                    size_t *const end) {
+int64_t decode_long(trit_t const *const trits, size_t const num_trits,
+                    size_t *const size) {
   if (memcmp(trits, encoded_zero, encoded_length(0)) == 0) {
-    *end = encoded_length(0);
+    *size = encoded_length(0);
     return 0;
   }
   int64_t value = 0;
   size_t encoding_start = 0;
-  while (encoding_start < length &&
+  while (encoding_start < num_trits &&
          trits_to_long(&trits[encoding_start], RADIX) <= 0)
     encoding_start += RADIX;
-  if (encoding_start >= length) return -1;
+  if (encoding_start >= num_trits) {
+    return -1;
+  }
   encoding_start += RADIX;
   size_t encoding_length = min_trits((1 << (encoding_start / RADIX)) - 1);
   size_t encoding = trits_to_long(&trits[encoding_start], encoding_length);
   // Bound checking for the lookup table
-  if (encoding_start / RADIX > 13) return -1;
+  if (encoding_start / RADIX > 13) {
+    return -1;
+  }
   for (size_t i = 0; i < encoding_start / RADIX; i += 1) {
     int64_t tryte_value = trits_to_long(&trits[i * RADIX], RADIX);
-    if ((encoding >> i) & 1) tryte_value = -tryte_value;
+    if ((encoding >> i) & 1) {
+      tryte_value = -tryte_value;
+    }
     value += pow27LUT[i] * tryte_value;
   }
-  *end = encoding_start + encoding_length;
+  *size = encoding_start + encoding_length;
   return value;
 }

--- a/common/trinary/trit_long.h
+++ b/common/trinary/trit_long.h
@@ -14,16 +14,44 @@ extern "C" {
 
 #include "common/trinary/trits.h"
 
-int64_t trits_to_long(trit_t const *const trit, size_t const i);
+/// Returns the number of trits needed to encode the value
+/// @return size_t - the number of trit needed to encode the value
 size_t min_trits(int64_t const value);
+
+/// Convert an array of trits to an integer value
+/// @param[in] trits - an array of trits
+/// @param[in] num_trits - the number of trits in the array
+/// @return int64_t - the value encoded in the array of trits
+int64_t trits_to_long(trit_t const *const trits, size_t const num_trits);
+/// Convert an integer value to an array of trits
+/// @param[in] value - an integer value
+/// @param[in] trits - an array of trits
+/// @return size_t - the number of trits needed to encode the value
 size_t long_to_trits(int64_t const value, trit_t *const trits);
 
+/// Returns the nearest multiple of 3 of the value, rounded up
+/// @param[in] value - an integer value
+/// @return size_t - the nearest multiple of 3 of the value
 size_t nearest_greater_multiple_of_three(size_t const value);
 
+/// Returns the number of trits needed for encoding of a value
+/// @return size_t - the number of trit needed for encoding
 size_t encoded_length(int64_t const value);
-int encode_long(int64_t const value, trit_t *const trits, size_t const size);
-int64_t decode_long(trit_t const *const trits, size_t const length,
-                    size_t *const end);
+
+/// Encode a value (for MAM)
+/// @param[in] value - an integer value
+/// @param[in] trits - an array of trits
+/// @param[in] num_trits - the number of trits in the array
+/// @return int - return 0 on succes, -1 on failure
+int encode_long(int64_t const value, trit_t *const trits,
+                size_t const num_trits);
+/// Decode a value (for MAM)
+/// @param[in] trits - an array of trits
+/// @param[in] num_trits - the number of trits in the array
+/// @param[in/out] size - the size of the encoded data
+/// @return int64_t - the value decoded from the array of trits
+int64_t decode_long(trit_t const *const trits, size_t const num_trits,
+                    size_t *const size);
 
 #endif
 #ifdef __cplusplus


### PR DESCRIPTION
common/trinary: fix long_to_trits fails for very large integer values (resolves #375 )

# Test Plan:
Usual test plan