### PR TITLE
mam/v2: wots - calc_pks

### DIFF
--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -109,6 +109,30 @@ size_t flex_trits_insert(flex_trit_t *const to_flex_trits, size_t const to_len,
   return num_trits;
 }
 
+size_t flex_trits_insert_from_pos(flex_trit_t *const dst_trits,
+                                  size_t const dst_len,
+                                  flex_trit_t const *const src_trits,
+                                  size_t const src_len,
+                                  size_t const src_start_pos,
+                                  size_t const dst_start_pos,
+                                  size_t const num_trits) {
+  // Bounds checking
+  if (num_trits == 0 || num_trits > src_len || num_trits > dst_len ||
+      src_start_pos >= src_len || (src_start_pos + num_trits) > src_len ||
+      dst_start_pos >= dst_len || (dst_start_pos + num_trits) > dst_len) {
+    return 0;
+  }
+#if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
+  memcpy(dst_trits + dst_start_pos, src_trits + src_start_pos, num_trits);
+#else
+  for (size_t i = 0; i < num_trits; i++) {
+    trit_t t = flex_trits_at(src_trits, src_len, src_start_pos + i);
+    flex_trits_set_at(dst_trits, dst_len, dst_start_pos + i, t);
+  }
+#endif
+  return num_trits;
+}
+
 size_t flex_trits_to_trits(trit_t *const trits, size_t const to_len,
                            flex_trit_t const *const flex_trits,
                            size_t const len, size_t const num_trits) {

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -187,12 +187,30 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
 /// @param[in] to_len - the number of trits encoded in the to_flex_trits array
 /// @param[in] flex_trits - the array containing the trits to copy over
 /// @param[in] len - the number of trits the flex_trits array stores
-/// @param[in] start - the start index in the target array
+/// @param[in] start - the start index in the destination array
 /// @param[in] num_trits - the number of trits to copy over
 /// @return size_t - the number of trits copied over
 size_t flex_trits_insert(flex_trit_t *const to_flex_trits, size_t const to_len,
                          flex_trit_t const *const flex_trits, size_t const len,
                          size_t const start, size_t const num_trits);
+
+/// Inserts the contents of an array into another array starting at a given
+/// index.
+/// @param[in] dst_trits - the array to insert into
+/// @param[in] dst_len - the number of trits encoded in the to_flex_trits array
+/// @param[in] src_trits - the array containing the trits to copy over
+/// @param[in] src_len - the number of trits the flex_trits array stores
+/// @param[in] src_start_pos - the start index on the source array
+/// @param[in] dst_start_pos - the start index on the destination array
+/// @param[in] num_trits - the number of trits to copy over
+/// @return size_t - the number of trits copied over
+size_t flex_trits_insert_from_pos(flex_trit_t *const dst_trits,
+                                  size_t const dst_len,
+                                  flex_trit_t const *const src_trits,
+                                  size_t const src_len,
+                                  size_t const src_start_pos,
+                                  size_t const dst_start_pos,
+                                  size_t const num_trits);
 
 /// Returns an array of trits regardless of the current memory storage
 /// scheme

--- a/common/trinary/trit_array.c
+++ b/common/trinary/trit_array.c
@@ -79,6 +79,17 @@ trit_array_p trit_array_insert(trit_array_p const trit_array,
   return trit_array;
 }
 
+trit_array_p trit_array_insert_from_pos(trit_array_p const dst_trits,
+                                        trit_array_p const src_trits,
+                                        size_t const src_start_pos,
+                                        size_t const dst_start_pos,
+                                        size_t const num_trits) {
+  flex_trits_insert_from_pos(dst_trits->trits, dst_trits->num_trits,
+                             src_trits->trits, src_trits->num_trits,
+                             src_start_pos, dst_start_pos, num_trits);
+  return dst_trits;
+}
+
 trit_t *trit_array_to_int8(trit_array_p const trit_array, trit_t *const trits,
                            size_t const len) {
   flex_trits_to_trits(trits, len, trit_array->trits, trit_array->num_trits,

--- a/common/trinary/trit_array.h
+++ b/common/trinary/trit_array.h
@@ -90,12 +90,26 @@ trit_array_p trit_array_slice_at_most(trit_array_p const trit_array,
 /// index.
 /// @param[in] trit_array - the array to insert into
 /// @param[in] from_trit_array - the array containing the trits to copy over
-/// @param[in] start - the start index in the target array
+/// @param[in] start - the start index in the destination array
 /// @param[in] num_trits - the number of trits to copy over
 /// @return trit_array_p - the receiver
 trit_array_p trit_array_insert(trit_array_p const trit_array,
                                trit_array_p const from_trit_array,
                                size_t const start, size_t const num_trits);
+
+/// Inserts the contents of an array into the receiver starting at a given
+/// index.
+/// @param[in] dst_trits - the array to insert into
+/// @param[in] src_trits - the array containing the trits to copy over
+/// @param[in] src_start_pos - the start index on the source array
+/// @param[in] dst_start_pos - the start index on the destination array
+/// @param[in] num_trits - the number of trits to copy over
+/// @return trit_array_p - the receiver
+trit_array_p trit_array_insert_from_pos(trit_array_p const dst_trits,
+                                        trit_array_p const src_trits,
+                                        size_t const src_start_pos,
+                                        size_t const dst_start_pos,
+                                        size_t const num_trits);
 
 /// Returns an array of trits regardless of the current memory storage scheme
 /// @param[in] trit_array - the array of packed trits

--- a/common/trinary/trit_tryte.c
+++ b/common/trinary/trit_tryte.c
@@ -50,7 +50,12 @@ uint8_t set_trit_at(tryte_t *const trytes, size_t const length, size_t index,
   tryte_t tryte = trytes[tindex];
   size_t cindex = tryte == '9' ? 0 : tryte - '@';
   trit_t trits[3];
-  memcpy(trits, TRYTE_TO_TRITS_MAPPINGS[cindex], NUMBER_OF_TRITS_IN_A_TRYTE);
+  if (cindex > 26) {
+    // uninitialized
+    memcpy(trits, TRYTE_TO_TRITS_MAPPINGS[0], NUMBER_OF_TRITS_IN_A_TRYTE);
+  } else {
+    memcpy(trits, TRYTE_TO_TRITS_MAPPINGS[cindex], NUMBER_OF_TRITS_IN_A_TRYTE);
+  }
   size_t uindex = index % 3U;
   trits[uindex] = trit;
   tryte = trits[0] + trits[1] * 3 + trits[2] * 9;

--- a/mam/v2/wots.c
+++ b/mam/v2/wots.c
@@ -18,12 +18,7 @@ static void wots_calc_pks(isponge *const sponge, trit_array_p sk_pks,
                           trit_array_p pk) {
   size_t i, j;
 
-  TRIT_ARRAY_DECLARE(sk_part_trits_array, 0);
-  flex_trit_t
-      sk_part_flex_trits[trit_array_bytes_for_trits(MAM2_WOTS_SK_PART_SIZE)];
-  trit_array_set_trits(&sk_part_trits_array, sk_part_flex_trits,
-                       MAM2_WOTS_SK_PART_SIZE);
-
+  TRIT_ARRAY_DECLARE(sk_part_trits_array, MAM2_WOTS_SK_PART_SIZE);
   MAM2_ASSERT(sk_pks->num_trits == MAM2_WOTS_SK_SIZE);
   MAM2_ASSERT(pk->num_trits == MAM2_WOTS_PK_SIZE);
 
@@ -149,20 +144,11 @@ void wots_gen_sk3(wots_t *const wots, prng_t *const prng, trits_t const nonce1,
 }
 
 void wots_calc_pk(wots_t *const wots, trits_t pk) {
-  TRIT_ARRAY_DECLARE(sk_trits_array, 0);
-  flex_trit_t sk_flex_trits[trit_array_bytes_for_trits(MAM2_WOTS_SK_SIZE)];
-  memcpy(sk_flex_trits, wots->sk, MAM2_WOTS_SK_FLEX_SIZE);
-  trit_array_set_trits(&sk_trits_array, sk_flex_trits, MAM2_WOTS_SK_SIZE);
-
-  TRIT_ARRAY_DECLARE(pk_trits_array, 0);
-  flex_trit_t pk_flex_trits[trit_array_bytes_for_trits(MAM2_WOTS_PK_SIZE)];
-  flex_trits_from_trits(pk_flex_trits, MAM2_WOTS_PK_SIZE, pk.p + pk.d,
-                        MAM2_WOTS_PK_SIZE, MAM2_WOTS_PK_SIZE);
-  trit_array_set_trits(&pk_trits_array, pk_flex_trits, MAM2_WOTS_PK_SIZE);
-
+  TRIT_ARRAY_DECLARE(sk_trits_array, MAM2_WOTS_SK_SIZE);
+  memcpy(sk_trits_array.trits, wots->sk, MAM2_WOTS_SK_FLEX_SIZE);
+  TRIT_ARRAY_MAKE_FROM_RAW(pk_trits_array, MAM2_WOTS_PK_SIZE, pk.p + pk.d);
   wots_calc_pks(wots->sponge, &sk_trits_array, &pk_trits_array);
-
-  flex_trits_to_trits(pk.p + pk.d, MAM2_WOTS_PK_SIZE, pk_flex_trits,
+  flex_trits_to_trits(pk.p + pk.d, MAM2_WOTS_PK_SIZE, pk_trits_array.trits,
                       MAM2_WOTS_PK_SIZE, MAM2_WOTS_PK_SIZE);
 }
 

--- a/mam/v2/wots.c
+++ b/mam/v2/wots.c
@@ -14,23 +14,31 @@
  * Private functions
  */
 
-static void wots_calc_pks(isponge *const sponge, trits_t sk_pks, trits_t pk) {
+static void wots_calc_pks(isponge *const sponge, trit_array_p sk_pks,
+                          trit_array_p pk) {
   size_t i, j;
-  trits_t sk_part, pks = sk_pks;
 
-  MAM2_ASSERT(trits_size(sk_pks) == MAM2_WOTS_SK_SIZE);
-  MAM2_ASSERT(trits_size(pk) == MAM2_WOTS_PK_SIZE);
+  TRIT_ARRAY_DECLARE(sk_part_trits_array, 0);
+  flex_trit_t
+      sk_part_flex_trits[trit_array_bytes_for_trits(MAM2_WOTS_SK_PART_SIZE)];
+  trit_array_set_trits(&sk_part_trits_array, sk_part_flex_trits,
+                       MAM2_WOTS_SK_PART_SIZE);
 
+  MAM2_ASSERT(sk_pks->num_trits == MAM2_WOTS_SK_SIZE);
+  MAM2_ASSERT(pk->num_trits == MAM2_WOTS_PK_SIZE);
+
+  size_t sk_pos = 0;
   for (i = 0; i < MAM2_WOTS_SK_PART_COUNT; ++i) {
-    sk_part = trits_take(sk_pks, MAM2_WOTS_SK_PART_SIZE);
-    sk_pks = trits_drop(sk_pks, MAM2_WOTS_SK_PART_SIZE);
-
+    trit_array_insert_from_pos(&sk_part_trits_array, sk_pks, sk_pos, 0,
+                               MAM2_WOTS_SK_PART_SIZE);
     for (j = 0; j < 26; ++j) {
-      sponge_hash(sponge, sk_part, sk_part);
+      sponge_hash_flex(sponge, &sk_part_trits_array, &sk_part_trits_array);
     }
+    trit_array_insert_from_pos(sk_pks, &sk_part_trits_array, 0, sk_pos,
+                               MAM2_WOTS_SK_PART_SIZE);
+    sk_pos += MAM2_WOTS_SK_PART_SIZE;
   }
-
-  sponge_hash(sponge, pks, pk);
+  sponge_hash_flex(sponge, sk_pks, pk);
 }
 
 static void wots_hash_sign(isponge *const sponge, trits_t sk_sig,
@@ -141,12 +149,21 @@ void wots_gen_sk3(wots_t *const wots, prng_t *const prng, trits_t const nonce1,
 }
 
 void wots_calc_pk(wots_t *const wots, trits_t pk) {
-  MAM2_TRITS_DEF(sk_pks, MAM2_WOTS_SK_SIZE);
-  // TODO Remove when wots_calc_pks takes flex_trit_t *
-  flex_trits_to_trits(sk_pks.p + sk_pks.d, MAM2_WOTS_SK_SIZE, wots->sk,
-                      MAM2_WOTS_SK_SIZE, MAM2_WOTS_SK_SIZE);
-  wots_calc_pks(wots->sponge, sk_pks, pk);
-  trits_set_zero(sk_pks);
+  TRIT_ARRAY_DECLARE(sk_trits_array, 0);
+  flex_trit_t sk_flex_trits[trit_array_bytes_for_trits(MAM2_WOTS_SK_SIZE)];
+  memcpy(sk_flex_trits, wots->sk, MAM2_WOTS_SK_FLEX_SIZE);
+  trit_array_set_trits(&sk_trits_array, sk_flex_trits, MAM2_WOTS_SK_SIZE);
+
+  TRIT_ARRAY_DECLARE(pk_trits_array, 0);
+  flex_trit_t pk_flex_trits[trit_array_bytes_for_trits(MAM2_WOTS_PK_SIZE)];
+  flex_trits_from_trits(pk_flex_trits, MAM2_WOTS_PK_SIZE, pk.p + pk.d,
+                        MAM2_WOTS_PK_SIZE, MAM2_WOTS_PK_SIZE);
+  trit_array_set_trits(&pk_trits_array, pk_flex_trits, MAM2_WOTS_PK_SIZE);
+
+  wots_calc_pks(wots->sponge, &sk_trits_array, &pk_trits_array);
+
+  flex_trits_to_trits(pk.p + pk.d, MAM2_WOTS_PK_SIZE, pk_flex_trits,
+                      MAM2_WOTS_PK_SIZE, MAM2_WOTS_PK_SIZE);
 }
 
 void wots_sign(wots_t *const wots, trits_t const hash, trits_t sig) {


### PR DESCRIPTION
- fix `set_trit_at` on uninitialized dest arrays
- wots_calc_pks: trits_t -> trit_array_t
-  add `trit_array_insert_from_pos` that takes poistions in both src/dest arrays
