### PR TITLE
utils/containers/lock_free: queue - small refac

### DIFF
--- a/utils/containers/lock_free/BUILD
+++ b/utils/containers/lock_free/BUILD
@@ -3,3 +3,8 @@ load(":queue_lf_generator.bzl", "queue_generate")
 queue_generate(
     type = "int",
 )
+
+cc_library(
+    name = "lf_queue_struct",
+    hdrs = ["queue_structs.h"],
+)

--- a/utils/containers/lock_free/lf_queue.c.tpl
+++ b/utils/containers/lock_free/lf_queue.c.tpl
@@ -10,8 +10,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-void iota_lf_umm_queue_{TYPE}_init_owner(iota_lf_umm_queue_{TYPE}_t* const queue,
-                                         uint32_t element_size) {
+void iota_lf_umm_queue_{TYPE}_init_owner(iota_lf_umm_queue_t* const queue) {
   lfds711_queue_umm_init_valid_on_current_logical_core(
       &queue->queue, &queue->queue_element_dummy, NULL);
 
@@ -19,11 +18,11 @@ void iota_lf_umm_queue_{TYPE}_init_owner(iota_lf_umm_queue_{TYPE}_t* const queue
                                                       NULL);
 }
 
-void iota_lf_umm_queue_{TYPE}_init_user(iota_lf_umm_queue_{TYPE}_t* const queue) {
+void iota_lf_umm_queue_{TYPE}_init_user(iota_lf_umm_queue_t* const queue) {
   LFDS711_MISC_MAKE_VALID_ON_CURRENT_LOGICAL_CORE_INITS_COMPLETED_BEFORE_NOW_ON_ANY_OTHER_LOGICAL_CORE;
 }
 
-void* iota_lf_umm_queue_{TYPE}_free(iota_lf_umm_queue_{TYPE}_t* const queue) {
+void* iota_lf_umm_queue_{TYPE}_free(iota_lf_umm_queue_t* const queue) {
   struct lfds711_freelist_element* fe;
   iota_lf_queue_umm_{TYPE}_t* queue_element;
   if (queue == NULL) {
@@ -42,7 +41,7 @@ void* iota_lf_umm_queue_{TYPE}_free(iota_lf_umm_queue_{TYPE}_t* const queue) {
   lfds711_freelist_cleanup(&queue->freelist, NULL);
 }
 
-retcode_t iota_lf_umm_queue_{TYPE}_enqueue(iota_lf_umm_queue_{TYPE}_t* const queue,
+retcode_t iota_lf_umm_queue_{TYPE}_enqueue(iota_lf_umm_queue_t* const queue,
         {TYPE} const* const data) {
   iota_lf_queue_umm_{TYPE}_t* p = NULL;
   bool reused_element = false;
@@ -71,7 +70,7 @@ retcode_t iota_lf_umm_queue_{TYPE}_enqueue(iota_lf_umm_queue_{TYPE}_t* const que
 }
 
 iota_lf_queue_umm_{TYPE}_t* iota_lf_umm_queue_{TYPE}_dequeue(
-        iota_lf_umm_queue_{TYPE}_t* const queue) {
+        iota_lf_umm_queue_t* const queue) {
   struct lfds711_queue_umm_element* qe;
   iota_lf_queue_umm_{TYPE}_t* p = NULL;
 
@@ -89,7 +88,7 @@ iota_lf_queue_umm_{TYPE}_t* iota_lf_umm_queue_{TYPE}_dequeue(
   return p;
 }
 
-size_t iota_lf_umm_queue_{TYPE}_count(const iota_lf_umm_queue_{TYPE}_t* const queue) {
+size_t iota_lf_umm_queue_{TYPE}_count(const iota_lf_umm_queue_t* const queue) {
   lfds711_pal_uint_t count;
   lfds711_queue_umm_query(&queue->queue,
                           LFDS711_QUEUE_UMM_QUERY_SINGLETHREADED_GET_COUNT,

--- a/utils/containers/lock_free/lf_queue.h.tpl
+++ b/utils/containers/lock_free/lf_queue.h.tpl
@@ -9,14 +9,15 @@
  * UMM - unbounded queue, multiple producers, multiple consumers
  */
 
-#ifndef __UTILS_CONTAINERS_LOCK_FREE_QUEUE_UMM_H__
-#define __UTILS_CONTAINERS_LOCK_FREE_QUEUE_UMM_H__
+#ifndef __UTILS_CONTAINERS_LOCK_FREE_LF_QUEUE_UMM_{TYPE}_H__
+#define __UTILS_CONTAINERS_LOCK_FREE_LF_QUEUE_UMM_{TYPE}_H__
 
 #include <stddef.h>
 #include <stdint-gcc.h>
 
 #include <liblfds711.h>
 #include "common/errors.h"
+#include "utils/containers/lock_free/queue_structs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,8 +45,7 @@ typedef struct {
  * @return void
  */
 
-void iota_lf_umm_queue_{TYPE}_init_owner(iota_lf_umm_queue_{TYPE}_t* const queue,
-                                         uint32_t element_size);
+void iota_lf_umm_queue_{TYPE}_init_owner(iota_lf_umm_queue_t* const queue);
 
 /**
  * Init user function
@@ -56,7 +56,7 @@ void iota_lf_umm_queue_{TYPE}_init_owner(iota_lf_umm_queue_{TYPE}_t* const queue
  * @return void
  */
 
-void iota_lf_umm_queue_{TYPE}_init_user(iota_lf_umm_queue_{TYPE}_t* const queue);
+void iota_lf_umm_queue_{TYPE}_init_user(iota_lf_umm_queue_t* const queue);
 
 /**
  * Frees the queue
@@ -66,7 +66,7 @@ void iota_lf_umm_queue_{TYPE}_init_user(iota_lf_umm_queue_{TYPE}_t* const queue)
  * @return void
  */
 
-void* iota_lf_umm_queue_{TYPE}_free(iota_lf_umm_queue_{TYPE}_t* const queue);
+void* iota_lf_umm_queue_{TYPE}_free(iota_lf_umm_queue_t* const queue);
 
 /**
  * Enqueues an element
@@ -77,7 +77,7 @@ void* iota_lf_umm_queue_{TYPE}_free(iota_lf_umm_queue_{TYPE}_t* const queue);
  * @return error code
  */
 
-retcode_t iota_lf_umm_queue_{TYPE}_enqueue(iota_lf_umm_queue_{TYPE}_t* const queue,
+retcode_t iota_lf_umm_queue_{TYPE}_enqueue(iota_lf_umm_queue_t* const queue,
                                             {TYPE} const* const data);
 
 /**
@@ -89,7 +89,7 @@ retcode_t iota_lf_umm_queue_{TYPE}_enqueue(iota_lf_umm_queue_{TYPE}_t* const que
  */
 
 iota_lf_queue_umm_{TYPE}_t* iota_lf_umm_queue_{TYPE}_dequeue(
-        iota_lf_umm_queue_{TYPE}_t* const queue);
+        iota_lf_umm_queue_t* const queue);
 
 /**
  * count number of elements
@@ -99,10 +99,10 @@ iota_lf_queue_umm_{TYPE}_t* iota_lf_umm_queue_{TYPE}_dequeue(
  * @return the number of elements
  */
 
-size_t iota_lf_umm_queue_{TYPE}_count(const iota_lf_umm_queue_{TYPE}_t* const queue);
+size_t iota_lf_umm_queue_{TYPE}_count(const iota_lf_umm_queue_t* const queue);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // __UTILS_CONTAINERS_LOCK_FREE_QUEUE_UMM_H__
+#endif  // __UTILS_CONTAINERS_LOCK_FREE_LF_QUEUE_UMM_{TYPE}_H__

--- a/utils/containers/lock_free/queue_lf_generator.bzl
+++ b/utils/containers/lock_free/queue_lf_generator.bzl
@@ -47,6 +47,7 @@ def queue_generate(type):
             "//common:errors",
             "@liblfds",
             "//utils/containers:person_example",
+            "//utils/containers/lock_free:lf_queue_struct",
         ],
         visibility = ["//visibility:public"],
     )

--- a/utils/containers/lock_free/queue_structs.h
+++ b/utils/containers/lock_free/queue_structs.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+/*
+ * UMM - unbounded queue, multiple producers, multiple consumers
+ */
+
+#ifndef __UTILS_CONTAINERS_LOCK_FREE_QUEUE_STRUCTS_H__
+#define __UTILS_CONTAINERS_LOCK_FREE_QUEUE_STRUCTS_H__
+
+#include <stddef.h>
+#include <stdint-gcc.h>
+
+#include <liblfds711.h>
+#include "common/errors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  struct lfds711_queue_umm_element queue_element_dummy;
+  struct lfds711_queue_umm_state queue;
+  struct lfds711_freelist_state freelist;
+} iota_lf_umm_queue_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __UTILS_CONTAINERS_LOCK_FREE_QUEUE_STRUCTS_H__

--- a/utils/containers/lock_free/tests/queue_umm.c
+++ b/utils/containers/lock_free/tests/queue_umm.c
@@ -12,8 +12,8 @@
 #include "utils/containers/lock_free/lf_queue_int.h"
 
 void queue_integers_same_thread() {
-  iota_lf_umm_queue_int_t queue;
-  iota_lf_umm_queue_int_init_owner(&queue, sizeof(int));
+  iota_lf_umm_queue_t queue;
+  iota_lf_umm_queue_int_init_owner(&queue);
   iota_lf_umm_queue_int_init_user(&queue);
   for (int i = 0; i < 1000; ++i) {
     iota_lf_umm_queue_int_enqueue(&queue, &i);


### PR DESCRIPTION
- Generic include guards 
- remove unnecessary arg in init method
- export queue struct to commonly included header since it is not type dependent