### PR TITLE
utils/containers/hash_indexed_map : returned wrong type

### DIFF
--- a/utils/hash_indexed_map.c
+++ b/utils/hash_indexed_map.c
@@ -32,7 +32,7 @@ bool hash_to_indexed_hash_set_map_find(
     return false;
   }
   if (res == NULL) {
-    return RC_NULL_PARAM;
+    return false;
   }
   HASH_FIND(hh, *map, hash, FLEX_TRIT_SIZE_243, *res);
   return *res != NULL;


### PR DESCRIPTION
- returned error type instead of bool (false), which would have been resolved to "true" and would have 
  caused a crash if happend