### PR TITLE
processor: do not log invalid transactions as errors

### DIFF
--- a/consensus/transaction_validator/tests/test_transaction_validator.c
+++ b/consensus/transaction_validator/tests/test_transaction_validator.c
@@ -31,7 +31,7 @@ void transaction_invalid_value() {
   conf.snapshot_timestamp_sec = transaction_attachment_timestamp(tx1) / 1000;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
   transaction_set_value(tx1, -IOTA_SUPPLY - 1);
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -50,7 +50,7 @@ void transaction_invalid_hash() {
   conf.snapshot_timestamp_sec = transaction_attachment_timestamp(tx1) / 1000;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
   tx1->consensus.hash[FLEX_TRIT_SIZE_243 - 1] = tx1->consensus.hash[0];
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -70,7 +70,7 @@ void transaction_invalid_attachment_timestamp_too_futuristic() {
   transaction_validator_t tv;
   conf.snapshot_timestamp_sec = 0;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -89,7 +89,7 @@ void transaction_invalid_attachment_timestamp_too_old() {
   conf.snapshot_timestamp_sec = current_timestamp_ms() / 1000;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
   tx1->consensus.hash[FLEX_TRIT_SIZE_243 - 1] = tx1->consensus.hash[0];
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -109,7 +109,7 @@ void transaction_invalid_value_tx_wrong_address() {
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
   transaction_address(tx1)[FLEX_TRIT_SIZE_243 - 1] =
       transaction_address(tx1)[4];
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -129,7 +129,7 @@ void transaction_invalid_timestamp_too_futuristic() {
   transaction_validator_t tv;
   conf.snapshot_timestamp_sec = 0;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -150,7 +150,7 @@ void transaction_invalid_timestamp_too_old() {
   transaction_validator_t tv;
   conf.snapshot_timestamp_sec = current_time / 1000;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1) == false);
+  TEST_ASSERT_FALSE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);
@@ -168,7 +168,7 @@ void transaction_is_valid() {
   transaction_validator_t tv;
   conf.snapshot_timestamp_sec = transaction_attachment_timestamp(tx1) / 1000;
   TEST_ASSERT(iota_consensus_transaction_validator_init(&tv, &conf) == RC_OK);
-  TEST_ASSERT(iota_consensus_transaction_validate(&tv, tx1));
+  TEST_ASSERT_TRUE(iota_consensus_transaction_validate(&tv, tx1));
 
   TEST_ASSERT(iota_consensus_transaction_validator_destroy(&tv) == RC_OK);
   transaction_free(tx1);

--- a/consensus/transaction_validator/transaction_validator.c
+++ b/consensus/transaction_validator/transaction_validator.c
@@ -50,19 +50,20 @@ retcode_t iota_consensus_transaction_validator_destroy(
 bool iota_consensus_transaction_validate(
     transaction_validator_t* const tv, iota_transaction_t* const transaction) {
   if (transaction_weight_magnitude(transaction) < tv->conf->mwm) {
-    log_error(TRANSACTION_VALIDATOR_LOGGER_ID,
-              "Validation failed, Invalid hash\n");
+    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
+              "Validation failed, invalid weight magnitude\n");
     return false;
   }
 
   if (has_invalid_timestamp(tv, transaction)) {
-    log_error(TRANSACTION_VALIDATOR_LOGGER_ID,
-              "Validation failed, Invalid timestamp\n");
+    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
+              "Validation failed, invalid timestamp\n");
     return false;
   }
+
   if (llabs(transaction_value(transaction)) > IOTA_SUPPLY) {
-    log_error(TRANSACTION_VALIDATOR_LOGGER_ID,
-              "Validation failed, Invalid value\n");
+    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
+              "Validation failed, invalid value\n");
     return false;
   }
 
@@ -72,8 +73,8 @@ bool iota_consensus_transaction_validate(
                       NUM_TRITS_PER_FLEX_TRIT, NUM_TRITS_PER_FLEX_TRIT);
   if (transaction_value(transaction) != 0 &&
       buffer[NUM_TRITS_PER_FLEX_TRIT - 1] != 0) {
-    log_error(TRANSACTION_VALIDATOR_LOGGER_ID,
-              "Validation failed, Invalid address for value transaction\n");
+    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
+              "Validation failed, invalid address for value transaction\n");
     return false;
   }
 

--- a/gossip/components/processor.c
+++ b/gossip/components/processor.c
@@ -79,8 +79,7 @@ static retcode_t process_transaction_bytes(processor_t const *const processor,
   // Validates the transaction
   if (!iota_consensus_transaction_validate(processor->transaction_validator,
                                            &transaction)) {
-    log_warning(PROCESSOR_LOGGER_ID, "Invalid transaction\n");
-    ret = RC_PROCESSOR_INVALID_TRANSACTION;
+    log_debug(PROCESSOR_LOGGER_ID, "Invalid transaction\n");
     goto failure;
   }
 


### PR DESCRIPTION
- Logs invalid transactions as debug instead of error
- Does not return an error when invalid transaction arrives anymore
- Reorganizes transaction validations blocks

# Test Plan:
CI
