### PR TITLE
receiver: set IP to host for TCP neighbors

### DIFF
--- a/gossip/neighbor.c
+++ b/gossip/neighbor.c
@@ -33,6 +33,7 @@ retcode_t neighbor_init_with_uri(neighbor_t *const neighbor,
   }
   if (strcmp(scheme, "tcp") == 0) {
     neighbor->endpoint.protocol = PROTOCOL_TCP;
+    strcpy(neighbor->endpoint.ip, neighbor->endpoint.host);
   } else if (strcmp(scheme, "udp") == 0) {
     neighbor->endpoint.protocol = PROTOCOL_UDP;
     if (udp_endpoint_init(&neighbor->endpoint) == false) {


### PR DESCRIPTION
While waiting for #223 to be done, this PR temporarily allow TCP gossiping by setting the neighbor `ip` field with the value of the neighbor `host` field.

Hence; to use TCP gossiping, one must only use IPs for now.

# Test Plan:
Not applicable.
