### PR TITLE
ciri: fix transaction requester and tips cache size logs

### DIFF
--- a/gossip/node.c
+++ b/gossip/node.c
@@ -82,7 +82,7 @@ static retcode_t node_transaction_requester_init(node_t* const node,
   }
 
   log_debug(NODE_LOGGER_ID, "Added %d transactions to request\n",
-            pack.num_loaded);
+            requester_size(&node->transaction_requester));
 
 done:
   hash_pack_free(&pack);
@@ -122,7 +122,8 @@ static retcode_t node_tips_cache_init(node_t* const node) {
     }
   }
 
-  log_debug(NODE_LOGGER_ID, "Added %d tips to cache\n", pack.num_loaded);
+  log_debug(NODE_LOGGER_ID, "Added %d tips to cache\n",
+            tips_cache_size(&node->tips));
 
 done:
   hash_pack_free(&pack);


### PR DESCRIPTION
This PR logs the real size values of transaction requester and tips cache.
Previous version logged the number of rows fetched from the database.
It could not reflect the real size for some reasons, e.g. genesis hash being counted in requested hashes.

# Test Plan:
Not applicable
