### PR TITLE
solidifier: fix current approver hash cast

### DIFF
--- a/consensus/transaction_solidifier/transaction_solidifier.c
+++ b/consensus/transaction_solidifier/transaction_solidifier.c
@@ -95,7 +95,8 @@ static retcode_t propagate_solid_transactions(
     }
     for (approver_index = 0; approver_index < hash_pack.num_loaded;
          ++approver_index) {
-      curr_approver_hash = (flex_trit_t *)hash_pack.models[approver_index];
+      curr_approver_hash =
+          ((trit_array_t *)hash_pack.models[approver_index])->trits;
       if ((ret =
                iota_consensus_transaction_solidifier_check_and_update_solid_state(
                    ts, curr_approver_hash)) != RC_OK) {


### PR DESCRIPTION
The error logs `No transactions were loaded for the provided hash` were due to a bad cast in the solidifier resulting in bad SQL queries.
 
# Test Plan:
CI
