### PR TITLE
Fix exit_prob_randomizer compilation error on macOS

### DIFF
--- a/common/storage/sql/sqlite3/tests/BUILD
+++ b/common/storage/sql/sqlite3/tests/BUILD
@@ -18,6 +18,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    tools = ["@sqlite3//:shell"],
     cmd = "$(location @sqlite3//:shell) $@ < $<",
+    tools = ["@sqlite3//:shell"],
 )

--- a/consensus/bundle_validator/tests/BUILD
+++ b/consensus/bundle_validator/tests/BUILD
@@ -17,6 +17,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    tools = ["@sqlite3//:shell"],
     cmd = "$(location @sqlite3//:shell) $@ < $<",
+    tools = ["@sqlite3//:shell"],
 )

--- a/consensus/entry_point_selector/tests/BUILD
+++ b/consensus/entry_point_selector/tests/BUILD
@@ -17,6 +17,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    tools = ["@sqlite3//:shell"],
     cmd = "$(location @sqlite3//:shell) $@ < $<",
+    tools = ["@sqlite3//:shell"],
 )

--- a/consensus/exit_probability_randomizer/tests/BUILD
+++ b/consensus/exit_probability_randomizer/tests/BUILD
@@ -23,6 +23,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    tools = ["@sqlite3//:shell"],
     cmd = "$(location @sqlite3//:shell) $@ < $<",
+    tools = ["@sqlite3//:shell"],
 )

--- a/consensus/exit_probability_randomizer/tests/test_exit_probability_randomizer.c
+++ b/consensus/exit_probability_randomizer/tests/test_exit_probability_randomizer.c
@@ -520,7 +520,7 @@ void test_1_bundle(void) {
 
   cw_calc_result out;
 
-  for (uint i = 0; i < bundle_size; ++i) {
+  for (unsigned int i = 0; i < bundle_size; ++i) {
     TEST_ASSERT(iota_tangle_transaction_load_hashes_of_approvers(
                     &tangle, txs[i]->hash, &pack) == RC_OK);
   }

--- a/consensus/exit_probability_validator/tests/BUILD
+++ b/consensus/exit_probability_validator/tests/BUILD
@@ -21,6 +21,6 @@ genrule(
     name = "db_file",
     srcs = ["//common/storage/sql:schema"],
     outs = ["ciri.db"],
-    tools = ["@sqlite3//:shell"],
     cmd = "$(location @sqlite3//:shell) $@ < $<",
+    tools = ["@sqlite3//:shell"],
 )


### PR DESCRIPTION
This PR fixes a compilation error on macOS

# Test Plan:
Usual tests
