### PR TITLE
Sponge flex api

### DIFF
--- a/mam/v2/sponge.c
+++ b/mam/v2/sponge.c
@@ -149,11 +149,11 @@ void sponge_absorbn(isponge *s, trit_t c2, size_t n, trits_t *Xs) {
 }
 
 void sponge_encr(isponge *s, trits_t X, trits_t Y) {
-  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n, X.p);
-  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, Y.n, Y.p);
+  size_t y_size = Y.n - Y.d;
+  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n, X.p + X.d);
+  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, Y.n, Y.p + Y.d);
   sponge_encr_flex(s, &X_arr, &Y_arr);
-  flex_trits_to_trits(Y.p, Y_arr.num_trits, Y_arr.trits, Y_arr.num_trits,
-                      Y_arr.num_trits);
+  flex_trits_to_trits(Y.p + Y.d, y_size, Y_arr.trits, y_size, y_size);
 }
 
 void sponge_encr_flex(isponge *s, trit_array_p X_arr, trit_array_p Y_arr) {
@@ -195,11 +195,11 @@ void sponge_encr_flex(isponge *s, trit_array_p X_arr, trit_array_p Y_arr) {
 }
 
 void sponge_decr(isponge *s, trits_t Y, trits_t X) {
-  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n, X.p);
-  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, Y.n, Y.p);
+  size_t x_size = X.n - X.d;
+  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n, X.p + X.d);
+  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, Y.n, Y.p + Y.d);
   sponge_decr_flex(s, &X_arr, &Y_arr);
-  flex_trits_to_trits(X.p, X_arr.num_trits, X_arr.trits, X_arr.num_trits,
-                      X_arr.num_trits);
+  flex_trits_to_trits(X.p + X.d, x_size, X_arr.trits, x_size, x_size);
 }
 
 void sponge_decr_flex(isponge *s, trit_array_p X_arr, trit_array_p Y_arr) {

--- a/mam/v2/sponge.c
+++ b/mam/v2/sponge.c
@@ -61,7 +61,7 @@ void sponge_init(isponge *s) { trits_set_zero(sponge_state_trits(s)); }
 
 void sponge_absorb(isponge *s, trit_t c2, trits_t X) {
   size_t num_trits = X.n - X.d;
-  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, num_trits, X.p);
+  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, num_trits, X.p + X.d);
   sponge_absorb_flex(s, c2, &X_arr);
   flex_trits_to_trits(&X.p[X.d], num_trits, X_arr.trits, num_trits, num_trits);
 }
@@ -98,7 +98,7 @@ void sponge_absorb_flex(isponge *s, trit_t c2, trit_array_p X_arr) {
 
 void sponge_squeeze(isponge *s, trit_t c2, trits_t Y) {
   size_t num_trits = Y.n - Y.d;
-  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, num_trits, Y.p);
+  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, num_trits, Y.p + Y.d);
   sponge_squeeze_flex(s, c2, &Y_arr);
   flex_trits_to_trits(&Y.p[Y.d], num_trits, Y_arr.trits, num_trits, num_trits);
 }
@@ -242,8 +242,8 @@ void sponge_decr_flex(isponge *s, trit_array_p X_arr, trit_array_p Y_arr) {
 
 void sponge_hash(isponge *s, trits_t X, trits_t Y) {
   size_t y_size = Y.n - Y.d;
-  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n - X.d, &X.p[X.d]);
-  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, y_size, &Y.p[Y.d]);
+  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n - X.d, X.p + X.d);
+  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, y_size, Y.p + Y.d);
   sponge_hash_flex(s, &X_arr, &Y_arr);
   flex_trits_to_trits(&Y.p[Y.d], y_size, Y_arr.trits, y_size, y_size);
 }

