### PR TITLE
infra: toolchain compatibility with bazel 0.20.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,7 @@ git_repository(
 
 git_repository(
     name = "iota_toolchains",
-    commit = "aeef0cf0a5194da308db582551feae222af61003",
+    commit = "9a6c200013d971524f8427b6a404bab0a67a9328",
     remote = "https://github.com/iotaledger/toolchains.git",
 )
 


### PR DESCRIPTION
Fixed #607 

# Test Plan:
No need on CI

Tested via CLI: 
**Using Bazel 0.20.0**
```
bazel build --crosstool_top=@iota_toolchains//tools/aarch64--glibc--bleeding-edge-2018.07-1:toolchain --cpu=aarch64 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain //ciri
```