### PR TITLE
consensus/exit_probablility_randomizer: exit_prob_map

### DIFF
--- a/consensus/exit_probability_randomizer/exit_prob_map.h
+++ b/consensus/exit_probability_randomizer/exit_prob_map.h
@@ -35,9 +35,10 @@ struct ep_prob_map_randomizer_s {
  * @return a status code
  */
 retcode_t iota_consensus_exit_prob_map_reset(
-    ep_randomizer_t *const exit_probability_randomizer);
+    ep_prob_map_randomizer_t *const exit_probability_randomizer);
 
-void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer);
+void iota_consensus_exit_prob_map_init(
+    ep_prob_map_randomizer_t *const randomizer);
 
 /**
  * Randomize a tip selection based on exit probabilities
@@ -60,7 +61,7 @@ void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer);
  * @return a status code
  */
 retcode_t iota_consensus_exit_prob_map_randomize(
-    ep_randomizer_t const *const exit_probability_randomizer,
+    ep_prob_map_randomizer_t const *const exit_probability_randomizer,
     tangle_t *const tangle,
     exit_prob_transaction_validator_t *const ep_validator,
     cw_calc_result *const cw_result, flex_trit_t const *const ep,
@@ -82,7 +83,7 @@ retcode_t iota_consensus_exit_prob_map_randomize(
  * @return a status code
  */
 retcode_t iota_consensus_exit_prob_map_calculate_probs(
-    ep_randomizer_t const *const exit_probability_randomizer,
+    ep_prob_map_randomizer_t const *const exit_probability_randomizer,
     tangle_t *const tangle,
     exit_prob_transaction_validator_t *const ep_validator,
     cw_calc_result *const cw_result, flex_trit_t const *const ep,
@@ -99,7 +100,7 @@ retcode_t iota_consensus_exit_prob_map_calculate_probs(
  * @return a statuc code
  */
 retcode_t iota_consensus_exit_prob_map_destroy(
-    ep_randomizer_t *const exit_probability_randomizer);
+    ep_prob_map_randomizer_t *const exit_probability_randomizer);
 
 /**
  * Extracts tips into set

--- a/consensus/exit_probability_randomizer/exit_probability_randomizer.c
+++ b/consensus/exit_probability_randomizer/exit_probability_randomizer.c
@@ -22,7 +22,8 @@ retcode_t iota_consensus_ep_randomizer_init(
   if (impl == EP_RANDOM_WALK) {
     iota_consensus_random_walker_init(ep_randomizer);
   } else if (impl == EP_RANDOMIZE_MAP_AND_SAMPLE) {
-    iota_consensus_exit_prob_map_init(ep_randomizer);
+    iota_consensus_exit_prob_map_init(
+        (ep_prob_map_randomizer_t *)ep_randomizer);
   } else if (impl == EP_NO_IMPLEMENTATION) {
     return RC_CONSENSUS_NOT_IMPLEMENTED;
   }


### PR DESCRIPTION
- On both virtual and non virtual functions inside `exit_prob_map`, accept explicitly the derived class ptr to 
  avoid casting