### PR TITLE
mam1: fix failing security tests

### DIFF
--- a/common/sign/v2/iss.c.inc
+++ b/common/sign/v2/iss.c.inc
@@ -104,7 +104,7 @@ int _ISS_PREFIX(signature)(trit_t *sig, trit_t const *const hash,
     return 1;
   }
 
-  for (i = start_offset % window; sig < se; i++) {
+  for (i = start_offset % window; sig < se;) {
     for (j = i * ISS_CHUNK_LENGTH; j < (i + 1) * ISS_CHUNK_LENGTH && sig < se;
          j += TRYTE_WIDTH) {
       s = hash[j] + hash[j + 1] * 3 + hash[j + 2] * 9;
@@ -123,25 +123,24 @@ int _ISS_PREFIX(sig_digest)(trit_t *dig, trit_t const *const hash,
   int s;
   trit_t *sig_start, *end;
 
+  sig_start = sig;
   end = &sig[sig_len];
   if (!(window = signed_window(hash))) {
     return 1;
   }
 
   for (i = offset % window; sig < end;) {
-    sig_start = sig;
     for (j = i * ISS_CHUNK_LENGTH; j < (i + 1) * ISS_CHUNK_LENGTH && sig < end;
          j += TRYTE_WIDTH) {
       s = hash[j] + hash[j + 1] * 3 + hash[j + 2] * 9;
       _ISS_PREFIX(digest)(sig, s - TRYTE_VALUE_MIN, c);
       sig = &sig[HASH_LENGTH_TRIT];
     }
-    _HASH_PREFIX(absorb)(c, sig_start, ISS_KEY_LENGTH);
-    _HASH_PREFIX(squeeze)(c, dig, HASH_LENGTH_TRIT);
-    _HASH_PREFIX(reset)(c);
-    dig = &dig[HASH_LENGTH_TRIT];
     i = (i + 1) % window;
   }
+  _HASH_PREFIX(absorb)(c, sig_start, window * ISS_KEY_LENGTH);
+  _HASH_PREFIX(squeeze)(c, dig, HASH_LENGTH_TRIT);
+  _HASH_PREFIX(reset)(c);
   return 0;
 }
 

--- a/mam/v1/mam.c
+++ b/mam/v1/mam.c
@@ -173,12 +173,11 @@ int mam_parse(trit_t *const payload, size_t const payload_length,
 
   // decrypt signature from payload
   curl_reset(enc_curl);
-  trit_t digest[*security * HASH_LENGTH_TRIT];
-  iss_curl_sig_digest(digest, hash, 0, payload + offset,
+  iss_curl_sig_digest(hash, hash, 0, payload + offset,
                       *security * ISS_KEY_LENGTH, enc_curl);
 
   // complete the address
-  iss_curl_address(hash, digest, *security * HASH_LENGTH_TRIT, enc_curl);
+  iss_curl_address(hash, hash, HASH_LENGTH_TRIT, enc_curl);
   offset += *security * ISS_KEY_LENGTH;
 
   // decrypt siblings number from payload

--- a/mam/v1/tests/test_mam.c
+++ b/mam/v1/tests/test_mam.c
@@ -14,7 +14,7 @@
 #include "mam/v1/mam.h"
 #include "utils/merkle.h"
 
-void test_create(void) {
+void test_mam_sec(int security) {
   char *const seed =
       "TX9XRR9SRCOBMTYDTMKNEIJCSZIMEUPWCNLC9DPDZKKAEMEFVSTEVUFTRUZXEHLULEIYJIEO"
       "WIC9STAHW";
@@ -39,9 +39,8 @@ void test_create(void) {
   size_t index = 7;
   size_t message_length = strlen(message) * 3;
 
-  size_t security = 1;
   size_t start = 0;
-  size_t count = 16;
+  size_t count = 8;
   size_t next_start = start + count;
   size_t next_count = 1;
   size_t tree_size = merkle_size(count);
@@ -88,10 +87,16 @@ void test_create(void) {
   free(payload);
 }
 
+void test_mam() {
+  test_mam_sec(1);
+  test_mam_sec(2);
+  test_mam_sec(3);
+}
+
 int main(void) {
   UNITY_BEGIN();
 
-  RUN_TEST(test_create);
+  RUN_TEST(test_mam);
 
   return UNITY_END();
 }


### PR DESCRIPTION
Fixes #549 by
- Fixing a double incrementation in ISSV2 signature
- Fixing ISSV2 signature digest for security >= 2

# Test Plan:
Added security mam tests for security 2 and 3
