### PR TITLE
gossip: use is_empty functions instead of size functions

### DIFF
--- a/gossip/components/broadcaster.c
+++ b/gossip/components/broadcaster.c
@@ -31,7 +31,7 @@ static void *broadcaster_routine(broadcaster_t *const broadcaster) {
   lock_handle_lock(&lock_cond);
 
   while (broadcaster->running) {
-    if (broadcaster_size(broadcaster) == 0) {
+    if (broadcaster_is_empty(broadcaster)) {
       cond_handle_timedwait(&broadcaster->cond, &lock_cond,
                             BROADCASTER_TIMEOUT_SEC);
     }

--- a/gossip/components/broadcaster.h
+++ b/gossip/components/broadcaster.h
@@ -90,6 +90,17 @@ size_t broadcaster_size(broadcaster_t *const broadcaster);
  */
 retcode_t broadcaster_stop(broadcaster_t *const broadcaster);
 
+/**
+ * Tells whether the broadcaster queue is empty or not
+ *
+ * @param broadcaster The broadcaster
+ *
+ * @return true if empty, false otherwise
+ */
+static inline bool broadcaster_is_empty(broadcaster_t *const broadcaster) {
+  return broadcaster->queue == NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/gossip/components/processor.c
+++ b/gossip/components/processor.c
@@ -273,7 +273,7 @@ static void *processor_routine(processor_t *const processor) {
   lock_handle_lock(&lock_cond);
 
   while (processor->running) {
-    if (processor_size(processor) == 0) {
+    if (processor_is_empty(processor)) {
       cond_handle_timedwait(&processor->cond, &lock_cond,
                             PROCESSOR_TIMEOUT_SEC);
     }

--- a/gossip/components/processor.h
+++ b/gossip/components/processor.h
@@ -109,6 +109,17 @@ retcode_t processor_on_next(processor_t *const processor,
  */
 size_t processor_size(processor_t *const processor);
 
+/**
+ * Tells whether the processor queue is empty or not
+ *
+ * @param processor The processor
+ *
+ * @return true if empty, false otherwise
+ */
+static inline bool processor_is_empty(processor_t *const processor) {
+  return processor->queue == NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/gossip/components/responder.c
+++ b/gossip/components/responder.c
@@ -46,7 +46,7 @@ static retcode_t get_transaction_for_request(responder_t const *const responder,
 
     log_debug(RESPONDER_LOGGER_ID, "Responding to random tip request\n");
     if (rand_handle_probability() < responder->node->conf.p_reply_random_tip &&
-        requester_size(&responder->node->transaction_requester) > 0) {
+        !requester_is_empty(&responder->node->transaction_requester)) {
       neighbor->nbr_random_tx_req++;
       if ((ret = tips_cache_random_tip(&responder->node->tips, tip)) != RC_OK) {
         return ret;
@@ -143,7 +143,7 @@ static void *responder_routine(responder_t *const responder) {
   lock_handle_lock(&lock_cond);
 
   while (responder->running) {
-    if (responder_size(responder) == 0) {
+    if (responder_is_empty(responder)) {
       cond_handle_timedwait(&responder->cond, &lock_cond,
                             RESPONDER_TIMEOUT_SEC);
     }

--- a/gossip/components/responder.h
+++ b/gossip/components/responder.h
@@ -102,6 +102,17 @@ retcode_t responder_on_next(responder_t *const responder,
  */
 size_t responder_size(responder_t *const responder);
 
+/**
+ * Tells whether the responder queue is empty or not
+ *
+ * @param responder The responder
+ *
+ * @return true if empty, false otherwise
+ */
+static inline bool responder_is_empty(responder_t *const responder) {
+  return responder->queue == NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/gossip/components/transaction_requester.h
+++ b/gossip/components/transaction_requester.h
@@ -124,6 +124,18 @@ retcode_t get_transaction_to_request(
     transaction_requester_t *const transaction_requester,
     flex_trit_t *const hash, bool const milestone);
 
+/**
+ * Tells whether the requester queue is empty or not
+ *
+ * @param requester The requester
+ *
+ * @return true if empty, false otherwise
+ */
+static inline bool requester_is_empty(
+    transaction_requester_t *const requester) {
+  return requester->milestones == NULL && requester->transactions == NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/gossip/components/transaction_requester_worker.c
+++ b/gossip/components/transaction_requester_worker.c
@@ -14,7 +14,6 @@
 
 #define REQUESTER_LOGGER_ID "requester"
 #define REQUESTER_INTERVAL 10
-#define REQUESTER_THRESHOLD 100
 
 /*
  * Private functions
@@ -33,7 +32,7 @@ static void *transaction_requester_routine(
   }
 
   while (transaction_requester->running) {
-    if (requester_size(transaction_requester) <= REQUESTER_THRESHOLD) {
+    if (requester_is_empty(transaction_requester)) {
       goto sleep;
     }
     tips_cache_random_tip(&transaction_requester->node->tips, hash);


### PR DESCRIPTION
Since gossip queues can be filled with several thousand elements, prefer using `*_is_empty` functions instead of `*_size` function whenever possible.

# Test Plan:
CI
