### PR TITLE
storage: open connection in no mutex mode

### DIFF
--- a/common/storage/sql/sqlite3/connection.c
+++ b/common/storage/sql/sqlite3/connection.c
@@ -38,7 +38,7 @@ retcode_t connection_init(connection_t const* const conn,
   log_info(SQLITE3_LOGGER_ID, "Connection to database %s created\n",
            config->db_path);
 
-  if ((rc = sqlite3_busy_timeout((sqlite3*)conn->db, 1000)) != SQLITE_OK) {
+  if ((rc = sqlite3_busy_timeout((sqlite3*)conn->db, 10000)) != SQLITE_OK) {
     return RC_SQLITE3_FAILED_CONFIG;
   }
 


### PR DESCRIPTION
To fully benefit from multi-threaded sqlite3, connections need to be open in no-mutex mode.
Also includes increasing busy signal.

https://www.sqlite.org/c3ref/open.html
> If the SQLITE_OPEN_NOMUTEX flag is set, then the database connection opens in the multi-thread threading mode as long as the single-thread mode has not been set at compile-time or start-time.

# Test Plan:
CI
