### PR TITLE
Exit probs mapping

### DIFF
--- a/consensus/exit_probability_randomizer/BUILD
+++ b/consensus/exit_probability_randomizer/BUILD
@@ -1,7 +1,37 @@
 cc_library(
-    name = "exit_probability_randomizer",
+    name = "global_calcs",
+    srcs = ["global_calcs.c"],
+    hdrs = ["global_calcs.h"],
+    deps = [
+        "//common:errors",
+        "//common/trinary:flex_trit",
+        "//consensus/cw_rating_calculator",
+        "//utils/handles:rand",
+    ],
+)
+
+cc_library(
+    name = "shared",
     visibility = ["//visibility:public"],
     deps = [
+        ":global_calcs",
+        "//common:errors",
+        "//common/trinary:flex_trit",
+        "//consensus/cw_rating_calculator",
+        "//consensus/exit_probability_validator",
+        "//consensus/tangle",
+        "//utils:logger_helper",
+        "//utils/containers/hash:hash_double_map",
+        "//utils/handles:rand",
+    ],
+)
+
+cc_library(
+    name = "exit_probability_randomizer",
+    srcs = ["exit_probability_randomizer.c"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":exit_prob_map",
         ":walker",
     ],
 )
@@ -9,7 +39,6 @@ cc_library(
 cc_library(
     name = "walker",
     srcs = [
-        "exit_probability_randomizer.c",
         "walker.c",
     ],
     hdrs = [
@@ -18,12 +47,21 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//common:errors",
-        "//common/trinary:trit_array",
-        "//consensus/cw_rating_calculator",
-        "//consensus/exit_probability_validator",
-        "//consensus/tangle",
-        "//utils:logger_helper",
-        "//utils/handles:rand",
+        ":shared",
+    ],
+)
+
+cc_library(
+    name = "exit_prob_map",
+    srcs = [
+        "exit_prob_map.c",
+    ],
+    hdrs = [
+        "exit_prob_map.h",
+        "exit_probability_randomizer.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":shared",
     ],
 )

--- a/consensus/exit_probability_randomizer/exit_prob_map.c
+++ b/consensus/exit_probability_randomizer/exit_prob_map.c
@@ -35,7 +35,7 @@ static void iota_consensus_exit_prob_map_add_exit_probs(
 static retcode_t iota_consensus_exit_prob_remove_invalid_tip_candidates(
     cw_calc_result *const cw_result,
     exit_prob_transaction_validator_t *const ep_validator) {
-  retcode_t ret;
+  retcode_t ret = RC_OK;
   hash243_set_entry_t *tip_entry = NULL;
   hash243_set_entry_t *tip_tmp_entry = NULL;
   hash243_set_t tips = NULL;
@@ -47,18 +47,20 @@ static retcode_t iota_consensus_exit_prob_remove_invalid_tip_candidates(
              ep_validator, tip_entry->hash, &has_valid_tail)) != RC_OK) {
       log_error(EXIT_PROB_MAP_LOGGER_ID,
                 "Tail transaction validation failed: %" PRIu64 "\n", ret);
-      return ret;
+      goto done;
     }
     if (!has_valid_tail) {
       if (!hash_to_indexed_hash_set_map_find(
               &cw_result->tx_to_approvers, tip_entry->hash, &approvers_entry)) {
-        return RC_OK;
+        goto done;
       }
       hash243_set_remove(&approvers_entry->approvers, tip_entry->hash);
     }
   }
+
+done:
   hash243_set_free(&tips);