--- a/mam/v2/sponge.c
+++ b/mam/v2/sponge.c
@@ -241,9 +241,17 @@ void sponge_decr_flex(isponge *s, trit_array_p X_arr, trit_array_p Y_arr) {
 }
 
 void sponge_hash(isponge *s, trits_t X, trits_t Y) {
+  size_t y_size = Y.n - Y.d;
+  TRIT_ARRAY_MAKE_FROM_RAW(X_arr, X.n - X.d, &X.p[X.d]);
+  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, y_size, &Y.p[Y.d]);
+  sponge_hash_flex(s, &X_arr, &Y_arr);
+  flex_trits_to_trits(&Y.p[Y.d], y_size, Y_arr.trits, y_size, y_size);
+}
+
+void sponge_hash_flex(isponge *s, trit_array_p X, trit_array_p Y) {
   sponge_init(s);
-  sponge_absorb(s, MAM2_SPONGE_CTL_HASH, X);
-  sponge_squeeze(s, MAM2_SPONGE_CTL_HASH, Y);
+  sponge_absorb_flex(s, MAM2_SPONGE_CTL_HASH, X);
+  sponge_squeeze_flex(s, MAM2_SPONGE_CTL_HASH, Y);
 }
 
 void sponge_hashn(isponge *s, size_t n, trits_t *Xs, trits_t Y) {

--- a/mam/v2/sponge.c
+++ b/mam/v2/sponge.c
@@ -97,9 +97,21 @@ void sponge_absorb_flex(isponge *s, trit_t c2, trit_array_p X_arr) {
 }
 
 void sponge_squeeze(isponge *s, trit_t c2, trits_t Y) {
+  size_t num_trits = Y.n - Y.d;
+  TRIT_ARRAY_MAKE_FROM_RAW(Y_arr, num_trits, Y.p);
+  sponge_squeeze_flex(s, c2, &Y_arr);
+  flex_trits_to_trits(&Y.p[Y.d], num_trits, Y_arr.trits, num_trits, num_trits);
+}
+
+void sponge_squeeze_flex(isponge *s, trit_t c2, trit_array_p Y_arr) {
   trits_t Yi;
   size_t ni;
   trit_t c0 = -1, c1;
+  trit_t y_rep[Y_arr->num_trits];
+  flex_trits_to_trits(y_rep, Y_arr->num_trits, Y_arr->trits, Y_arr->num_trits,
+                      Y_arr->num_trits);
+  trits_t Y = trits_from_rep(Y_arr->num_trits, y_rep);
+  trit_t *y_p = Y.p;
   do {
     Yi = trits_take_min(Y, MAM2_SPONGE_RATE);
     c1 = (trits_size(Y) < MAM2_SPONGE_RATE) ? 0 : 1;
@@ -110,6 +122,9 @@ void sponge_squeeze(isponge *s, trit_t c2, trits_t Y) {
     trits_copy(sponge_outer_trits(s, ni), Yi);
     set_control_tryte(s, 0, c0, c1, c2);
   } while (!trits_is_empty(Y));
+
+  flex_trits_from_trits(Y_arr->trits, Y_arr->num_trits, y_p, Y_arr->num_trits,
+                        Y_arr->num_trits);
 }
 
 void sponge_absorbn(isponge *s, trit_t c2, size_t n, trits_t *Xs) {

--- a/mam/v2/sponge.h
+++ b/mam/v2/sponge.h
@@ -103,6 +103,12 @@ void sponge_encr(isponge *s, /*!< [in] sponge interface */
                  trits_t Y   /*!< [out] ciphertext */
 );
 
+/*! \brief Sponge AE encryption. */
+void sponge_encr_flex(isponge *s,     /*!< [in] sponge interface */
+                      trit_array_p X, /*!< [in] plaintext */
+                      trit_array_p Y  /*!< [out] ciphertext */
+);
+
 /*! \brief Sponge AE decryption. */
 void sponge_decr(isponge *s, /*!< [in] sponge interface */
                  trits_t X,  /*!< [in] ciphertext */

--- a/mam/v2/sponge.h
+++ b/mam/v2/sponge.h
@@ -97,6 +97,13 @@ void sponge_squeeze(
     trits_t Y   /*!< [out] output data */
 );
 
+/*! \brief Sponge squeezing. */
+void sponge_squeeze_flex(
+    isponge *s,    /*!< [in] sponge interface */
+    trit_t c2,     /*!< [in] control trit encoding output data type */
+    trit_array_p Y /*!< [out] output data */
+);
+
 /*! \brief Sponge AE encryption. */
 void sponge_encr(isponge *s, /*!< [in] sponge interface */
                  trits_t X,  /*!< [in] plaintext */

--- a/mam/v2/sponge.h
+++ b/mam/v2/sponge.h
@@ -80,7 +80,7 @@ void sponge_absorb(isponge *s, /*!< [in] sponge interface */
                    trits_t X  /*!< [in] input data */
 );
 
-void sponge_absorb_arr(isponge *s, trit_t c2, trit_array_p X_arr);
+void sponge_absorb_flex(isponge *s, trit_t c2, trit_array_p X_arr);
 
 /*! \brief Absorb concatenation of `Xs[0]`..`Xs[n-1]` */
 void sponge_absorbn(

--- a/mam/v2/sponge.h
+++ b/mam/v2/sponge.h
@@ -135,6 +135,12 @@ void sponge_hash(isponge *s, /*!< [in] sponge interface */
 );
 
 /*! \brief Sponge hashing. */
+void sponge_hash_flex(isponge *s,     /*!< [in] sponge interface */
+                      trit_array_p X, /*!< [in] input data */
+                      trit_array_p Y  /*!< [out] hash value */
+);
+
+/*! \brief Sponge hashing. */
 void sponge_hashn(isponge *s,  /*!< [in] sponge interface */
                   size_t n,    /*!< [in] input data blocks count */
                   trits_t *Xs, /*!< [in] input data blocks */

--- a/mam/v2/sponge.h
+++ b/mam/v2/sponge.h
@@ -115,6 +115,12 @@ void sponge_decr(isponge *s, /*!< [in] sponge interface */
                  trits_t Y   /*!< [out] plaintext */
 );
 
+/*! \brief Sponge AE decryption. */
+void sponge_decr_flex(isponge *s,     /*!< [in] sponge interface */
+                      trit_array_p X, /*!< [in] ciphertext */
+                      trit_array_p Y  /*!< [out] plaintext */
+);
+
 /*! \brief Sponge hashing. */
 void sponge_hash(isponge *s, /*!< [in] sponge interface */
                  trits_t X,  /*!< [in] input data */

--- a/mam/v2/trits.c
+++ b/mam/v2/trits.c
@@ -288,7 +288,7 @@ void trits_swap_sub(trits_t y, trits_t s) {
   }
 }
 
-void flex_from_trits(trits_t t, flex_trit_t *flex_trits) {
+void flex_trit_t_from_trits_t(trits_t t, flex_trit_t *flex_trits) {
   size_t n = t.n - t.d;
   flex_trits_from_trits(flex_trits, n, &t.p[t.d], n, n);
 }

--- a/mam/v2/trits.h
+++ b/mam/v2/trits.h
@@ -149,7 +149,7 @@ void trits_copy_sub(trits_t y, trits_t s, trits_t x);
 void trits_swap_add(trits_t x, trits_t s);
 void trits_swap_sub(trits_t y, trits_t s);
 
-void flex_from_trits(trits_t t, flex_trit_t *flex_trits);
+void flex_trit_t_from_trits_t(trits_t t, flex_trit_t *flex_trits);
 
 /*! \brief Print string rep of `x` into stdout if MAM2_DEBUG defined. */
 #ifdef MAM2_DEBUG


### PR DESCRIPTION
- For every function in `sponge.h` (except `sponge_hashn`/`sponge_absorbn`) , add a cloned function with `_flex` suffix that takes `trit_array_p` arg  
