### PR TITLE
storage: do not select deltas on milestone loading

### DIFF
--- a/common/storage/sql/statements.c
+++ b/common/storage/sql/statements.c
@@ -205,19 +205,22 @@ char *iota_statement_milestone_insert =
     "," MILESTONE_COL_HASH ")VALUES(?,?)";
 
 char *iota_statement_milestone_select_by_hash =
-    "SELECT * FROM " MILESTONE_TABLE_NAME " WHERE " MILESTONE_COL_HASH "=?";
+    "SELECT " MILESTONE_COL_INDEX "," MILESTONE_COL_HASH
+    " FROM " MILESTONE_TABLE_NAME " WHERE " MILESTONE_COL_HASH "=?";
 
 char *iota_statement_milestone_select_first =
-    "SELECT * FROM " MILESTONE_TABLE_NAME " ORDER BY " MILESTONE_COL_INDEX
+    "SELECT " MILESTONE_COL_INDEX "," MILESTONE_COL_HASH
+    " FROM " MILESTONE_TABLE_NAME " ORDER BY " MILESTONE_COL_INDEX
     " ASC LIMIT 1";
 
 char *iota_statement_milestone_select_last =
-    "SELECT * FROM " MILESTONE_TABLE_NAME " ORDER BY " MILESTONE_COL_INDEX
+    "SELECT " MILESTONE_COL_INDEX "," MILESTONE_COL_HASH
+    " FROM " MILESTONE_TABLE_NAME " ORDER BY " MILESTONE_COL_INDEX
     " DESC LIMIT 1";
 
 char *iota_statement_milestone_select_next =
-    "SELECT * FROM " MILESTONE_TABLE_NAME " WHERE " MILESTONE_COL_INDEX
-    "=(?+1)";
+    "SELECT " MILESTONE_COL_INDEX "," MILESTONE_COL_HASH
+    " FROM " MILESTONE_TABLE_NAME " WHERE " MILESTONE_COL_INDEX "=(?+1)";
 
 char *iota_statement_milestone_exist =
     "SELECT 1 WHERE EXISTS(SELECT 1 "


### PR DESCRIPTION
In this PR, we do not select deltas anymore since they are not part of the actual milestone model, are heavy and should only be handled by `iota_stor_state_delta_store` and `iota_stor_state_delta_load`.

Fixes #612 

# Test Plan:
CI