-  return RC_OK;
+  return ret;
 }
 
 /*

--- a/consensus/exit_probability_randomizer/exit_prob_map.c
+++ b/consensus/exit_probability_randomizer/exit_prob_map.c
@@ -178,9 +178,7 @@ retcode_t iota_consensus_exit_prob_map_calculate_probs(
       approver_idx++;
     }
 
-    if (!iota_consensus_is_tx_a_tip(&cw_rhash_to_indexed_hash_set_entry_t
-                                        *approvers_entry = NULL;
-                                    esult->tx_to_approvers, curr_tx)) {
+    if (!iota_consensus_is_tx_a_tip(&cw_result->tx_to_approvers, curr_tx)) {
       curr_tx_entry->value = 0;
     }
 

--- a/consensus/exit_probability_randomizer/exit_prob_map.c
+++ b/consensus/exit_probability_randomizer/exit_prob_map.c
@@ -26,7 +26,6 @@ static void iota_consensus_exit_prob_map_add_exit_probs(
   hash_to_double_map_entry_t *curr_approver_entry = NULL;
   if (hash_to_double_map_find(*hash_to_probs, hash, &curr_approver_entry)) {
     curr_approver_entry->value += value;
-
   } else {
     hash_to_double_map_add(*hash_to_probs, hash, value);
   }
@@ -82,9 +81,7 @@ retcode_t iota_consensus_exit_prob_map_randomize(
     flex_trit_t *tip) {
   retcode_t ret;
   ep_prob_map_randomizer_t *prob_randomizer =
-      (ep_prob_map_randomizer_t *const)randomizer;
-
-  double rand_weight;
+      (ep_prob_map_randomizer_t *)randomizer;
 
   if (prob_randomizer->exit_probs == NULL) {
     if ((ret = iota_consensus_exit_prob_map_calculate_probs(
@@ -98,7 +95,7 @@ retcode_t iota_consensus_exit_prob_map_randomize(
   hash243_set_t tips = NULL;
   iota_consensus_exit_prob_map_eps_extract_tips(cw_result, &tips);
   // Randomizes uniformly a value between 0 to 1
-  rand_weight = rand_handle_probability();
+  double rand_weight = rand_handle_probability();
   hash243_set_entry_t *tip_entry = NULL;
   hash243_set_entry_t *tip_tmp_entry = NULL;
   hash_to_double_map_entry_t *curr_ep = NULL;

--- a/consensus/exit_probability_randomizer/exit_prob_map.h
+++ b/consensus/exit_probability_randomizer/exit_prob_map.h
@@ -26,6 +26,14 @@ struct ep_prob_map_randomizer_s {
   hash_to_double_map_t transition_probs;
 };
 
+/**
+ * Resets the exit and transition probabilities maps so it can be recalculated,
+ * This function needs to be locked for write
+ *
+ * @param exit_probability_randomizer The base class
+ *
+ * @return void
+ */
 void iota_consensus_exit_prob_map_reset(
     ep_randomizer_t *const exit_probability_randomizer);
 
@@ -41,6 +49,8 @@ void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer);
  * "iota_consensus_exit_prob_map_reset" before randomizing again, to get a new
  * exit probabilities calculation
  *
+ * This function needs to be locked for read
+ *
  * @param exit_probability_randomizer The base class
  * @param ep_validator The validator - used for the entry point
  * @param cw_result The cumulative weight data
@@ -49,7 +59,6 @@ void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer);
  *
  * @return a status code
  */
