### PR TITLE
mam/v2: sponge - replace state with flex_trits

### DIFF
--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -361,3 +361,10 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
 #endif
   return num_trits;
 }
+
+void flex_trit_set_range(flex_trit_t *trits, size_t start, size_t end,
+                         trit_t value) {
+  for (size_t idx = start; idx < end; ++idx) {
+    flex_trits_set_at(trits, end, idx, value);
+  }
+}

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -260,6 +260,14 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
 size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
                              const byte_t *bytes, size_t len, size_t num_trits);
 
+/// Set a range with value
+/// @param[in] flex_trits - the trits to set
+/// @param[in] start - start index
+/// @param[in] end - end index
+/// @param[in] value - the value to set
+void flex_trit_set_range(flex_trit_t *trits, size_t start, size_t end,
+                         trit_t value);
+
 #endif
 #ifdef __cplusplus
 }

--- a/common/trinary/trit_array.c
+++ b/common/trinary/trit_array.c
@@ -89,9 +89,7 @@ trit_t *trit_array_to_int8(trit_array_p const trit_array, trit_t *const trits,
 trit_array_p trit_array_set_range(trit_array_p const trits, size_t start,
                                   size_t end, trit_t value) {
   assert(start < trits->num_trits && end < trits->num_trits);
-  for (size_t idx = start; idx < end; ++idx) {
-    trit_array_set_at(trits, idx, value);
-  }
+  flex_trit_set_range(trits->trits, start, end, value);
   return trits;
 }
 

--- a/mam/v2/curl.c
+++ b/mam/v2/curl.c
@@ -65,7 +65,14 @@ MAM2_INLINE static trits_t curl_outer_trits(curl_sponge *s, size_t n) {
   return trits_take(curl_state_trits(s), n);
 }
 
-static void curl_transform(curl_sponge *s) { s->i.f(s->i.stack, s->i.s); }
+static void curl_transform(curl_sponge *s) {
+  trit_t state_trits[MAM2_SPONGE_WIDTH];
+  flex_trits_to_trits(state_trits, MAM2_SPONGE_WIDTH, s->i.state,
+                      MAM2_SPONGE_WIDTH, MAM2_SPONGE_WIDTH);
+  s->i.f(s->i.stack, state_trits);
+  flex_trits_from_trits(s->i.state, MAM2_SPONGE_WIDTH, state_trits,
+                        MAM2_SPONGE_WIDTH, MAM2_SPONGE_WIDTH);
+}
 
 MAM2_SAPI void curl_init(curl_sponge *s) {
   trits_set_zero(curl_state_trits(s));
@@ -100,7 +107,6 @@ MAM2_SAPI void curl_squeeze(curl_sponge *s, trits_t Y) {
 }
 
 MAM2_SAPI isponge *curl_sponge_init(curl_sponge *c) {
-  c->i.s = c->s;
   c->i.stack = c->s2;
   c->i.f = curl_f81;
   return &c->i;

--- a/mam/v2/defs.h
+++ b/mam/v2/defs.h
@@ -135,6 +135,15 @@ typedef uint8_t byte;
 /*! \brief Assert expression. */
 #define MAM2_ASSERT(expr) assert(expr)
 
+#if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+#define FLEX_TRIT_SIZE_SPONGE_WIDTH 729
+#elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE)
+#define FLEX_TRIT_SIZE_SPONGE_WIDTH 243
+#elif defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
+#define FLEX_TRIT_SIZE_SPONGE_WIDTH 183
+#elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
+#define FLEX_TRIT_SIZE_SPONGE_WIDTH 146
+#endif
 // TODO - Figure out what to do with those (@tsvisabo)
 
 #define MAM2_API

--- a/mam/v2/sponge.h
+++ b/mam/v2/sponge.h
@@ -55,20 +55,13 @@ typedef trit_t sponge_state_t[MAM2_WORDS(MAM2_SPONGE_WIDTH)];
 typedef struct _isponge {
   void (*f)(void *, trit_t *); /*!< sponge transformation */
   void *stack;                 /*!< additional memory used by `f` */
-  trit_t *s;                   /*!< sponge state */
-
   // TODO - replace s field and also get correct size
-  flex_trit_t flex_trit_state[MAM2_SPONGE_WIDTH];
+  flex_trit_t state[FLEX_TRIT_SIZE_SPONGE_WIDTH]; /*!< sponge state */
 
 } isponge;
 
 /*! \brief Fork (copy) sponge state. `fork` must be initialized. */
 MAM2_API void sponge_fork(isponge *s, isponge *fork);
-
-/*! \brief Get part (the first `n` trits) of the sponge outer state.
-\note It is usually used with `sponge_absorb1`.
-*/
-MAM2_INLINE MAM2_SAPI trits_t sponge_outer_trits(isponge *s, size_t n);
 
 /*! \brief Sponge state initialization. */
 MAM2_API void sponge_init(isponge *s /*!< [in] sponge interface */

--- a/mam/v2/tests/common.h
+++ b/mam/v2/tests/common.h
@@ -29,6 +29,7 @@
 #include "mam/v2/wots.h"
 
 #include "common/trinary/add.h"
+#include "mam/v2/defs.h"
 
 #if !defined(MAM2_MSS_TEST_MAX_D)
 #define MAM2_MSS_TEST_MAX_D 3
@@ -37,7 +38,6 @@
 typedef struct _test_sponge_s {
   isponge s;
   sponge_state_t stack;
-  sponge_state_t state;
 } test_sponge_t;
 
 typedef struct _test_prng_s {
@@ -164,7 +164,6 @@ MAM2_SAPI void test_f(void *buf, trit_t *s) {
 static isponge *test_sponge_init(test_sponge_t *s) {
   s->s.f = test_f;
   s->s.stack = s->stack;
-  s->s.s = s->state;
   return &s->s;
 }
 


### PR DESCRIPTION
 - Replace `s` field with `state` field which is of `flex_trit_t*` type rather than `trit_t*`