### PR TITLE
 common/trinary: trits and bytes conversions optimizations

### DIFF
--- a/common/defs.h
+++ b/common/defs.h
@@ -13,12 +13,20 @@
 // Trytes related definitions
 
 #define TRYTE_ALPHABET "9ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-#define TRYTE_SPACE 27
-#define TRYTE_VALUE_MAX 13
-#define TRYTE_VALUE_MIN -13
-#define TRYTE_WIDTH 3
 
 // Conversion definitions
+
+#define TRYTE_SPACE 27
+#define BYTE_SPACE 243
+
+#define TRYTE_VALUE_MAX 13
+#define BYTE_VALUE_MAX 121
+
+#define TRYTE_VALUE_MIN -13
+#define BYTE_VALUE_MIN -121
+
+#define TRYTE_WIDTH 3
+#define BYTE_WIDTH 5
 
 #define NUMBER_OF_TRITS_IN_A_TRYTE 3
 #define NUMBER_OF_TRITS_IN_A_BYTE 5

--- a/common/defs.h
+++ b/common/defs.h
@@ -13,6 +13,7 @@
 // Trytes related definitions
 
 #define TRYTE_ALPHABET "9ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#define TRYTE_SPACE 27
 #define TRYTE_VALUE_MAX 13
 #define TRYTE_VALUE_MIN -13
 #define TRYTE_WIDTH 3

--- a/common/trinary/BUILD
+++ b/common/trinary/BUILD
@@ -105,6 +105,7 @@ cc_library(
     hdrs = ["tryte_long.h"],
     deps = [
         ":tryte",
+        "//common:defs",
     ],
 )
 

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -79,12 +79,12 @@ size_t flex_trits_slice(flex_trit_t *const to_flex_trits, size_t const to_len,
       bytes_to_trits(((byte_t *)flex_trits + i + 1), 1, ((trit_t *)trits + 5),
                      5);
     }
-    to_flex_trits[j] = trits_to_byte(trits + offset, 0, 5);
+    to_flex_trits[j] = trits_to_byte(trits + offset, 5);
   }
   // There is a risk of noise after the last trit so we need to clean up
   uint8_t residual = num_trits % 5U;
   if (residual) {
-    to_flex_trits[num_bytes - 1] = trits_to_byte(trits + offset, 0, residual);
+    to_flex_trits[num_bytes - 1] = trits_to_byte(trits + offset, residual);
   }
 #endif
   return num_bytes;
@@ -285,7 +285,7 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
   if (num_trits > len || num_trits > to_len) {
     return 0;
   }
-  memset(bytes, 0, min_bytes(to_len));
+  memset(bytes, 0, MIN_BYTES(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
   trits_to_bytes((trit_t *)flex_trits, bytes, num_trits);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE) || \
@@ -312,7 +312,7 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
       offset += max_trits;
     }
     trits_for_byte = MIN(5, offset);
-    bytes[j] = trits_to_byte(shifter.trits, 0, trits_for_byte);
+    bytes[j] = trits_to_byte(shifter.trits, trits_for_byte);
 #if BYTE_ORDER == LITTLE_ENDIAN
     shifter.val = shifter.val >> 40;
 #elif BYTE_ORDER == BIG_ENDIAN
@@ -321,13 +321,13 @@ size_t flex_trits_to_bytes(byte_t *bytes, size_t to_len,
     offset -= 5;
   }
 #elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
-  size_t num_bytes = min_bytes(num_trits);
+  size_t num_bytes = MIN_BYTES(num_trits);
   size_t residual = num_trits % 5;
   if (residual) {
     trit_t last_byte[5] = {0};
     num_bytes--;
     byte_to_trits(flex_trits[num_bytes], last_byte, 5);
-    bytes[num_bytes] = trits_to_byte(last_byte, 0, residual);
+    bytes[num_bytes] = trits_to_byte(last_byte, residual);
   }
   memcpy(bytes, flex_trits, num_bytes);
 #endif
@@ -343,7 +343,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
   }
   memset(to_flex_trits, FLEX_TRIT_NULL_VALUE, NUM_FLEX_TRITS_FOR_TRITS(to_len));
 #if defined(FLEX_TRIT_ENCODING_1_TRIT_PER_BYTE)