-
 retcode_t iota_consensus_exit_prob_map_randomize(
     ep_randomizer_t const *const exit_probability_randomizer,
     exit_prob_transaction_validator_t *const ep_validator,
@@ -57,6 +66,8 @@ retcode_t iota_consensus_exit_prob_map_randomize(
     flex_trit_t *tip);
 /**
  * Calculates exit and overall transition probabilities
+ *
+ * This function needs to be locked for write
  *
  * @param exit_probability_randomizer The base class
  * @param ep_validator The validator - used for the entry point
@@ -69,7 +80,6 @@ retcode_t iota_consensus_exit_prob_map_randomize(
  *
  * @return a status code
  */
-
 retcode_t iota_consensus_exit_prob_map_calculate_probs(
     ep_randomizer_t const *const exit_probability_randomizer,
     exit_prob_transaction_validator_t *const ep_validator,
@@ -80,23 +90,25 @@ retcode_t iota_consensus_exit_prob_map_calculate_probs(
 /**
  * Virtual distructor
  *
+ * This function needs to be locked for write
+ *
  * @param exit_probability_randomizer The base class
  *
  * @return void
  */
-
 void iota_consensus_exit_prob_map_destroy(
     ep_randomizer_t *const exit_probability_randomizer);
 
 /**
  * Extracts tips into set
  *
+ * This function needs to be locked for read
+ *
  * @param cw_result The cumulative weight data
  * @param tips The result set
  *
  * @return void
  */
-
 void iota_consensus_exit_prob_map_eps_extract_tips(
     cw_calc_result *const cw_result, hash243_set_t *const tips);
 

--- a/consensus/exit_probability_randomizer/exit_prob_map.h
+++ b/consensus/exit_probability_randomizer/exit_prob_map.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef __CONSENSUS_EXIT_PROBABILITY_RANDOMIZER_EXIT_PROB_MAP_H__
+#define __CONSENSUS_EXIT_PROBABILITY_RANDOMIZER_EXIT_PROB_MAP_H__
+
+#include "common/errors.h"
+#include "consensus/cw_rating_calculator/cw_rating_calculator.h"
+#include "consensus/exit_probability_randomizer/exit_probability_randomizer.h"
+#include "consensus/exit_probability_validator/exit_probability_validator.h"
+#include "utils/containers/hash/hash_double_map.h"
+#include "utils/time.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ep_prob_map_randomizer_s ep_prob_map_randomizer_t;
+struct ep_prob_map_randomizer_s {
+  ep_randomizer_t base;
+  hash_to_double_map_t exit_probs;
+  hash_to_double_map_t transition_probs;
+};
+
+void iota_consensus_exit_prob_map_reset(
+    ep_randomizer_t *const exit_probability_randomizer);
+
+void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer);
+
+retcode_t iota_consensus_exit_prob_map_randomize(
+    ep_randomizer_t const *const exit_probability_randomizer,
+    exit_prob_transaction_validator_t *const ep_validator,
+    cw_calc_result *const cw_result, flex_trit_t const *const ep,
+    flex_trit_t *tip);
+/**
+ * Calculates exit and overall transition probabilities
+ *
+ * @param exit_probability_randomizer The base class
+ * @param ep_validator The validator - used for the entry point
+ * @param cw_result The cumulative weight data, Null means that cw will be
+ * recalculated
+ * @param ep The entry point hash
+ * @param hash_to_exit_probs The mapping of the calculated exit probabilities -
+ * non tips will have 0 probability
+ * @param hash_to_trans_probs The mapping of the calculated transition
+ * probabilities
+ *
+ * @return a status code
+ */
+
+retcode_t iota_consensus_exit_prob_map_calculate_probs(
+    ep_randomizer_t const *const exit_probability_randomizer,
+    exit_prob_transaction_validator_t *const ep_validator,
+    cw_calc_result *const cw_result, flex_trit_t const *const ep,
+    hash_to_double_map_t *const hash_to_exit_probs,
+    hash_to_double_map_t *const hash_to_trans_probs);
+
+/**
+ * Virtual distructor
+ *
+ * @param exit_probability_randomizer The base class
+ *
+ * @return void
+ */
+
+void iota_consensus_exit_prob_map_destroy(
+    ep_randomizer_t *const exit_probability_randomizer);
+
+/**
+ * Extracts tips into set
+ *
+ * @param cw_result The cumulative weight data
+ * @param tips The result set
+ *
+ * @return void
+ */
+
+void iota_consensus_exit_prob_map_eps_extract_tips(
+    cw_calc_result *const cw_result, hash243_set_t *const tips);
+
+double iota_consensus_exit_prob_map_sum_probs(
+    hash_to_double_map_t *const hash_to_probs);
+
+static ep_randomizer_vtable exit_prob_map_vtable = {
+    .exit_probability_randomize = iota_consensus_exit_prob_map_randomize,
+    .exit_probability_destroy = iota_consensus_exit_prob_map_destroy,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __CONSENSUS_EXIT_PROBABILITY_RANDOMIZER_EXIT_PROB_MAP_H__

--- a/consensus/exit_probability_randomizer/exit_prob_map.h
+++ b/consensus/exit_probability_randomizer/exit_prob_map.h
@@ -31,6 +31,25 @@ void iota_consensus_exit_prob_map_reset(
 
 void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer);
 
+/**
+ * Randomize a tip selection based on exit probabilities
+ * This implementation does not validate the entry point upon
+ * every randomization but rather when the entire exit probabilities map
+ * is being calculated (when "iota_consensus_exit_prob_map_calculate_probs" is
+ * called), when the Tangle is updated with new transaction user should
+ * recalculate "cw_result" and make sure to call
+ * "iota_consensus_exit_prob_map_reset" before randomizing again, to get a new
+ * exit probabilities calculation
+ *
+ * @param exit_probability_randomizer The base class
+ * @param ep_validator The validator - used for the entry point
+ * @param cw_result The cumulative weight data
+ * @param ep The entry point hash - this is not required in this implementation
+ * @param tip The selected tip hash
+ *
+ * @return a status code
+ */
+
 retcode_t iota_consensus_exit_prob_map_randomize(
     ep_randomizer_t const *const exit_probability_randomizer,
     exit_prob_transaction_validator_t *const ep_validator,
@@ -41,8 +60,7 @@ retcode_t iota_consensus_exit_prob_map_randomize(
  *
  * @param exit_probability_randomizer The base class
  * @param ep_validator The validator - used for the entry point
- * @param cw_result The cumulative weight data, Null means that cw will be
- * recalculated
+ * @param cw_result The cumulative weight data
  * @param ep The entry point hash
  * @param hash_to_exit_probs The mapping of the calculated exit probabilities -
  * non tips will have 0 probability

--- a/consensus/exit_probability_randomizer/exit_probability_randomizer.c
+++ b/consensus/exit_probability_randomizer/exit_probability_randomizer.c
@@ -6,6 +6,7 @@
  */
 
 #include "consensus/exit_probability_randomizer/exit_probability_randomizer.h"
+#include "consensus/exit_probability_randomizer/exit_prob_map.h"
 #include "consensus/exit_probability_randomizer/walker.h"
 #include "utils/handles/rand.h"
 #include "utils/logger_helper.h"
@@ -22,6 +23,8 @@ retcode_t iota_consensus_ep_randomizer_init(
   ep_randomizer->tangle = tangle;
   if (impl == EP_RANDOM_WALK) {
     iota_consensus_random_walker_init(ep_randomizer);
+  } else if (impl == EP_RANDOMIZE_MAP_AND_SAMPLE) {
+    iota_consensus_exit_prob_map_init(ep_randomizer);
   } else if (impl == EP_NO_IMPLEMENTATION) {
     return RC_CONSENSUS_NOT_IMPLEMENTED;
   }

--- a/consensus/exit_probability_randomizer/exit_probability_randomizer.c
+++ b/consensus/exit_probability_randomizer/exit_probability_randomizer.c
@@ -33,6 +33,9 @@ retcode_t iota_consensus_ep_randomizer_init(
 
 retcode_t iota_consensus_ep_randomizer_destroy(
     ep_randomizer_t *const ep_randomizer) {
+  if (ep_randomizer->base.vtable.exit_probability_destroy != NULL) {
+    ep_randomizer->base.vtable.exit_probability_destroy(ep_randomizer);
+  }
   logger_helper_destroy(EXIT_PROBABILITY_RANDOMIZER_LOGGER_ID);
   ep_randomizer->tangle = NULL;
   return RC_OK;

--- a/consensus/exit_probability_randomizer/exit_probability_randomizer.h
+++ b/consensus/exit_probability_randomizer/exit_probability_randomizer.h
@@ -36,6 +36,9 @@ typedef struct {
       exit_prob_transaction_validator_t *const epv,
       cw_calc_result *const cw_result, flex_trit_t const *const ep,
       flex_trit_t *const tip);
+
+  void (*exit_probability_destroy)(ep_randomizer_t const *const ep_randomizer);
+
 } ep_randomizer_vtable;
 
 struct ep_randomizer_base_s {

--- a/consensus/exit_probability_randomizer/exit_probability_randomizer.h
+++ b/consensus/exit_probability_randomizer/exit_probability_randomizer.h
@@ -26,7 +26,7 @@ typedef struct ep_randomizer_s ep_randomizer_t;
 typedef enum ep_randomizer_implementation_e {
   EP_NO_IMPLEMENTATION,
   EP_RANDOM_WALK,
-  EP_RANDOMIZE_SAMPLE,
+  EP_RANDOMIZE_MAP_AND_SAMPLE,
 } ep_randomizer_implementation_t;
 
 typedef struct {

--- a/consensus/exit_probability_randomizer/global_calcs.c
+++ b/consensus/exit_probability_randomizer/global_calcs.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "consensus/exit_probability_randomizer/global_calcs.h"
+#include <math.h>
+#include "utils/macros.h"
+
+retcode_t map_transition_probabilities(double alpha,
+                                       hash_to_int64_t_map_t const cw_ratings,
+                                       hash243_set_t const *const approvers,
+                                       double transition_probs[]) {
+  hash243_set_entry_t *curr_approver = NULL;
+  hash243_set_entry_t *tmp_approver = NULL;
+  hash_to_int64_t_map_entry_t const *curr_rating = NULL;
+  size_t num_approvers = hash243_set_size(approvers);
+  double sum_transition_probabilities = 0;
+  double target = 0;
+  double max_weight = 0;
+  size_t idx = 0;
+
+  HASH_ITER(hh, *approvers, curr_approver, tmp_approver) {
+    if (!hash_to_int64_t_map_find(&cw_ratings, curr_approver->hash,
+                                  &curr_rating)) {
+      return RC_CONSENSUS_EXIT_PROBABILITIES_MISSING_RATING;
+    }
+    transition_probs[idx++] = curr_rating->value;
+    max_weight = MAX(max_weight, curr_rating->value);
+  }
+  for (idx = 0; idx < num_approvers; ++idx) {
+    transition_probs[idx] -= max_weight;
+    transition_probs[idx] = exp(transition_probs[idx] * alpha);
+    sum_transition_probabilities += transition_probs[idx];
+  }
+
+  for (idx = 0; idx < num_approvers; ++idx) {
+    transition_probs[idx] /= sum_transition_probabilities;
+  }
+  return RC_OK;
+}

--- a/consensus/exit_probability_randomizer/global_calcs.h
+++ b/consensus/exit_probability_randomizer/global_calcs.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef __CONSENSUS_EXIT_PROBABILITY_RANDOMIZER_GLOBAL_CALCS_H__
+#define __CONSENSUS_EXIT_PROBABILITY_RANDOMIZER_GLOBAL_CALCS_H__
+
+#include "common/errors.h"
+#include "consensus/cw_rating_calculator/cw_rating_calculator.h"
+#include "utils/containers/hash/hash_int64_t_map.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Maps transition probabilities to direct approvers
+ *
+ * @param alpha The alpha param of the random walk
+ * @param cw_ratings The cumulative weights data
+ * @param approvers The set of direct approvers
+ * @param transition_probs The result is in the order of iteration over
+ * "approvers"
+ *
+ * @return a status code
+ */
+
+extern retcode_t map_transition_probabilities(
+    double alpha, hash_to_int64_t_map_t const cw_ratings,
+    hash243_set_t const *const approvers, double transition_probs[]);
+
+static inline bool iota_consensus_is_tx_a_tip(
+    hash_to_indexed_hash_set_map_t const *const tx_to_approvers,
+    flex_trit_t const *const tx) {
+  hash_to_indexed_hash_set_entry_t *aps = NULL;
+  hash_to_indexed_hash_set_map_find(tx_to_approvers, tx, &aps);
+  return hash243_set_size(&aps->approvers) == 0;
+}
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __CONSENSUS_EXIT_PROBABILITY_RANDOMIZER_GLOBAL_CALCS_H__

--- a/consensus/exit_probability_randomizer/walker.h
+++ b/consensus/exit_probability_randomizer/walker.h
@@ -12,6 +12,7 @@
 #include "consensus/cw_rating_calculator/cw_rating_calculator.h"
 #include "consensus/exit_probability_randomizer/exit_probability_randomizer.h"
 #include "consensus/exit_probability_validator/exit_probability_validator.h"
+#include "utils/containers/hash/hash_double_map.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,7 +23,6 @@ void iota_consensus_random_walker_init(ep_randomizer_t *const randomizer);
 retcode_t iota_consensus_random_walker_randomize(
     ep_randomizer_t const *const exit_probability_randomizer,
     exit_prob_transaction_validator_t *const ep_validator,
-
     cw_calc_result *const cw_result, flex_trit_t const *const ep,
     flex_trit_t *tip);
 

--- a/consensus/exit_probability_randomizer/walker.h
+++ b/consensus/exit_probability_randomizer/walker.h
@@ -28,6 +28,7 @@ retcode_t iota_consensus_random_walker_randomize(
 
 static ep_randomizer_vtable random_walk_vtable = {
     .exit_probability_randomize = iota_consensus_random_walker_randomize,
+    .exit_probability_destroy = NULL,
 };
 
 #ifdef __cplusplus

--- a/utils/containers/hash/BUILD
+++ b/utils/containers/hash/BUILD
@@ -86,6 +86,10 @@ hash_map_generate(
     mapped_type = "int64_t",
 )
 
+hash_map_generate(
+    mapped_type = "double",
+)
+
 cc_library(
     name = "hash_array",
     srcs = ["hash_array.c"],

--- a/utils/containers/hash/hash_map.c.tpl
+++ b/utils/containers/hash/hash_map.c.tpl
@@ -65,6 +65,6 @@ void hash_to_{TYPE}_map_keys(hash_to_{TYPE}_map_t *const map, hash243_set_t * co
   hash_to_{TYPE}_map_entry_t *curr_entry = NULL;
   hash_to_{TYPE}_map_entry_t *tmp_entry = NULL;
   HASH_ITER(hh, *map, curr_entry, tmp_entry) {
-  hash243_set_add(keys,curr_entry->hash);
+    hash243_set_add(keys,curr_entry->hash);
   }
 }

--- a/utils/containers/hash/hash_map.c.tpl
+++ b/utils/containers/hash/hash_map.c.tpl
@@ -10,7 +10,7 @@
 
 retcode_t hash_to_{TYPE}_map_add(hash_to_{TYPE}_map_t *const map,
                                   flex_trit_t const *const hash,
-                                  {TYPE} const value) {
+                                  {TYPE} value) {
   hash_to_{TYPE}_map_entry_t *map_entry = NULL;
   map_entry = (hash_to_{TYPE}_map_entry_t *)malloc(
       sizeof(hash_to_{TYPE}_map_entry_t));
@@ -59,4 +59,12 @@ void hash_to_{TYPE}_map_free(hash_to_{TYPE}_map_t *const map) {
     free(curr_entry);
   }
   *map = NULL;
+}
+
+void hash_to_{TYPE}_map_keys(hash_to_{TYPE}_map_t *const map, hash243_set_t * const keys){
+  hash_to_{TYPE}_map_entry_t *curr_entry = NULL;
+  hash_to_{TYPE}_map_entry_t *tmp_entry = NULL;
+  HASH_ITER(hh, *map, curr_entry, tmp_entry) {
+  hash243_set_add(keys,curr_entry->hash);
+  }
 }

--- a/utils/containers/hash/hash_map.h.tpl
+++ b/utils/containers/hash/hash_map.h.tpl
@@ -12,6 +12,7 @@
 
 #include "common/errors.h"
 #include "common/trinary/flex_trit.h"
+#include "utils/containers/hash/hash243_set.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +35,8 @@ bool hash_to_{TYPE}_map_find(hash_to_{TYPE}_map_t const *const map,
         flex_trit_t const *const hash,
 hash_to_{TYPE}_map_entry_t ** const res);
 void hash_to_{TYPE}_map_free(hash_to_{TYPE}_map_t *const map);
-
+void hash_to_{TYPE}_map_keys(hash_to_{TYPE}_map_t *const map,
+                             hash243_set_t * const keys);
 
 #ifdef __cplusplus
 }

--- a/utils/containers/hash/hash_map_generator.bzl
+++ b/utils/containers/hash/hash_map_generator.bzl
@@ -47,6 +47,7 @@ def hash_map_generate(mapped_type):
             "//common:errors",
             "//common/trinary:flex_trit",
             "//utils/handles:rand",
+            "//utils/containers/hash:hash243_set",
             "@com_github_uthash//:uthash",
         ],
         visibility = ["//visibility:public"],


### PR DESCRIPTION
- This PR includes an implementation for tip selection that rather than performing random-walk whenever 
asking for a tip, this implementation maps all tips to their exit probabilities and allows sampling from them
- Allows multiple - relatively cheap tip selections until tangle is updated
- Allows querying for a tip's exit probability