### PR TITLE
mam: add C++ extern C for unmangled symbols

### DIFF
--- a/mam/v1/mam.h
+++ b/mam/v1/mam.h
@@ -12,6 +12,10 @@
 #include "common/trinary/trit_long.h"
 #include "mam/v1/mask.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Initializes the encryption/decryption state for a MAM session
  *
@@ -91,5 +95,9 @@ int mam_parse(trit_t *const payload, size_t const payload_length,
               trit_t const *const root, size_t *const index,
               trit_t *const next_root, size_t *const security,
               Curl *const enc_curl);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  //__MAM_H__

--- a/utils/merkle.h
+++ b/utils/merkle.h
@@ -15,6 +15,10 @@
 #define LEAF_INDEX_OUT_OF_BOUNDS 3
 #define DEPTH_OUT_OF_BOUNDS 4
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Computes the size of a merkle tree, e.g. its node number
  *
@@ -99,5 +103,9 @@ int merkle_branch(trit_t const *const tree, trit_t *const siblings,
 void merkle_root(trit_t *const hash, trit_t const *const siblings,
                  size_t const siblings_number, size_t const leaf_index,
                  Curl *const c);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  //__UTILS_MERKLE_H__


### PR DESCRIPTION
A user reported on Discord that he wasn't able to link mam/merkle functions in a C++ project.

# Test Plan:
Ci must pass.