-  size_t num_bytes = min_bytes(num_trits);
+  size_t num_bytes = MIN_BYTES(num_trits);
   bytes_to_trits(bytes, num_bytes, to_flex_trits, num_trits);
 #elif defined(FLEX_TRIT_ENCODING_3_TRITS_PER_BYTE) || \
     defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
@@ -373,13 +373,13 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len,
     offset -= trits_for_byte;
   }
 #elif defined(FLEX_TRIT_ENCODING_5_TRITS_PER_BYTE)
-  size_t num_bytes = min_bytes(num_trits);
+  size_t num_bytes = MIN_BYTES(num_trits);
   size_t residual = num_trits % 5;
   if (residual) {
     trit_t last_byte[5] = {0};
     num_bytes--;
     byte_to_trits(bytes[num_bytes], last_byte, 5);
-    to_flex_trits[num_bytes] = trits_to_byte(last_byte, 0, residual);
+    to_flex_trits[num_bytes] = trits_to_byte(last_byte, residual);
   }
   memcpy(to_flex_trits, bytes, num_bytes);
 #endif

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -153,7 +153,7 @@ static inline uint8_t flex_trits_set_at(flex_trit_t *const flex_trits,
   index = index / 5U;
   byte_to_trits(*(flex_trits + index), trits, 5);
   trits[tindex] = trit;
-  flex_trits[index] = trits_to_byte(trits, 0, 5);
+  flex_trits[index] = trits_to_byte(trits, 5);
 #endif
   return 1;
 }

