### PR TITLE
common/storage: fix C99 compatibility

### DIFF
--- a/common/storage/sql/sqlite3/storage.c
+++ b/common/storage/sql/sqlite3/storage.c
@@ -125,6 +125,12 @@ static void
 select_transactions_populate_from_row_essence_attachment_and_metadata(
     sqlite3_stmt* const statement, iota_transaction_t const tx);
 
+static void select_transactions_populate_from_row_essence_and_consensus(
+    sqlite3_stmt* const statement, iota_transaction_t const tx);
+
+static void select_transactions_populate_from_row_metadata(
+    sqlite3_stmt* const statement, iota_transaction_t const tx);
+
 static retcode_t prepare_statement(sqlite3* const db,
                                    sqlite3_stmt** const sqlite_statement,
                                    char const* const statement) {


### PR DESCRIPTION
sqlite3 was missing some C-style forward declarations

