### PR TITLE
milestone_tracker: fix milestone solidifier sleep value

### DIFF
--- a/consensus/milestone_tracker/milestone_tracker.h
+++ b/consensus/milestone_tracker/milestone_tracker.h
@@ -16,9 +16,6 @@
 #include "utils/handles/rw_lock.h"
 #include "utils/handles/thread.h"
 
-#define MILESTONE_VALIDATION_INTERVAL 10uLL
-#define SOLID_MILESTONE_RESCAN_INTERVAL 5000uLL
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Removes a potential bad sleep value due to an unsigned implicit cast resulting in very long sleep; hence blocking milestone solidification.

# Test Plan:
CI
