### PR TITLE
main: print tx stats log

### DIFF
--- a/ciri/main.c
+++ b/ciri/main.c
@@ -13,6 +13,7 @@
 #include "utils/logger_helper.h"
 
 #define MAIN_LOGGER_ID "main"
+#define STATS_LOG_INTERVAL 10
 
 static core_t core_g;
 
@@ -69,7 +70,22 @@ int main(int argc, char* argv[]) {
   flex_trit_t dummy[FLEX_TRIT_SIZE_8019];
   memset(dummy, FLEX_TRIT_NULL_VALUE, FLEX_TRIT_SIZE_8019);
   broadcaster_on_next(&core_g.node.broadcaster, dummy);
-  sleep(1000);
+
+  size_t count = 0;
+  while (true) {
+    if (iota_tangle_transaction_count(&core_g.consensus.tangle, &count) !=
+        RC_OK) {
+      ret = EXIT_FAILURE;
+      break;
+    }
+    log_info(MAIN_LOGGER_ID,
+             "Transactions: to process %d, to broadcast %d, to request %d, "
+             "count %d\n",
+             processor_size(&core_g.node.processor),
+             broadcaster_size(&core_g.node.broadcaster),
+             requester_size(&core_g.node.transaction_requester), count);
+    sleep(STATS_LOG_INTERVAL);
+  }
 
   log_info(MAIN_LOGGER_ID, "Stopping cIRI core\n");
   if (core_stop(&core_g) != RC_OK) {

--- a/ciri/main.c
+++ b/ciri/main.c
@@ -80,10 +80,11 @@ int main(int argc, char* argv[]) {
     }
     log_info(MAIN_LOGGER_ID,
              "Transactions: to process %d, to broadcast %d, to request %d, "
-             "count %d\n",
+             "to reply %d, count %d\n",
              processor_size(&core_g.node.processor),
              broadcaster_size(&core_g.node.broadcaster),
-             requester_size(&core_g.node.transaction_requester), count);
+             requester_size(&core_g.node.transaction_requester),
+             responder_size(&core_g.node.responder), count);
     sleep(STATS_LOG_INTERVAL);
   }
 

--- a/common/storage/sql/sqlite3/storage.c
+++ b/common/storage/sql/sqlite3/storage.c
@@ -338,6 +338,33 @@ static void select_transactions_populate_from_row(sqlite3_stmt* const statement,
   tx->solid = sqlite3_column_int(statement, 17);
 }
 
+retcode_t iota_stor_transaction_count(connection_t const* const conn,
+                                      size_t* const count) {
+  retcode_t ret = RC_OK;
+  sqlite3_stmt* sqlite_statement = NULL;
+  int rc = 0;
+
+  if ((ret = prepare_statement((sqlite3*)conn->db, &sqlite_statement,
+                               iota_statement_transaction_count)) != RC_OK) {
+    goto done;
+  }
+
+  rc = sqlite3_step(sqlite_statement);
+
+  if (rc == SQLITE_ROW) {
+    *count = sqlite3_column_int64(sqlite_statement, 0);
+  } else if (rc != SQLITE_OK && rc != SQLITE_DONE) {
+    log_error(SQLITE3_LOGGER_ID, "Step failed with sqlite3 code: %" PRIu64 "\n",
+              rc);
+    ret = RC_SQLITE3_FAILED_STEP;
+    goto done;
+  }
+
+done:
+  finalize_statement(sqlite_statement);
+  return ret;
+}
+
 retcode_t iota_stor_transaction_store(connection_t const* const conn,
                                       iota_transaction_t const tx) {
   retcode_t ret = RC_OK;

--- a/common/storage/sql/statements.c
+++ b/common/storage/sql/statements.c
@@ -78,6 +78,9 @@ char *iota_statement_transaction_exist_by_hash =
 char *iota_statement_transaction_approvers_count =
     "SELECT COUNT(*) FROM " TRANSACTION_TABLE_NAME " WHERE branch=? OR trunk=?";
 
+char *iota_statement_transaction_count =
+    "SELECT COUNT(*) FROM " TRANSACTION_TABLE_NAME;
+
 /*
  * Milestone statements
  */

--- a/common/storage/sql/statements.h
+++ b/common/storage/sql/statements.h
@@ -31,6 +31,7 @@ extern char* iota_statement_transaction_update_solid_state;
 extern char* iota_statement_transaction_exist;
 extern char* iota_statement_transaction_exist_by_hash;
 extern char* iota_statement_transaction_approvers_count;
+extern char* iota_statement_transaction_count;
 
 /*
  * Milestone statements

--- a/common/storage/storage.h
+++ b/common/storage/storage.h
@@ -40,6 +40,9 @@ typedef enum transaction_field_e {
   TRANSACTION_FIELD_ADDRESS
 } transaction_field_t;
 
+extern retcode_t iota_stor_transaction_count(connection_t const* const conn,
+                                             size_t* const count);
+
 extern retcode_t iota_stor_transaction_store(connection_t const* const conn,
                                              iota_transaction_t const data_in);
 

--- a/consensus/tangle/tangle.c
+++ b/consensus/tangle/tangle.c
@@ -26,6 +26,11 @@ retcode_t iota_tangle_destroy(tangle_t *const tangle) {
  * Transaction operations
  */
 
+retcode_t iota_tangle_transaction_count(tangle_t const *const tangle,
+                                        size_t *const count) {
+  return iota_stor_transaction_count(&tangle->conn, count);
+}
+
 retcode_t iota_tangle_transaction_store(tangle_t const *const tangle,
                                         iota_transaction_t const tx) {
   return iota_stor_transaction_store(&tangle->conn, tx);

--- a/consensus/tangle/tangle.h
+++ b/consensus/tangle/tangle.h
@@ -37,6 +37,9 @@ retcode_t iota_tangle_destroy(tangle_t *const tangle);
  * Transaction operations
  */
 
+retcode_t iota_tangle_transaction_count(tangle_t const *const tangle,
+                                        size_t *const count);
+
 retcode_t iota_tangle_transaction_store(tangle_t const *const tangle,
                                         iota_transaction_t const tx);
 


### PR DESCRIPTION
The main is now printing tx stats logs.

Sample: `2018-11-05 12:04:21:           main:   INFO: Transactions: to process 0, to broadcast 0, to request 49, count 3956`

Depends on #470, will rebase after merge.

Should make #260 easier to implement.

# Test Plan:
Not applicable.
