### PR TITLE
Use sqlite3 shell target instead of sqlite3 on environment

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "org_iota_entangled")
 
 git_repository(
     name = "rules_iota",
-    commit = "39eeaf4fad15929b0fcc88b8fc473925a6bd9060",
+    commit = "8571197145287c75a2b9cd93531db27d765fafc4",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 

--- a/common/storage/sql/sqlite3/tests/BUILD
+++ b/common/storage/sql/sqlite3/tests/BUILD
@@ -18,5 +18,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    cmd = "sqlite3 $@ < $<",
+    tools = ["@sqlite3//:shell"],
+    cmd = "$(location @sqlite3//:shell) $@ < $<",
 )

--- a/consensus/bundle_validator/tests/BUILD
+++ b/consensus/bundle_validator/tests/BUILD
@@ -17,5 +17,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    cmd = "sqlite3 $@ < $<",
+    tools = ["@sqlite3//:shell"],
+    cmd = "$(location @sqlite3//:shell) $@ < $<",
 )

--- a/consensus/entry_point_selector/tests/BUILD
+++ b/consensus/entry_point_selector/tests/BUILD
@@ -17,5 +17,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    cmd = "sqlite3 $@ < $<",
+    tools = ["@sqlite3//:shell"],
+    cmd = "$(location @sqlite3//:shell) $@ < $<",
 )

--- a/consensus/exit_probability_randomizer/tests/BUILD
+++ b/consensus/exit_probability_randomizer/tests/BUILD
@@ -23,5 +23,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    cmd = "sqlite3 $@ < $<",
+    tools = ["@sqlite3//:shell"],
+    cmd = "$(location @sqlite3//:shell) $@ < $<",
 )

--- a/consensus/exit_probability_validator/tests/BUILD
+++ b/consensus/exit_probability_validator/tests/BUILD
@@ -21,5 +21,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    cmd = "sqlite3 $@ < $<",
+    tools = ["@sqlite3//:shell"],
+    cmd = "$(location @sqlite3//:shell) $@ < $<",
 )


### PR DESCRIPTION
Instead of depending on a `sqlite3` executable to be available on the PATH, we should build one and use it ourselves! :)

# Tests
Tests pass