--- a/common/trinary/tests/test_trit_byte.c
+++ b/common/trinary/tests/test_trit_byte.c
@@ -17,7 +17,7 @@
 void test_trit_to_byte(void) {
   trit_t trits[] = {TRITS_IN};
   size_t trits_size = sizeof(trits) / sizeof(trit_t);
-  byte_t bytes[min_bytes(trits_size)];
+  byte_t bytes[MIN_BYTES(trits_size)];
   byte_t exp[] = {BYTES_EXP};
   trits_to_bytes(trits, bytes, trits_size);
   TEST_ASSERT_EQUAL_MEMORY(exp, bytes, sizeof(exp));
@@ -27,7 +27,7 @@ void test_to_from_byte(void) {
   trit_t trits[] = {TRITS_IN};
   size_t trits_size = sizeof(trits) / sizeof(trit_t);
   trit_t trits_out[trits_size];
-  size_t bytes_size = min_bytes(trits_size);
+  size_t bytes_size = MIN_BYTES(trits_size);
   byte_t bytes[bytes_size];
   trits_to_bytes(trits, bytes, trits_size);
   bytes_to_trits(bytes, bytes_size, trits_out, trits_size);
@@ -40,7 +40,7 @@ void test_from_byte(void) {
   size_t trits_size = sizeof(trits) / sizeof(trit_t);
   trit_t trits_out[trits_size];
   trit_t partial_trits[trits_size];
-  size_t bytes_size = min_bytes(trits_size);
+  size_t bytes_size = MIN_BYTES(trits_size);
   for (int len = 0; len <= trits_size; len++) {
     memset(trits_out, 0, trits_size);
     memset(partial_trits, 0, trits_size);

--- a/common/trinary/trit_byte.h
+++ b/common/trinary/trit_byte.h
@@ -5,38 +5,44 @@
  * Refer to the LICENSE file for licensing information
  */
 
+#ifndef __COMMON_TRINARY_TRIT_BYTE_H__
+#define __COMMON_TRINARY_TRIT_BYTE_H__
+
+#include "common/defs.h"
+#include "common/trinary/bytes.h"
+#include "common/trinary/trits.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifndef __COMMON_TRINARY_TRIT_BYTE_H__
-#define __COMMON_TRINARY_TRIT_BYTE_H__
-
-#include "common/trinary/bytes.h"
-#include "common/trinary/trits.h"
-
 /// Returns the number of bytes needed to pack num_trits trits
 /// @param[in] num_trits - the number of trits to pack
 /// @return size_t - the number of bytes needed
-size_t min_bytes(size_t num_trits);
+#define MIN_BYTES(num_trits) \
+  (((num_trits) + NUMBER_OF_TRITS_IN_A_BYTE - 1) / NUMBER_OF_TRITS_IN_A_BYTE)
+
 /// Packs an array of trits into byte (max 5 packed trits)
 /// @param[in] trits - An array of trits
-/// @param[in] cum - the accumulator, maybe be not 0
 /// @param[in] num_trits - the number of trits to convert
 /// @return byte_t - the num_trits trits packed into a byte
-byte_t trits_to_byte(trit_t const *const trits, byte_t const cum,
-                     size_t const num_trits);
+byte_t trits_to_byte(trit_t const *const trits, size_t const num_trits);
+
 /// Packs an array of trits into an array of bytes
 /// @param[in] trits - An array of trits
 /// @param[in] cum - the accumulator, maybe be not 0
 /// @param[in] num_trits - the number of trits to convert
 /// @return byte_t - the num_trits trits packed into a byte
-void trits_to_bytes(trit_t *trits, byte_t *bytes, size_t num_trits);
+void trits_to_bytes(trit_t const *const trits, byte_t *const bytes,
+                    size_t const num_trits);
+
 /// Unpacks a byte into an array of trits
 /// @param[in] byte - A byte of packed trits
 /// @param[in] trits - An array of trits
 /// @param[in] num_trits - the number of trits to unpack (max 5)
-void byte_to_trits(byte_t byte, trit_t *const trit, size_t const num_trits);
+void byte_to_trits(byte_t const byte, trit_t *const trits,
+                   size_t const num_trits);
+
 /// Unpacks an array of byte into an array of trits
 /// @param[in] bytes - An array bytes (packed trits)
 /// @param[in] n_bytes - the number of bytes in the array
@@ -45,7 +51,8 @@ void byte_to_trits(byte_t byte, trit_t *const trit, size_t const num_trits);
 void bytes_to_trits(byte_t const *const bytes, size_t const num_bytes,
                     trit_t *const trits, size_t const num_trits);
 
-#endif
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // __COMMON_TRINARY_TRIT_BYTE_H__

--- a/common/trinary/trit_byte.h
+++ b/common/trinary/trit_byte.h
@@ -15,8 +15,6 @@ extern "C" {
 #include "common/trinary/bytes.h"
 #include "common/trinary/trits.h"
 
-#define NUMBER_OF_TRITS_IN_A_BYTE 5
-
 /// Returns the number of bytes needed to pack num_trits trits
 /// @param[in] num_trits - the number of trits to pack
 /// @return size_t - the number of bytes needed

--- a/common/trinary/trit_long.h
+++ b/common/trinary/trit_long.h
@@ -5,14 +5,14 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef __COMMON_TRINARY_TRIT_LONG_H__
 #define __COMMON_TRINARY_TRIT_LONG_H__
 
 #include "common/trinary/trits.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /// Returns the number of trits needed to encode the value
 /// @return size_t - the number of trit needed to encode the value
@@ -53,7 +53,8 @@ int encode_long(int64_t const value, trit_t *const trits,
 int64_t decode_long(trit_t const *const trits, size_t const num_trits,
                     size_t *const size);
 
-#endif
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // __COMMON_TRINARY_TRIT_LONG_H__

--- a/common/trinary/trit_ptrit.c
+++ b/common/trinary/trit_ptrit.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "trit_ptrit.h"
+#include "common/trinary/trit_ptrit.h"
 
 void trits_to_ptrits(trit_t const *const trits, ptrit_t *const ptrits,
                      size_t const index, size_t const length) {
@@ -54,8 +54,9 @@ void trits_to_ptrits_fill(trit_t const *const trits, ptrit_t *const ptrits,
 }
 
 void ptrits_to_trits(ptrit_t const *const ptrits, trit_t *const trits,
-                     size_t const index, size_t length) {
+                     size_t const index, size_t const length) {
   size_t j = 0;
+
   if (length == 0) {
     return;
   }

--- a/common/trinary/trit_ptrit.h
+++ b/common/trinary/trit_ptrit.h
@@ -5,10 +5,6 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef __COMMON_TRINARY_TRIT_PTRIT_H_
 #define __COMMON_TRINARY_TRIT_PTRIT_H_
 
@@ -16,14 +12,19 @@ extern "C" {
 #include "common/trinary/ptrit_incr.h"
 #include "common/trinary/trits.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void trits_to_ptrits(trit_t const *const trits, ptrit_t *const ptrits,
                      size_t const index, size_t const length);
 void trits_to_ptrits_fill(trit_t const *const trits, ptrit_t *const ptrits,
                           size_t const length);
 void ptrits_to_trits(ptrit_t const *const ptrits, trit_t *const trits,
-                     size_t const index, size_t length);
+                     size_t const index, size_t const length);
 
-#endif
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // __COMMON_TRINARY_TRIT_PTRIT_H_

--- a/common/trinary/trit_tryte.c
+++ b/common/trinary/trit_tryte.c
@@ -9,14 +9,13 @@
 
 #include "common/trinary/trit_tryte.h"
 
-static const trit_t
-    TRYTE_TO_TRITS_MAPPINGS[TRYTE_SPACE][NUMBER_OF_TRITS_IN_A_TRYTE] = {
-        {0, 0, 0},   {1, 0, 0},   {-1, 1, 0},  {0, 1, 0},   {1, 1, 0},
-        {-1, -1, 1}, {0, -1, 1},  {1, -1, 1},  {-1, 0, 1},  {0, 0, 1},
-        {1, 0, 1},   {-1, 1, 1},  {0, 1, 1},   {1, 1, 1},   {-1, -1, -1},
-        {0, -1, -1}, {1, -1, -1}, {-1, 0, -1}, {0, 0, -1},  {1, 0, -1},
-        {-1, 1, -1}, {0, 1, -1},  {1, 1, -1},  {-1, -1, 0}, {0, -1, 0},
-        {1, -1, 0},  {-1, 0, 0}};
+static const trit_t TRYTES_TRITS_LUT[TRYTE_SPACE][NUMBER_OF_TRITS_IN_A_TRYTE] =
+    {{0, 0, 0},   {1, 0, 0},   {-1, 1, 0},  {0, 1, 0},   {1, 1, 0},
+     {-1, -1, 1}, {0, -1, 1},  {1, -1, 1},  {-1, 0, 1},  {0, 0, 1},
+     {1, 0, 1},   {-1, 1, 1},  {0, 1, 1},   {1, 1, 1},   {-1, -1, -1},
+     {0, -1, -1}, {1, -1, -1}, {-1, 0, -1}, {0, 0, -1},  {1, 0, -1},
+     {-1, 1, -1}, {0, 1, -1},  {1, 1, -1},  {-1, -1, 0}, {0, -1, 0},
+     {1, -1, 0},  {-1, 0, 0}};
 
 trit_t get_trit_at(tryte_t const *const trytes, size_t const length,
                    size_t const index) {
@@ -25,9 +24,9 @@ trit_t get_trit_at(tryte_t const *const trytes, size_t const length,
     return 0;
   }
   tryte_t tryte = trytes[tindex];
-  size_t cindex = tryte == '9' ? 0 : tryte - '@';
+  size_t cindex = INDEX_OF_TRYTE(tryte);
   tindex = index % 3U;
-  return TRYTE_TO_TRITS_MAPPINGS[cindex][tindex];
+  return TRYTES_TRITS_LUT[cindex][tindex];
 }
 
 uint8_t set_trit_at(tryte_t *const trytes, size_t const length,
@@ -37,13 +36,13 @@ uint8_t set_trit_at(tryte_t *const trytes, size_t const length,
     return 0;
   }
   tryte_t tryte = trytes[tindex];
-  size_t cindex = tryte == '9' ? 0 : tryte - '@';
+  size_t cindex = INDEX_OF_TRYTE(tryte);
   trit_t trits[3];
   if (cindex > 26) {
     // uninitialized
-    memcpy(trits, TRYTE_TO_TRITS_MAPPINGS[0], NUMBER_OF_TRITS_IN_A_TRYTE);
+    memcpy(trits, TRYTES_TRITS_LUT[0], NUMBER_OF_TRITS_IN_A_TRYTE);
   } else {
-    memcpy(trits, TRYTE_TO_TRITS_MAPPINGS[cindex], NUMBER_OF_TRITS_IN_A_TRYTE);
+    memcpy(trits, TRYTES_TRITS_LUT[cindex], NUMBER_OF_TRITS_IN_A_TRYTE);
   }
   size_t uindex = index % 3U;
   trits[uindex] = trit;
@@ -59,13 +58,13 @@ void trits_to_trytes(trit_t const *const trits, tryte_t *const trytes,
                      size_t const length) {
   int k = 0;
 
-  for (size_t i = 0, j = 0; i < length; i += 3, j++) {
+  for (size_t i = 0, j = 0; i < length; i += RADIX, j++) {
     k = 0;
     for (size_t l = length - i < NUMBER_OF_TRITS_IN_A_TRYTE
                         ? length - i
                         : NUMBER_OF_TRITS_IN_A_TRYTE;
          l-- > 0;) {
-      k *= 3;
+      k *= RADIX;
       k += trits[i + l];
     }
     if (k < 0) {
@@ -81,9 +80,8 @@ void trytes_to_trits(tryte_t const *const trytes, trit_t *const trits,
     return;
   }
 
-  for (size_t i = 0, j = 0; i < length; i++, j += 3) {
-    memcpy(trits + j,
-           TRYTE_TO_TRITS_MAPPINGS[trytes[i] == '9' ? 0 : trytes[i] - '@'],
+  for (size_t i = 0, j = 0; i < length; i++, j += RADIX) {
+    memcpy(trits + j, TRYTES_TRITS_LUT[INDEX_OF_TRYTE(trytes[i])],
            NUMBER_OF_TRITS_IN_A_TRYTE);
   }
 }

--- a/common/trinary/trit_tryte.c
+++ b/common/trinary/trit_tryte.c
@@ -7,29 +7,19 @@
 
 #include <string.h>
 
-#include "common/defs.h"
 #include "common/trinary/trit_tryte.h"
 
-#define TRYTE_SPACE 27
-#define TRITS_TO_TRYTES_MAP                                                 \
-  {0, 0, 0}, {1, 0, 0}, {-1, 1, 0}, {0, 1, 0}, {1, 1, 0}, {-1, -1, 1},      \
-      {0, -1, 1}, {1, -1, 1}, {-1, 0, 1}, {0, 0, 1}, {1, 0, 1}, {-1, 1, 1}, \
-      {0, 1, 1}, {1, 1, 1}, {-1, -1, -1}, {0, -1, -1}, {1, -1, -1},         \
-      {-1, 0, -1}, {0, 0, -1}, {1, 0, -1}, {-1, 1, -1}, {0, 1, -1},         \
-      {1, 1, -1}, {-1, -1, 0}, {0, -1, 0}, {1, -1, 0}, {                    \
-    -1, 0, 0                                                                \
-  }
+static const trit_t
+    TRYTE_TO_TRITS_MAPPINGS[TRYTE_SPACE][NUMBER_OF_TRITS_IN_A_TRYTE] = {
+        {0, 0, 0},   {1, 0, 0},   {-1, 1, 0},  {0, 1, 0},   {1, 1, 0},
+        {-1, -1, 1}, {0, -1, 1},  {1, -1, 1},  {-1, 0, 1},  {0, 0, 1},
+        {1, 0, 1},   {-1, 1, 1},  {0, 1, 1},   {1, 1, 1},   {-1, -1, -1},
+        {0, -1, -1}, {1, -1, -1}, {-1, 0, -1}, {0, 0, -1},  {1, 0, -1},
+        {-1, 1, -1}, {0, 1, -1},  {1, 1, -1},  {-1, -1, 0}, {0, -1, 0},
+        {1, -1, 0},  {-1, 0, 0}};
 
-static const trit_t TRYTE_TO_TRITS_MAPPINGS[TRYTE_SPACE]
-                                           [NUMBER_OF_TRITS_IN_A_TRYTE] = {
-                                               TRITS_TO_TRYTES_MAP};
-
-size_t num_trytes_for_trits(size_t num_trits) {
-  return (num_trits + NUMBER_OF_TRITS_IN_A_TRYTE - 1) /
-         NUMBER_OF_TRITS_IN_A_TRYTE;
-}
-
-trit_t get_trit_at(tryte_t *const trytes, size_t const length, size_t index) {
+trit_t get_trit_at(tryte_t const *const trytes, size_t const length,
+                   size_t const index) {
   size_t tindex = index / 3U;
   if (tindex >= length) {
     return 0;
@@ -40,8 +30,8 @@ trit_t get_trit_at(tryte_t *const trytes, size_t const length, size_t index) {
   return TRYTE_TO_TRITS_MAPPINGS[cindex][tindex];
 }
 
-uint8_t set_trit_at(tryte_t *const trytes, size_t const length, size_t index,
-                    trit_t trit) {
+uint8_t set_trit_at(tryte_t *const trytes, size_t const length,
+                    size_t const index, trit_t const trit) {
   size_t tindex = index / 3U;
   if (tindex >= length) {
     return 0;

--- a/common/trinary/trit_tryte.h
+++ b/common/trinary/trit_tryte.h
@@ -5,27 +5,33 @@
  * Refer to the LICENSE file for licensing information
  */
 
+#ifndef __COMMON_TRINARY_TRIT_TRYTE_H_
+#define __COMMON_TRINARY_TRIT_TRYTE_H_
+
+#include "common/defs.h"
+#include "common/trinary/trits.h"
+#include "common/trinary/tryte.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifndef __COMMON_TRINARY_TRIT_TRYTE_H_
-#define __COMMON_TRINARY_TRIT_TRYTE_H_
+static inline size_t num_trytes_for_trits(size_t num_trits) {
+  return (num_trits + NUMBER_OF_TRITS_IN_A_TRYTE - 1) /
+         NUMBER_OF_TRITS_IN_A_TRYTE;
+}
 
-#include "common/stdint.h"
-#include "common/trinary/trits.h"
-#include "common/trinary/tryte.h"
-
-size_t num_trytes_for_trits(size_t num_trits);
-trit_t get_trit_at(tryte_t *const trytes, size_t const length, size_t index);
-uint8_t set_trit_at(tryte_t *const trytes, size_t const length, size_t index,
-                    trit_t trit);
+trit_t get_trit_at(tryte_t const *const trytes, size_t const length,
+                   size_t const index);
+uint8_t set_trit_at(tryte_t *const trytes, size_t const length,
+                    size_t const index, trit_t const trit);
 void trits_to_trytes(trit_t const *const trits, tryte_t *const trytes,
                      size_t const length);
 void trytes_to_trits(tryte_t const *const trytes, trit_t *const trits,
                      size_t const length);
 
-#endif
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // __COMMON_TRINARY_TRIT_TRYTE_H_

--- a/common/trinary/trits.h
+++ b/common/trinary/trits.h
@@ -12,4 +12,4 @@
 
 typedef int8_t trit_t;
 
-#endif
+#endif  // __COMMON_TRINARY_TRIT_H_

--- a/common/trinary/tryte.h
+++ b/common/trinary/tryte.h
@@ -12,4 +12,6 @@
 
 typedef int8_t tryte_t;
 
+#define INDEX_OF_TRYTE(tryte) ((tryte) == '9' ? 0 : ((tryte) - 'A' + 1))
+
 #endif  // __COMMON_TRINARY_TRYTE_H_

--- a/common/trinary/tryte.h
+++ b/common/trinary/tryte.h
@@ -12,4 +12,4 @@
 
 typedef int8_t tryte_t;
 
-#endif
+#endif  // __COMMON_TRINARY_TRYTE_H_

--- a/common/trinary/tryte_ascii.c
+++ b/common/trinary/tryte_ascii.c
@@ -13,23 +13,16 @@ void ascii_to_trytes(char const *const input, tryte_t *const output) {
 
   for (int i = 0; input[i]; i++) {
     dec = input[i];
-    first = dec % 27;
-    second = (dec - first) / 27;
+    first = dec % TRYTE_SPACE;
+    second = (dec - first) / TRYTE_SPACE;
     output[j++] = TRYTE_ALPHABET[first];
     output[j++] = TRYTE_ALPHABET[second];
   }
 }
 
-static int index_of_tryte(tryte_t tryte) {
-  if (tryte == '9') {
-    return 0;
-  }
-  return tryte - 'A' + 1;
-}
-
 void trytes_to_ascii(tryte_t const *const input, char *const output) {
   for (int i = 0; input[i]; i += 2) {
     output[i / 2] =
-        index_of_tryte(input[i]) + index_of_tryte(input[i + 1]) * 27;
+        index_of_tryte(input[i]) + index_of_tryte(input[i + 1]) * TRYTE_SPACE;
   }
 }

--- a/common/trinary/tryte_ascii.c
+++ b/common/trinary/tryte_ascii.c
@@ -23,6 +23,6 @@ void ascii_to_trytes(char const *const input, tryte_t *const output) {
 void trytes_to_ascii(tryte_t const *const input, char *const output) {
   for (int i = 0; input[i]; i += 2) {
     output[i / 2] =
-        index_of_tryte(input[i]) + index_of_tryte(input[i + 1]) * TRYTE_SPACE;
+        INDEX_OF_TRYTE(input[i]) + INDEX_OF_TRYTE(input[i + 1]) * TRYTE_SPACE;
   }
 }

--- a/common/trinary/tryte_long.c
+++ b/common/trinary/tryte_long.c
@@ -5,26 +5,25 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "common/trinary/tryte_long.h"
 #include <math.h>
 
-#define TRYTE_SPACE 27
-#define TRYTE_STRING "9ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#include "common/defs.h"
+#include "common/trinary/tryte_long.h"
 
 size_t min_trytes(int64_t const value) {
   // Need minimum 1 tryte to represent any number
   size_t num = 1;
   int64_t v_abs = value < 0 ? -value : value;
   // As long as value is > than (27^2)/2, need one more tryte
-  while (v_abs > pow(27, num) / 2) {
+  while (v_abs > pow(TRYTE_SPACE, num) / 2) {
     num++;
   }
   return num;
 }
 
-int64_t trytes_to_long(tryte_t const *const trytes, size_t const i) {
+int64_t trytes_to_long(tryte_t const *const trytes, size_t const length) {
   int64_t value = 0;
-  for (size_t j = 0; j < i; j++) {
+  for (size_t j = 0; j < length; j++) {
     tryte_t tryte = trytes[j];
     // Trivial case, tryte value is 0
     if (tryte == '9') {
@@ -33,8 +32,8 @@ int64_t trytes_to_long(tryte_t const *const trytes, size_t const i) {
     // Get the tryte index - it's also the tryte value
     tryte = tryte - '@';
     // For indexes > 13 the value is negative
-    if (tryte > 13) {
-      tryte = tryte - 27;
+    if (tryte > TRYTE_VALUE_MAX) {
+      tryte = tryte - TRYTE_SPACE;
     }
     // Accumulate the tryte values
     value += tryte * pow(TRYTE_SPACE, j);
@@ -62,10 +61,10 @@ size_t long_to_trytes(int64_t const value, tryte_t *const trytes) {
     // If the original value was negative, the tryte value should also be
     // negative
     if (negative) {
-      tryte = tryte ? 27 - tryte : tryte;
+      tryte = tryte ? TRYTE_SPACE - tryte : tryte;
       v_abs = -v_abs;
     }
-    trytes[i] = TRYTE_STRING[tryte];
+    trytes[i] = TRYTE_ALPHABET[tryte];
   }
   return num_trytes;
 }

--- a/common/trinary/tryte_long.h
+++ b/common/trinary/tryte_long.h
@@ -5,20 +5,21 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef __COMMON_TRINARY_TRYTE_LONG_H_
 #define __COMMON_TRINARY_TRYTE_LONG_H_
 
 #include "common/trinary/tryte.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 size_t min_trytes(int64_t const value);
-int64_t trytes_to_long(tryte_t const *const trytes, size_t const i);
+int64_t trytes_to_long(tryte_t const *const trytes, size_t const length);
 size_t long_to_trytes(int64_t const value, tryte_t *const trytes);
 
-#endif  // __COMMON_TRINARY_TRYTE_LONG_H_
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // __COMMON_TRINARY_TRYTE_LONG_H_


### PR DESCRIPTION
- Various nits
- Optimizes trits and bytes conversions

100000000 iterations
trits_to_bytes  before  8755ms
trits_to_bytes  after   5392ms (-38.412%)

100000000 iterations
bytes_to_trits  before  11844ms
bytes_to_trits  after   5516ms (-53.428%)

A lookup table has been introduced for trits and bytes conversions. Since its size can be quite a bit for very small devices, it can be disabled with a `#define` and it defaults to recomputing values at runtime.

# Test Plan:
CI
