### PR TITLE
consensus/solidifer : Avoid DFS when not needed

### DIFF
--- a/consensus/transaction_solidifier/transaction_solidifier.c
+++ b/consensus/transaction_solidifier/transaction_solidifier.c
@@ -67,6 +67,13 @@ static retcode_t propagate_solid_transactions(
       break;
     }
 
+    if ((ret = iota_tangle_transaction_update_solid_state(
+             tangle, curr_entry->hash, true)) != RC_OK) {
+      log_error(TRANSACTION_SOLIDIFIER_LOGGER_ID,
+                "Updating solid state failed\n");
+      return ret;
+    }
+
     hash_pack_reset(&hash_pack);
     if ((ret = iota_tangle_transaction_load_hashes_of_approvers(
              tangle, curr_entry->hash, &hash_pack, 0)) != RC_OK) {
@@ -220,8 +227,6 @@ static retcode_t check_solidity_do_func(flex_trit_t *hash,
     is_in_new_solid_transactions_to_propagate =
         hash243_set_contains(ts->new_solid_transactions_to_propagate, hash);
     lock_handle_unlock(&ts->lock);
-    // We don't need to branch if current transaction is already found to be
-    // solid
     if (is_in_new_solid_transactions_to_propagate) {
       return RC_OK;
     }

--- a/consensus/transaction_solidifier/transaction_solidifier.c
+++ b/consensus/transaction_solidifier/transaction_solidifier.c
@@ -86,6 +86,9 @@ static retcode_t propagate_solid_transactions(
     for (size_t approver_index = 0; approver_index < hash_pack.num_loaded;
          ++approver_index) {
       approver_hash = ((flex_trit_t *)hash_pack.models[approver_index]);
+      if (hash243_set_contains(&transactions_to_propagate, approver_hash)) {
+        continue;
+      }
       if ((ret =
                iota_consensus_transaction_solidifier_check_and_update_solid_state(
                    ts, tangle, approver_hash)) != RC_OK) {
@@ -225,7 +228,7 @@ static retcode_t check_solidity_do_func(flex_trit_t *hash,
       !(transaction_solid((iota_transaction_t *)pack->models[0]))) {
     lock_handle_lock(&ts->lock);
     is_in_new_solid_transactions_to_propagate =
-        hash243_set_contains(ts->new_solid_transactions_to_propagate, hash);
+        hash243_set_contains(&ts->new_solid_transactions_to_propagate, hash);
     lock_handle_unlock(&ts->lock);
     if (is_in_new_solid_transactions_to_propagate) {
       return RC_OK;

--- a/consensus/transaction_solidifier/transaction_solidifier.h
+++ b/consensus/transaction_solidifier/transaction_solidifier.h
@@ -33,7 +33,7 @@ typedef struct transaction_solidifier_s {
   thread_handle_t thread;
   bool running;
   lock_handle_t lock;
-  hash243_set_t newly_set_solid_transactions;
+  hash243_set_t new_solid_transactions_to_propagate;
   tips_cache_t *tips;
 } transaction_solidifier_t;
 


### PR DESCRIPTION
- rename set
- do not branch if current traversed hash is already found to be solid in previous DFS traversal
