### PR TITLE
consensus/exit_probablility_validator: 

### DIFF
--- a/consensus/exit_probability_validator/exit_probability_validator.c
+++ b/consensus/exit_probability_validator/exit_probability_validator.c
@@ -128,7 +128,7 @@ retcode_t iota_consensus_exit_prob_transaction_validator_below_max_depth(
     if (hash243_set_size(&visited_hashes) == epv->conf->below_max_depth) {
       log_error(WALKER_VALIDATOR_LOGGER_ID,
                 "Validation failed, exceeded num of transactions\n");
-      *below_max_depth = false;
+      *below_max_depth = true;
       break;
     }
 

--- a/consensus/exit_probability_validator/tests/exit_probability_validator.c
+++ b/consensus/exit_probability_validator/tests/exit_probability_validator.c
@@ -223,7 +223,7 @@ void test_transaction_exceed_max_transactions() {
   bool is_valid = false;
   TEST_ASSERT(iota_consensus_exit_prob_transaction_validator_is_valid(
                   &epv, transaction_hash(txs[0]), &is_valid) == RC_OK);
-  TEST_ASSERT(is_valid);
+  TEST_ASSERT(!is_valid);
 
   transactions_free(txs, 2);
   destroy_epv(&epv);


### PR DESCRIPTION
below_max_depth:
 - pop from stack before pushing branch/trunk
- don't load tx for it's snapshot_index when hash is genesis's
- remove irrelevant test
- fix valid_transaction test
