### PR TITLE
cclient: add libcclient.so target

### DIFF
--- a/cclient/BUILD
+++ b/cclient/BUILD
@@ -12,9 +12,18 @@ cc_library(
     deps = [
         ":service",
         "//cclient/http",
+        "//common/helpers:checksum",
+        "//common/helpers:digest",
+        "//common/helpers:pow",
         "//common/helpers:sign",
         "//utils/containers/hash:hash243_queue",
     ],
+)
+
+cc_binary(
+    name = "libcclient.so",
+    linkshared = True,
+    deps = [":api"],
 )
 
 cc_library(


### PR DESCRIPTION
We need a cc_binary target to create a shared library that's linked all dependencies in.
This can then be exported and linked against from other targets.