### PR TITLE
common: HASH_LENGTH_BYTE should be 49 to fit 243 trits

### DIFF
--- a/common/defs.h
+++ b/common/defs.h
@@ -24,7 +24,7 @@
 
 // Hash length definitions
 
-#define HASH_LENGTH_BYTE 48
+#define HASH_LENGTH_BYTE 49
 #define HASH_LENGTH_TRYTE 81
 #define HASH_LENGTH_TRIT 243
 


### PR DESCRIPTION
48 only fits 240 trits, not 243

# Test Plan:
CI passes
