### PR TITLE
consensus/exit_probability_randomizer: mark test as flaky

### DIFF
--- a/consensus/exit_probability_randomizer/tests/BUILD
+++ b/consensus/exit_probability_randomizer/tests/BUILD
@@ -3,6 +3,7 @@ cc_test(
     srcs = [
         "test_exit_probability_randomizer.c",
     ],
+    flaky = True,
     data = [
         "snapshot.txt",
         ":db_file",


### PR DESCRIPTION
The test can sometimes fail due to chance. Marking it as flaky means it will rerun three times if it fails once.
