### PR TITLE
utils/logger: lock depending on the log level

### DIFF
--- a/cclient/iota_client_core_api.c
+++ b/cclient/iota_client_core_api.c
@@ -11,17 +11,19 @@
 
 #define CCLIENT_CORE_LOGGER_ID "cclient_core_api"
 
+static logger_id_t logger_id;
+
 retcode_t iota_client_core_init(iota_client_service_t* const serv) {
-  logger_helper_enable(CCLIENT_CORE_LOGGER_ID, LOGGER_DEBUG, true);
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d] enable logger %s.\n", __func__,
-           __LINE__, CCLIENT_CORE_LOGGER_ID);
+  logger_id = logger_helper_enable(CCLIENT_CORE_LOGGER_ID, LOGGER_DEBUG, true);
+  log_info(logger_id, "[%s:%d] enable logger %s.\n", __func__, __LINE__,
+           CCLIENT_CORE_LOGGER_ID);
   return iota_client_service_init(serv);
 }
 
 void iota_client_core_destroy(iota_client_service_t* const serv) {
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d] destroy logger %s.\n", __func__,
-           __LINE__, CCLIENT_CORE_LOGGER_ID);
-  logger_helper_release(CCLIENT_CORE_LOGGER_ID);
+  log_info(logger_id, "[%s:%d] destroy logger %s.\n", __func__, __LINE__,
+           CCLIENT_CORE_LOGGER_ID);
+  logger_helper_release(logger_id);
   iota_client_service_destroy(serv);
 }
 
@@ -31,9 +33,9 @@ retcode_t iota_client_get_node_info(const iota_client_service_t* const service,
 
   char_buffer_t* req_buff = char_buffer_new();
   char_buffer_t* res_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -46,7 +48,7 @@ retcode_t iota_client_get_node_info(const iota_client_service_t* const service,
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -69,9 +71,9 @@ retcode_t iota_client_get_neighbors(const iota_client_service_t* const service,
   retcode_t result = RC_OK;
   char_buffer_t* req_buff = char_buffer_new();
   char_buffer_t* res_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -85,7 +87,7 @@ retcode_t iota_client_get_neighbors(const iota_client_service_t* const service,
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -110,9 +112,9 @@ retcode_t iota_client_add_neighbors(const iota_client_service_t* const service,
 
   char_buffer_t* req_buff = char_buffer_new();
   char_buffer_t* res_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -126,7 +128,7 @@ retcode_t iota_client_add_neighbors(const iota_client_service_t* const service,
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -150,9 +152,9 @@ retcode_t iota_client_remove_neighbors(
   retcode_t result = RC_OK;
   char_buffer_t* req_buff = char_buffer_new();
   char_buffer_t* res_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -166,7 +168,7 @@ retcode_t iota_client_remove_neighbors(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -189,9 +191,9 @@ retcode_t iota_client_get_tips(const iota_client_service_t* const service,
   retcode_t result = RC_OK;
   char_buffer_t* req_buff = char_buffer_new();
   char_buffer_t* res_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -205,7 +207,7 @@ retcode_t iota_client_get_tips(const iota_client_service_t* const service,
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -230,9 +232,9 @@ retcode_t iota_client_find_transactions(
   retcode_t result = RC_OK;
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -245,7 +247,7 @@ retcode_t iota_client_find_transactions(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -269,9 +271,9 @@ retcode_t iota_client_get_trytes(const iota_client_service_t* const service,
   retcode_t result = RC_OK;
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -284,7 +286,7 @@ retcode_t iota_client_get_trytes(const iota_client_service_t* const service,
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -308,9 +310,9 @@ retcode_t iota_client_get_inclusion_states(
   retcode_t result = RC_OK;
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -323,7 +325,7 @@ retcode_t iota_client_get_inclusion_states(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -348,9 +350,9 @@ retcode_t iota_client_get_balances(iota_client_service_t const* const service,
 
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -364,7 +366,7 @@ retcode_t iota_client_get_balances(iota_client_service_t const* const service,
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -390,9 +392,9 @@ retcode_t iota_client_get_transactions_to_approve(
   retcode_t result = RC_OK;
   char_buffer_t* req_buff = char_buffer_new();
   char_buffer_t* res_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -407,7 +409,7 @@ retcode_t iota_client_get_transactions_to_approve(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -433,9 +435,9 @@ retcode_t iota_client_attach_to_tangle(
 
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -449,7 +451,7 @@ retcode_t iota_client_attach_to_tangle(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -470,7 +472,7 @@ done:
 retcode_t iota_client_interrupt_attaching_to_tangle(
     const iota_client_service_t* const service) {
   retcode_t result = RC_OK;
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   // TODO
   return result;
 }
@@ -481,9 +483,9 @@ retcode_t iota_client_broadcast_transactions(
   retcode_t result = RC_OK;
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -496,7 +498,7 @@ retcode_t iota_client_broadcast_transactions(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -518,9 +520,9 @@ retcode_t iota_client_store_transactions(
   retcode_t result = RC_OK;
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -533,7 +535,7 @@ retcode_t iota_client_store_transactions(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }
@@ -556,9 +558,9 @@ retcode_t iota_client_check_consistency(
 
   char_buffer_t* res_buff = char_buffer_new();
   char_buffer_t* req_buff = char_buffer_new();
-  log_info(CCLIENT_CORE_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (req_buff == NULL || res_buff == NULL) {
-    log_critical(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_OOM);
     result = RC_CCLIENT_OOM;
     goto done;
@@ -572,7 +574,7 @@ retcode_t iota_client_check_consistency(
 
   result = iota_service_query(service, req_buff, res_buff);
   if (result != RC_OK) {
-    log_error(CCLIENT_CORE_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               error_2_string(result));
     goto done;
   }

--- a/cclient/iota_client_extended_api.c
+++ b/cclient/iota_client_extended_api.c
@@ -10,16 +10,19 @@
 
 #define CCLIENT_EXTENDED_LOGGER_ID "cclient_extended_api"
 
+static logger_id_t logger_id;
+
 void iota_client_extended_init() {
-  logger_helper_enable(CCLIENT_EXTENDED_LOGGER_ID, LOGGER_DEBUG, true);
-  log_info(CCLIENT_EXTENDED_LOGGER_ID, "[%s:%d] enable logger %s.\n", __func__,
-           __LINE__, CCLIENT_EXTENDED_LOGGER_ID);
+  logger_id =
+      logger_helper_enable(CCLIENT_EXTENDED_LOGGER_ID, LOGGER_DEBUG, true);
+  log_info(logger_id, "[%s:%d] enable logger %s.\n", __func__, __LINE__,
+           CCLIENT_EXTENDED_LOGGER_ID);
 }
 
 void iota_client_extended_destroy() {
-  log_info(CCLIENT_EXTENDED_LOGGER_ID, "[%s:%d] destroy logger %s.\n", __func__,
-           __LINE__, CCLIENT_EXTENDED_LOGGER_ID);
-  logger_helper_release(CCLIENT_EXTENDED_LOGGER_ID);
+  log_info(logger_id, "[%s:%d] destroy logger %s.\n", __func__, __LINE__,
+           CCLIENT_EXTENDED_LOGGER_ID);
+  logger_helper_release(logger_id);
 }
 
 static retcode_t is_unused_address(iota_client_service_t const* const serv,
@@ -30,7 +33,7 @@ static retcode_t is_unused_address(iota_client_service_t const* const serv,
   find_transactions_req_t* find_tran_req = NULL;
   find_transactions_res_t* find_tran_res = NULL;
 
-  log_debug(CCLIENT_EXTENDED_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_debug(logger_id, "[%s:%d]\n", __func__, __LINE__);
   find_tran_req = find_transactions_req_new();
   find_tran_res = find_transactions_res_new();
   if (!find_tran_req || !find_tran_res) {
@@ -62,7 +65,7 @@ retcode_t iota_client_get_new_address(iota_client_service_t const* const serv,
   size_t addr_index = 0;
   bool is_unused = true;
 
-  log_debug(CCLIENT_EXTENDED_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_debug(logger_id, "[%s:%d]\n", __func__, __LINE__);
   // security validation
   if (addr_opt.security == 0 || addr_opt.security > 3) {
     return RC_CCLIENT_INVALID_SECURITY;
@@ -124,7 +127,7 @@ retcode_t iota_client_get_inputs(iota_client_service_t const* const serv,
   size_t counter = 0;
   out_input->total_balance = 0;
 
-  log_debug(CCLIENT_EXTENDED_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_debug(logger_id, "[%s:%d]\n", __func__, __LINE__);
   // get address list
   ret_code = iota_client_get_new_address(serv, seed, addr_opt,
                                          &balances_req->addresses);
@@ -147,7 +150,7 @@ retcode_t iota_client_get_inputs(iota_client_service_t const* const serv,
     // check if balance is sufficient
     if (out_input->total_balance < threshold) {
       ret_code = RC_CCLIENT_INSUFFICIENT_BALANCE;
-      log_warning(CCLIENT_EXTENDED_LOGGER_ID, "insufficient balance\n");
+      log_warning(logger_id, "insufficient balance\n");
     }
   }
 
@@ -262,11 +265,10 @@ retcode_t iota_client_find_transaction_objects(
   retcode_t ret_code = RC_OK;
   find_transactions_res_t* find_tx_res = find_transactions_res_new();
 
-  log_debug(CCLIENT_EXTENDED_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_debug(logger_id, "[%s:%d]\n", __func__, __LINE__);
   if (!find_tx_res) {
     ret_code = RC_CCLIENT_NULL_PTR;
-    log_error(CCLIENT_EXTENDED_LOGGER_ID,
-              "%s create request object failed: %s\n", __func__,
+    log_error(logger_id, "%s create request object failed: %s\n", __func__,
               error_2_string(ret_code));
     goto done;
   }
@@ -302,8 +304,7 @@ retcode_t iota_client_get_transaction_objects(
         transaction_array_push_back(out_tx_objs, &tx);
       } else {
         ret_code = RC_CCLIENT_TX_DESERIALIZE_FAILED;
-        log_error(CCLIENT_EXTENDED_LOGGER_ID, "%s: %s.\n", __func__,
-                  error_2_string(ret_code));
+        log_error(logger_id, "%s: %s.\n", __func__, error_2_string(ret_code));
         goto done;
       }
     }
@@ -336,7 +337,7 @@ retcode_t iota_client_is_promotable(iota_client_service_t const* const serv,
   ret_code =
       iota_client_check_consistency(serv, consistency_req, consistency_res);
   if (ret_code) {
-    log_warning(CCLIENT_EXTENDED_LOGGER_ID, "check consistency failed\n");
+    log_warning(logger_id, "check consistency failed\n");
     goto done;
   }
   if (consistency_res->state) {
@@ -349,7 +350,7 @@ retcode_t iota_client_is_promotable(iota_client_service_t const* const serv,
       if (tx_deserialize_offset) {
         // is above max depth
         time_now = current_timestamp_ms();
-        log_debug(CCLIENT_EXTENDED_LOGGER_ID,
+        log_debug(logger_id,
                   "checking depth, attachment_timestamp %ld, time: %ld\n",
                   tx.attachment.attachment_timestamp, time_now);
         if ((tx.attachment.attachment_timestamp < time_now) &&
@@ -358,8 +359,7 @@ retcode_t iota_client_is_promotable(iota_client_service_t const* const serv,
         }
       } else {
         ret_code = RC_CCLIENT_TX_DESERIALIZE_FAILED;
-        log_error(CCLIENT_EXTENDED_LOGGER_ID, "%s: %s.\n", __func__,
-                  error_2_string(ret_code));
+        log_error(logger_id, "%s: %s.\n", __func__, error_2_string(ret_code));
         goto done;
       }
     }
@@ -472,8 +472,7 @@ retcode_t iota_client_send_trytes(iota_client_service_t const* const serv,
       transaction_array_push_back(out_transactions, &tx);
     } else {
       ret_code = RC_CCLIENT_TX_DESERIALIZE_FAILED;
-      log_error(CCLIENT_EXTENDED_LOGGER_ID, "%s: %s.\n", __func__,
-                error_2_string(ret_code));
+      log_error(logger_id, "%s: %s.\n", __func__, error_2_string(ret_code));
       goto done;
     }
   }

--- a/cclient/serialization/json/json_serializer.c
+++ b/cclient/serialization/json/json_serializer.c
@@ -14,16 +14,18 @@
 
 #define JSON_LOGGER_ID "json_serializer"
 
+static logger_id_t logger_id;
+
 void logger_init_json_serializer() {
-  logger_helper_enable(JSON_LOGGER_ID, LOGGER_DEBUG, true);
-  log_info(JSON_LOGGER_ID, "[%s:%d] enable logger %s.\n", __func__, __LINE__,
+  logger_id = logger_helper_enable(JSON_LOGGER_ID, LOGGER_DEBUG, true);
+  log_info(logger_id, "[%s:%d] enable logger %s.\n", __func__, __LINE__,
            JSON_LOGGER_ID);
 }
 
 void logger_destroy_json_serializer() {
-  log_info(JSON_LOGGER_ID, "[%s:%d] destroy logger %s.\n", __func__, __LINE__,
+  log_info(logger_id, "[%s:%d] destroy logger %s.\n", __func__, __LINE__,
            JSON_LOGGER_ID);
-  logger_helper_release(JSON_LOGGER_ID);
+  logger_helper_release(logger_id);
 }
 
 void init_json_serializer(serializer_t* serializer) {
@@ -45,7 +47,7 @@ static retcode_t json_array_to_uint64(cJSON const* const obj,
       }
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -58,7 +60,7 @@ static retcode_t utarray_to_json_array(UT_array const* const ut,
   if (utarray_len(ut) > 0) {
     cJSON* array_obj = cJSON_CreateArray();
     if (array_obj == NULL) {
-      log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+      log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                    STR_CCLIENT_JSON_CREATE);
       return RC_CCLIENT_JSON_CREATE;
     }
@@ -86,7 +88,7 @@ static flex_hash_array_t* json_array_to_flex_hash_array(
       }
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return NULL;
   }
@@ -151,7 +153,7 @@ static retcode_t json_string_to_flex_hash(cJSON const* const json_obj,
   retcode_t ret = RC_OK;
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, key);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, key);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -161,7 +163,7 @@ static retcode_t json_string_to_flex_hash(cJSON const* const json_obj,
       return ret;
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not string\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not string\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -181,7 +183,7 @@ static retcode_t json_boolean_array_to_utarray(cJSON const* const obj,
       utarray_push_back(ut, &bl);
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -192,7 +194,7 @@ static retcode_t json_get_int(cJSON const* const json_obj,
                               char const* const obj_name, int* const num) {
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, obj_name);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -200,7 +202,7 @@ static retcode_t json_get_int(cJSON const* const json_obj,
   if (cJSON_IsNumber(json_value)) {
     *num = json_value->valueint;
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not number\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not number\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -213,7 +215,7 @@ static retcode_t json_get_uint16(cJSON const* const json_obj,
                                  uint16_t* const num) {
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, obj_name);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -221,7 +223,7 @@ static retcode_t json_get_uint16(cJSON const* const json_obj,
   if (cJSON_IsNumber(json_value)) {
     *num = (uint16_t)json_value->valueint;
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not number\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not number\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -234,7 +236,7 @@ static retcode_t json_get_uint32(cJSON const* const json_obj,
                                  uint32_t* const num) {
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, obj_name);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -242,7 +244,7 @@ static retcode_t json_get_uint32(cJSON const* const json_obj,
   if (cJSON_IsNumber(json_value)) {
     *num = (uint32_t)json_value->valuedouble;
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not number\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not number\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -255,7 +257,7 @@ static retcode_t json_get_uint64(cJSON const* const json_obj,
                                  uint64_t* const num) {
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, obj_name);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -263,7 +265,7 @@ static retcode_t json_get_uint64(cJSON const* const json_obj,
   if (cJSON_IsNumber(json_value)) {
     *num = (uint64_t)json_value->valuedouble;
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not number\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not number\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -278,7 +280,7 @@ static retcode_t json_get_string(cJSON const* const json_obj,
   size_t str_len = 0;
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, obj_name);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -287,14 +289,14 @@ static retcode_t json_get_string(cJSON const* const json_obj,
     str_len = strlen(json_value->valuestring);
     ret = char_buffer_allocate(text, str_len);
     if (ret != RC_OK) {
-      log_error(JSON_LOGGER_ID, "[%s:%d] memory allocation failed.\n", __func__,
+      log_error(logger_id, "[%s:%d] memory allocation failed.\n", __func__,
                 __LINE__);
       return ret;
     }
 
     strcpy(text->data, json_value->valuestring);
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not string\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not string\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -354,7 +356,7 @@ static retcode_t json_array_to_hash243_queue(cJSON const* const obj,
       }
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -381,7 +383,7 @@ static retcode_t json_array_to_hash243_stack(cJSON const* const obj,
       }
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -441,7 +443,7 @@ static retcode_t json_array_to_hash8019_queue(cJSON const* const obj,
       }
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -475,7 +477,7 @@ static retcode_t json_string_to_flex_trits(cJSON const* const json_obj,
   size_t trit_len = 0;
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, key);
   if (json_value == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s.\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__,
               STR_CCLIENT_JSON_KEY, key);
     return RC_CCLIENT_JSON_KEY;
   }
@@ -487,7 +489,7 @@ static retcode_t json_string_to_flex_trits(cJSON const* const json_obj,
       return RC_CCLIENT_FLEX_TRITS;
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not string\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not string\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -611,7 +613,7 @@ static retcode_t json_array_to_hash8019_array(cJSON const* const obj,
       }
     }
   } else {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s not array\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s not array\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
@@ -624,10 +626,10 @@ retcode_t json_find_transactions_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -669,7 +671,7 @@ retcode_t json_find_transactions_serialize_request(
   return ret;
 
 err:
-  log_error(JSON_LOGGER_ID, "[%s:%d] error!\n", __func__, __LINE__);
+  log_error(logger_id, "[%s:%d] error!\n", __func__, __LINE__);
   cJSON_Delete(json_root);
   return ret;
 }
@@ -677,13 +679,13 @@ err:
 retcode_t json_find_transactions_deserialize_response(
     serializer_t const* const s, char const* const obj,
     find_transactions_res_t* out) {
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -691,7 +693,7 @@ retcode_t json_find_transactions_deserialize_response(
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -710,10 +712,10 @@ retcode_t json_get_balances_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -757,10 +759,10 @@ retcode_t json_get_balances_deserialize_response(serializer_t const* const s,
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -768,7 +770,7 @@ retcode_t json_get_balances_deserialize_response(serializer_t const* const s,
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -802,10 +804,10 @@ retcode_t json_get_inclusion_state_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -844,10 +846,10 @@ retcode_t json_get_inclusion_state_deserialize_response(
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -855,7 +857,7 @@ retcode_t json_get_inclusion_state_deserialize_response(
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -871,7 +873,7 @@ retcode_t json_get_neighbors_serialize_request(const serializer_t* const s,
                                                char_buffer_t* out) {
   retcode_t ret = RC_OK;
   const char* req_text = "{\"command\":\"getNeighbors\"}";
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   ret = char_buffer_allocate(out, strlen(req_text));
   if (ret == RC_OK) {
     strcpy(out->data, req_text);
@@ -888,9 +890,9 @@ retcode_t json_get_neighbors_deserialize_response(const serializer_t* const s,
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
 
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -898,7 +900,7 @@ retcode_t json_get_neighbors_deserialize_response(const serializer_t* const s,
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -942,7 +944,7 @@ retcode_t json_get_node_info_serialize_request(const serializer_t* const s,
                                                char_buffer_t* out) {
   retcode_t ret = RC_OK;
   const char* req_text = "{\"command\":\"getNodeInfo\"}";
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   ret = char_buffer_allocate(out, strlen(req_text));
   if (ret == RC_OK) {
     strcpy(out->data, req_text);
@@ -956,10 +958,10 @@ retcode_t json_get_node_info_deserialize_response(const serializer_t* const s,
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -967,7 +969,7 @@ retcode_t json_get_node_info_deserialize_response(const serializer_t* const s,
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1056,7 +1058,7 @@ retcode_t json_get_tips_serialize_request(const serializer_t* const s,
                                           char_buffer_t* out) {
   retcode_t ret = RC_OK;
   const char* req_text = "{\"command\":\"getTips\"}";
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   ret = char_buffer_allocate(out, strlen(req_text));
   if (ret == RC_OK) {
     strcpy(out->data, req_text);
@@ -1070,10 +1072,10 @@ retcode_t json_get_tips_deserialize_response(const serializer_t* const s,
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1081,7 +1083,7 @@ retcode_t json_get_tips_deserialize_response(const serializer_t* const s,
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1100,10 +1102,10 @@ retcode_t json_get_transactions_to_approve_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1142,10 +1144,10 @@ retcode_t json_get_transactions_to_approve_deserialize_response(
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1153,7 +1155,7 @@ retcode_t json_get_transactions_to_approve_deserialize_response(
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1182,10 +1184,10 @@ retcode_t json_add_neighbors_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1219,10 +1221,10 @@ retcode_t json_add_neighbors_deserialize_response(const serializer_t* const s,
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1230,7 +1232,7 @@ retcode_t json_add_neighbors_deserialize_response(const serializer_t* const s,
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1248,10 +1250,10 @@ retcode_t json_remove_neighbors_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1285,10 +1287,10 @@ retcode_t json_remove_neighbors_deserialize_response(
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1296,7 +1298,7 @@ retcode_t json_remove_neighbors_deserialize_response(
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1314,10 +1316,10 @@ retcode_t json_get_trytes_serialize_request(const serializer_t* const s,
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1350,10 +1352,10 @@ retcode_t json_get_trytes_deserialize_response(const serializer_t* const s,
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1361,7 +1363,7 @@ retcode_t json_get_trytes_deserialize_response(const serializer_t* const s,
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1377,10 +1379,10 @@ retcode_t json_attach_to_tangle_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1428,10 +1430,10 @@ retcode_t json_attach_to_tangle_deserialize_response(
   retcode_t ret = RC_OK;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
 
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1439,14 +1441,14 @@ retcode_t json_attach_to_tangle_deserialize_response(
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
   }
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "exception");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;
@@ -1465,10 +1467,10 @@ retcode_t json_broadcast_transactions_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1502,10 +1504,10 @@ retcode_t json_store_transactions_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1539,10 +1541,10 @@ retcode_t json_check_consistency_serialize_request(
   retcode_t ret = RC_OK;
   const char* json_text = NULL;
   size_t len = 0;
-  log_info(JSON_LOGGER_ID, "[%s:%d]\n", __func__, __LINE__);
+  log_info(logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
   if (json_root == NULL) {
-    log_critical(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_critical(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
                  STR_CCLIENT_JSON_CREATE);
     return RC_CCLIENT_JSON_CREATE;
   }
@@ -1577,9 +1579,9 @@ retcode_t json_check_consistency_deserialize_response(
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
 
-  log_info(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__, obj);
+  log_info(logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
   if (json_obj == NULL) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s\n", __func__, __LINE__,
               STR_CCLIENT_JSON_PARSE);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_JSON_PARSE;
@@ -1587,7 +1589,7 @@ retcode_t json_check_consistency_deserialize_response(
 
   json_item = cJSON_GetObjectItemCaseSensitive(json_obj, "error");
   if (cJSON_IsString(json_item) && (json_item->valuestring != NULL)) {
-    log_error(JSON_LOGGER_ID, "[%s:%d] %s %s\n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s %s\n", __func__, __LINE__,
               STR_CCLIENT_RES_ERROR, json_item->valuestring);
     cJSON_Delete(json_obj);
     return RC_CCLIENT_RES_ERROR;

--- a/cclient/types/types.c
+++ b/cclient/types/types.c
@@ -9,20 +9,22 @@
 
 #define TYPES_LOGGER_ID "types"
 
+static logger_id_t logger_id;
+
 void logger_init_types() {
 // overwrite oom in utarray
 #undef oom
-#define oom() log_info(TYPES_LOGGER_ID, "[%s:%d] OOM.\n", __func__, __LINE__)
+#define oom() log_info(logger_id, "[%s:%d] OOM.\n", __func__, __LINE__)
 
-  logger_helper_enable(TYPES_LOGGER_ID, LOGGER_DEBUG, true);
-  log_info(TYPES_LOGGER_ID, "[%s:%d] enable logger %s.\n", __func__, __LINE__,
+  logger_id = logger_helper_enable(TYPES_LOGGER_ID, LOGGER_DEBUG, true);
+  log_info(logger_id, "[%s:%d] enable logger %s.\n", __func__, __LINE__,
            TYPES_LOGGER_ID);
 }
 
 void logger_destroy_types() {
-  log_info(TYPES_LOGGER_ID, "[%s:%d] destroy logger %s.\n", __func__, __LINE__,
+  log_info(logger_id, "[%s:%d] destroy logger %s.\n", __func__, __LINE__,
            TYPES_LOGGER_ID);
-  logger_helper_release(TYPES_LOGGER_ID);
+  logger_helper_release(logger_id);
 }
 
 char_buffer_t* char_buffer_new() {
@@ -31,7 +33,7 @@ char_buffer_t* char_buffer_new() {
     out->length = 0;
     out->data = NULL;
   } else {
-    log_error(TYPES_LOGGER_ID, "[%s:%d] %s \n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s \n", __func__, __LINE__,
               STR_CCLIENT_NULL_PTR);
   }
   return out;
@@ -43,8 +45,7 @@ retcode_t char_buffer_allocate(char_buffer_t* in, const size_t n) {
   }
   in->data = (char*)malloc(sizeof(char) * (n + 1));
   if (in->data == NULL) {
-    log_error(TYPES_LOGGER_ID, "[%s:%d] %s \n", __func__, __LINE__,
-              STR_CCLIENT_OOM);
+    log_error(logger_id, "[%s:%d] %s \n", __func__, __LINE__, STR_CCLIENT_OOM);
     return RC_CCLIENT_OOM;
   }
   in->length = n;
@@ -57,8 +58,7 @@ retcode_t char_buffer_set(char_buffer_t* in, char const* const str) {
 
   in->data = (char*)realloc(in->data, sizeof(char) * (size + 1));
   if (in->data == NULL) {
-    log_error(TYPES_LOGGER_ID, "[%s:%d] %s \n", __func__, __LINE__,
-              STR_CCLIENT_OOM);
+    log_error(logger_id, "[%s:%d] %s \n", __func__, __LINE__, STR_CCLIENT_OOM);
     return RC_CCLIENT_OOM;
   }
   in->length = size;
@@ -126,7 +126,7 @@ flex_hash_array_t* flex_hash_array_append(flex_hash_array_t* head,
       free(elt);
     }
   } else {
-    log_warning(TYPES_LOGGER_ID, "[%s:%d] %s \n", __func__, __LINE__,
+    log_warning(logger_id, "[%s:%d] %s \n", __func__, __LINE__,
                 STR_CCLIENT_NULL_PTR);
   }
   return head;
@@ -164,13 +164,13 @@ retcode_t flex_hash_to_char_buffer(trit_array_p hash, char_buffer_t* out) {
   retcode_t ret = RC_OK;
   size_t trits_len = 0;
   if (hash == NULL || hash->trits == NULL) {
-    log_error(TYPES_LOGGER_ID, "[%s:%d] %s \n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s \n", __func__, __LINE__,
               STR_CCLIENT_NULL_PTR);
     return RC_CCLIENT_NULL_PTR;
   }
   ret = char_buffer_allocate(out, hash->num_trits / 3);
   if (ret != RC_OK) {
-    log_error(TYPES_LOGGER_ID, "[%s:%d] %s \n", __func__, __LINE__,
+    log_error(logger_id, "[%s:%d] %s \n", __func__, __LINE__,
               error_2_string(ret));
     return ret;
   }

--- a/ciri/api/api.c
+++ b/ciri/api/api.c
@@ -17,6 +17,8 @@
 
 #define API_LOGGER_ID "api"
 
+static logger_id_t logger_id;
+
 /*
  * Private functions
  */
@@ -140,12 +142,12 @@ retcode_t iota_api_add_neighbors(iota_api_t const *const api,
     if ((ret = neighbor_init_with_uri(&neighbor, *uri)) != RC_OK) {
       return ret;
     }
-    log_info(API_LOGGER_ID, "Adding neighbor %s\n", *uri);
+    log_info(logger_id, "Adding neighbor %s\n", *uri);
     rw_lock_handle_wrlock(&api->node->neighbors_lock);
     if (neighbors_add(&api->node->neighbors, &neighbor) == RC_OK) {
       res->added_neighbors++;
     } else {
-      log_warning(API_LOGGER_ID, "Adding neighbor %s failed\n", *uri);
+      log_warning(logger_id, "Adding neighbor %s failed\n", *uri);
     }
     rw_lock_handle_unlock(&api->node->neighbors_lock);
   }
@@ -170,12 +172,12 @@ retcode_t iota_api_remove_neighbors(iota_api_t const *const api,
     if ((ret = neighbor_init_with_uri(&neighbor, *uri)) != RC_OK) {
       return ret;
     }
-    log_info(API_LOGGER_ID, "Removing neighbor %s\n", *uri);
+    log_info(logger_id, "Removing neighbor %s\n", *uri);
     rw_lock_handle_wrlock(&api->node->neighbors_lock);
     if (neighbors_remove(&api->node->neighbors, &neighbor) == RC_OK) {
       res->removed_neighbors++;
     } else {
-      log_warning(API_LOGGER_ID, "Removing neighbor %s failed\n", *uri);
+      log_warning(logger_id, "Removing neighbor %s failed\n", *uri);
     }
     rw_lock_handle_unlock(&api->node->neighbors_lock);
   }
@@ -416,7 +418,7 @@ retcode_t iota_api_store_transactions(
     }
     if ((ret = iota_consensus_transaction_solidifier_update_status(
              &api->consensus->transaction_solidifier, tangle, &tx)) != RC_OK) {
-      log_warning(API_LOGGER_ID, "Updating transaction status failed\n");
+      log_warning(logger_id, "Updating transaction status failed\n");
       return ret;
     }
     // TODO store metadata: arrival_time, status, sender (#407)
@@ -512,7 +514,7 @@ retcode_t iota_api_init(iota_api_t *const api, node_t *const node,
     return RC_NULL_PARAM;
   }
 
-  logger_helper_enable(API_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(API_LOGGER_ID, LOGGER_DEBUG, true);
   api->running = false;
   api->node = node;
   api->consensus = consensus;
@@ -554,6 +556,6 @@ retcode_t iota_api_destroy(iota_api_t *const api) {
     return RC_STILL_RUNNING;
   }
 
-  logger_helper_release(API_LOGGER_ID);
+  logger_helper_release(logger_id);
   return RC_OK;
 }

--- a/ciri/core.c
+++ b/ciri/core.c
@@ -10,33 +10,34 @@
 
 #define CORE_LOGGER_ID "core"
 
+static logger_id_t logger_id;
+
 retcode_t core_init(core_t* const core, tangle_t* const tangle) {
   if (core == NULL) {
     return RC_CORE_NULL_CORE;
   }
 
-  logger_helper_enable(CORE_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(CORE_LOGGER_ID, LOGGER_DEBUG, true);
   core->running = false;
 
-  log_info(CORE_LOGGER_ID, "Initializing consensus\n");
+  log_info(logger_id, "Initializing consensus\n");
   if (iota_consensus_init(&core->consensus, tangle,
                           &core->node.transaction_requester,
                           &core->node.tips) != RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Initializing consensus failed\n");
+    log_critical(logger_id, "Initializing consensus failed\n");
     return RC_CORE_FAILED_CONSENSUS_INIT;
   }
 
-  log_info(CORE_LOGGER_ID, "Initializing node gossip components\n");
+  log_info(logger_id, "Initializing node gossip components\n");
   if (node_init(&core->node, core, tangle) != RC_OK) {
-    log_critical(CORE_LOGGER_ID,
-                 "Initializing node gossip components failed\n");
+    log_critical(logger_id, "Initializing node gossip components failed\n");
     return RC_CORE_FAILED_NODE_INIT;
   }
 
-  log_info(CORE_LOGGER_ID, "Initializing API\n");
+  log_info(logger_id, "Initializing API\n");
   if (iota_api_init(&core->api, &core->node, &core->consensus, SR_JSON) !=
       RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Initializing API failed\n");
+    log_critical(logger_id, "Initializing API failed\n");
     return RC_CORE_FAILED_API_INIT;
   }
 
@@ -48,21 +49,21 @@ retcode_t core_start(core_t* const core, tangle_t* const tangle) {
     return RC_CORE_NULL_CORE;
   }
 
-  log_info(CORE_LOGGER_ID, "Starting consensus\n");
+  log_info(logger_id, "Starting consensus\n");
   if (iota_consensus_start(&core->consensus, tangle) != RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Starting consensus failed\n");
+    log_critical(logger_id, "Starting consensus failed\n");
     return RC_CORE_FAILED_CONSENSUS_START;
   }
 
-  log_info(CORE_LOGGER_ID, "Starting node gossip components\n");
+  log_info(logger_id, "Starting node gossip components\n");
   if (node_start(&core->node) != RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Starting node gossip components failed\n");
+    log_critical(logger_id, "Starting node gossip components failed\n");
     return RC_CORE_FAILED_NODE_START;
   }
 
-  log_info(CORE_LOGGER_ID, "Starting API\n");
+  log_info(logger_id, "Starting API\n");
   if (iota_api_start(&core->api) != RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Starting API failed\n");
+    log_critical(logger_id, "Starting API failed\n");
     return RC_CORE_FAILED_API_START;
   }
 
@@ -82,21 +83,21 @@ retcode_t core_stop(core_t* const core) {
 
   core->running = false;
 
-  log_info(CORE_LOGGER_ID, "Stopping node gossip components\n");
+  log_info(logger_id, "Stopping node gossip components\n");
   if (node_stop(&core->node) != RC_OK) {
-    log_error(CORE_LOGGER_ID, "Stopping node gossip components failed\n");
+    log_error(logger_id, "Stopping node gossip components failed\n");
     ret = RC_CORE_FAILED_NODE_STOP;
   }
 
-  log_info(CORE_LOGGER_ID, "Stopping API\n");
+  log_info(logger_id, "Stopping API\n");
   if (iota_api_stop(&core->api) != RC_OK) {
-    log_error(CORE_LOGGER_ID, "Stopping API failed\n");
+    log_error(logger_id, "Stopping API failed\n");
     ret = RC_CORE_FAILED_API_STOP;
   }
 
-  log_info(CORE_LOGGER_ID, "Stopping consensus\n");
+  log_info(logger_id, "Stopping consensus\n");
   if (iota_consensus_stop(&core->consensus) != RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Stopping consensus failed\n");
+    log_critical(logger_id, "Stopping consensus failed\n");
     return RC_CORE_FAILED_CONSENSUS_STOP;
   }
 
@@ -112,24 +113,24 @@ retcode_t core_destroy(core_t* const core) {
     return RC_CORE_STILL_RUNNING;
   }
 
-  log_info(CORE_LOGGER_ID, "Destroying API\n");
+  log_info(logger_id, "Destroying API\n");
   if (iota_api_destroy(&core->api) != RC_OK) {
-    log_error(CORE_LOGGER_ID, "Destroying API failed\n");
+    log_error(logger_id, "Destroying API failed\n");
     ret = RC_CORE_FAILED_API_DESTROY;
   }
 
-  log_info(CORE_LOGGER_ID, "Destroying node gossip components\n");
+  log_info(logger_id, "Destroying node gossip components\n");
   if (node_destroy(&core->node) != RC_OK) {
-    log_error(CORE_LOGGER_ID, "Destroying node gossip components failed\n");
+    log_error(logger_id, "Destroying node gossip components failed\n");
     ret = RC_CORE_FAILED_NODE_DESTROY;
   }
 
-  log_info(CORE_LOGGER_ID, "Destroying consensus\n");
+  log_info(logger_id, "Destroying consensus\n");
   if (iota_consensus_destroy(&core->consensus) != RC_OK) {
-    log_critical(CORE_LOGGER_ID, "Destroying consensus failed\n");
+    log_critical(logger_id, "Destroying consensus failed\n");
     ret = RC_CORE_FAILED_CONSENSUS_DESTROY;
   }
 
-  logger_helper_release(CORE_LOGGER_ID);
+  logger_helper_release(logger_id);
   return ret;
 }

--- a/ciri/main.c
+++ b/ciri/main.c
@@ -16,6 +16,7 @@
 #define STATS_LOG_INTERVAL 10
 
 static core_t core_g;
+static logger_id_t logger_id;
 
 int main(int argc, char* argv[]) {
   int ret = EXIT_SUCCESS;
@@ -27,7 +28,7 @@ int main(int argc, char* argv[]) {
   if (logger_helper_init() != RC_OK) {
     return EXIT_FAILURE;
   }
-  logger_helper_enable(MAIN_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(MAIN_LOGGER_ID, LOGGER_DEBUG, true);
 
   // Default configuration
 
@@ -53,27 +54,27 @@ int main(int argc, char* argv[]) {
 
   logger_output_level_set(stdout, core_g.conf.log_level);
 
-  log_info(MAIN_LOGGER_ID, "Initializing storage\n");
+  log_info(logger_id, "Initializing storage\n");
   if (storage_init() != RC_OK) {
-    log_critical(MAIN_LOGGER_ID, "Initializing storage failed\n");
+    log_critical(logger_id, "Initializing storage failed\n");
     return EXIT_FAILURE;
   }
 
   db_conf.db_path = core_g.conf.db_path;
   if (iota_tangle_init(&tangle, &db_conf) != RC_OK) {
-    log_critical(MAIN_LOGGER_ID, "Initializing tangle connection failed\n");
+    log_critical(logger_id, "Initializing tangle connection failed\n");
     return EXIT_FAILURE;
   }
 
-  log_info(MAIN_LOGGER_ID, "Initializing cIRI core\n");
+  log_info(logger_id, "Initializing cIRI core\n");
   if (core_init(&core_g, &tangle) != RC_OK) {
-    log_critical(MAIN_LOGGER_ID, "Initializing cIRI core failed\n");
+    log_critical(logger_id, "Initializing cIRI core failed\n");
     return EXIT_FAILURE;
   }
 
-  log_info(MAIN_LOGGER_ID, "Starting cIRI core\n");
+  log_info(logger_id, "Starting cIRI core\n");
   if (core_start(&core_g, &tangle) != RC_OK) {
-    log_critical(MAIN_LOGGER_ID, "Starting cIRI core failed\n");
+    log_critical(logger_id, "Starting cIRI core failed\n");
     return EXIT_FAILURE;
   }
 
@@ -90,7 +91,7 @@ int main(int argc, char* argv[]) {
       ret = EXIT_FAILURE;
       break;
     }
-    log_info(MAIN_LOGGER_ID,
+    log_info(logger_id,
              "Transactions: to process %d, to broadcast %d, to request %d, "
              "to reply %d, count %d\n",
              processor_size(&core_g.node.processor),
@@ -100,29 +101,30 @@ int main(int argc, char* argv[]) {
     sleep(STATS_LOG_INTERVAL);
   }
 
-  log_info(MAIN_LOGGER_ID, "Stopping cIRI core\n");
+  log_info(logger_id, "Stopping cIRI core\n");
   if (core_stop(&core_g) != RC_OK) {
-    log_error(MAIN_LOGGER_ID, "Stopping cIRI core failed\n");
+    log_error(logger_id, "Stopping cIRI core failed\n");
     ret = EXIT_FAILURE;
   }
 
-  log_info(MAIN_LOGGER_ID, "Destroying cIRI core\n");
+  log_info(logger_id, "Destroying cIRI core\n");
   if (core_destroy(&core_g) != RC_OK) {
-    log_error(MAIN_LOGGER_ID, "Destroying cIRI core failed\n");
+    log_error(logger_id, "Destroying cIRI core failed\n");
     ret = EXIT_FAILURE;
   }
 
-  log_info(MAIN_LOGGER_ID, "Destroying storage\n");
+  log_info(logger_id, "Destroying storage\n");
   if (storage_destroy() != RC_OK) {
-    log_critical(MAIN_LOGGER_ID, "Destroying storage failed\n");
+    log_error(logger_id, "Destroying storage failed\n");
     ret = EXIT_FAILURE;
   }
 
   if (iota_tangle_destroy(&tangle) != RC_OK) {
-    log_critical(MAIN_LOGGER_ID, "Destroying tangle connection failed\n");
+    log_error(logger_id, "Destroying tangle connection failed\n");
     ret = EXIT_FAILURE;
   }
 
+  logger_helper_release(logger_id);
   if (logger_helper_destroy() != RC_OK) {
     ret = EXIT_FAILURE;
   }

--- a/common/model/transfer.c
+++ b/common/model/transfer.c
@@ -9,6 +9,8 @@
 
 #define TRANSFER_LOGGER_ID "transfer"
 
+static logger_id_t logger_id;
+
 /***********************************************************************************************************
  * Private interface
  ***********************************************************************************************************/
@@ -33,12 +35,12 @@ static void transfer_iterator_next_data_transaction(
         transfer_iterator->transaction->data.signature_or_message, len,
         trans_data->data, data_len, offset, len);
     if (flex_ret == 0) {
-      log_warning(TRANSFER_LOGGER_ID, "[%s:%d] flex_trits slicing failed.\n",
-                  __func__, __LINE__);
+      log_warning(logger_id, "[%s:%d] flex_trits slicing failed.\n", __func__,
+                  __LINE__);
     }
   } else {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] the transfer type doesn't match.\n",
-              __func__, __LINE__);
+    log_error(logger_id, "[%s:%d] the transfer type doesn't match.\n", __func__,
+              __LINE__);
   }
 }
 
@@ -71,12 +73,12 @@ static void transfer_iterator_next_output_transaction(
             transfer_iterator->current_transfer_transaction_index,
         NUM_TRITS_SIGNATURE);
     if (flex_ret == 0) {
-      log_warning(TRANSFER_LOGGER_ID, "[%s:%d] flex_trits slicing failed.\n",
-                  __func__, __LINE__);
+      log_warning(logger_id, "[%s:%d] flex_trits slicing failed.\n", __func__,
+                  __LINE__);
     }
   } else {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] the transfer type doesn't match.\n",
-              __func__, __LINE__);
+    log_error(logger_id, "[%s:%d] the transfer type doesn't match.\n", __func__,
+              __LINE__);
   }
 }
 
@@ -90,8 +92,8 @@ static void transfer_iterator_next_input_transaction(
     memcpy(transaction_signature(tx), value_in->data, value_in->len);
     transaction_set_value(tx, transfer->value);
   } else {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] the transfer type doesn't match.\n",
-              __func__, __LINE__);
+    log_error(logger_id, "[%s:%d] the transfer type doesn't match.\n", __func__,
+              __LINE__);
   }
 }
 
@@ -100,25 +102,23 @@ static void transfer_iterator_next_input_transaction(
  ***********************************************************************************************************/
 
 void transfer_logger_init() {
-  logger_helper_enable(TRANSFER_LOGGER_ID, LOGGER_DEBUG, true);
-  log_info(TRANSFER_LOGGER_ID, "Enable logger %s.\n", TRANSFER_LOGGER_ID);
+  logger_id = logger_helper_enable(TRANSFER_LOGGER_ID, LOGGER_DEBUG, true);
+  log_info(logger_id, "Enable logger %s.\n", TRANSFER_LOGGER_ID);
 }
 
 void transfer_logger_destroy() {
-  log_info(TRANSFER_LOGGER_ID, "Destroy logger %s.\n", TRANSFER_LOGGER_ID);
-  logger_helper_release(TRANSFER_LOGGER_ID);
+  log_info(logger_id, "Destroy logger %s.\n", TRANSFER_LOGGER_ID);
+  logger_helper_release(logger_id);
 }
 
 bool validate_output(transfer_value_out_t const* const output) {
   if (!output->seed) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] seed is NULL.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] seed is NULL.\n", __func__, __LINE__);
     return false;
   }
 
   if (output->security < 1 || output->security > 3) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] security leve error.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] security leve error.\n", __func__, __LINE__);
     return false;
   }
   return true;
@@ -132,20 +132,19 @@ transfer_t* transfer_data_new(flex_trit_t const* const address,
   transfer_data_t* tf_data = NULL;
   transfer_t* transfer = NULL;
   if (!address) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] address cannot be NULL.\n", __func__,
+    log_error(logger_id, "[%s:%d] address cannot be NULL.\n", __func__,
               __LINE__);
     return NULL;
   }
 
   if (!tag) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] tag cannot be NULL.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] tag cannot be NULL.\n", __func__, __LINE__);
     return NULL;
   }
 
   if (!data && data_len != 0) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] data length should be 0.\n",
-              __func__, __LINE__);
+    log_error(logger_id, "[%s:%d] data length should be 0.\n", __func__,
+              __LINE__);
     return NULL;
   }
 
@@ -154,8 +153,7 @@ transfer_t* transfer_data_new(flex_trit_t const* const address,
     transfer = (transfer_t*)calloc(1, sizeof(transfer_t));
     if (!transfer) {
       free(tf_data);
-      log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-                __LINE__);
+      log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
       return NULL;
     }
 
@@ -180,27 +178,24 @@ transfer_t* transfer_value_out_new(transfer_value_out_t const* const output,
   transfer_value_out_t* value_out = NULL;
   transfer_t* tf = NULL;
   if (!validate_output(output)) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] output is invalid.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] output is invalid.\n", __func__, __LINE__);
     return NULL;
   }
 
   if (!address) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] address cannot be NULL.\n", __func__,
+    log_error(logger_id, "[%s:%d] address cannot be NULL.\n", __func__,
               __LINE__);
     return NULL;
   }
 
   if (!tag) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] tag cannot be NULL.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] tag cannot be NULL.\n", __func__, __LINE__);
     return NULL;
   }
 
   tf = (transfer_t*)calloc(1, sizeof(transfer_t));
   if (!tf) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
     return NULL;
   }
 
@@ -228,35 +223,32 @@ transfer_t* transfer_value_in_new(flex_trit_t const* const address,
   transfer_value_in_t* value_in = NULL;
   transfer_t* tf = NULL;
   if (!address) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] address cannot be NULL.\n", __func__,
+    log_error(logger_id, "[%s:%d] address cannot be NULL.\n", __func__,
               __LINE__);
     return NULL;
   }
 
   if (!tag) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] tag cannot be NULL.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] tag cannot be NULL.\n", __func__, __LINE__);
     return NULL;
   }
 
   if (!data && data_len != 0) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] data length should be 0.\n",
-              __func__, __LINE__);
+    log_error(logger_id, "[%s:%d] data length should be 0.\n", __func__,
+              __LINE__);
     return NULL;
   }
 
   tf = (transfer_t*)calloc(1, sizeof(transfer_t));
   if (!tf) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
     return NULL;
   }
 
   value_in = (transfer_value_in_t*)calloc(1, sizeof(transfer_value_in_t));
   if (!value_in) {
     free(tf);
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
     return NULL;
   }
   value_in->len = data_len;
@@ -300,8 +292,7 @@ size_t transfer_transactions_count(transfer_t* tf) {
 transfer_ctx_t* transfer_ctx_new() {
   transfer_ctx_t* tf_ctx = (transfer_ctx_t*)calloc(1, sizeof(transfer_ctx_t));
   if (!tf_ctx) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
     return NULL;
   }
   memset(tf_ctx->bundle, FLEX_TRIT_NULL_VALUE, FLEX_TRIT_SIZE_243);
@@ -355,8 +346,7 @@ transfer_iterator_t* transfer_iterator_new(transfer_t* transfers[], size_t len,
   transfer_iterator_t* transfer_iterator =
       (transfer_iterator_t*)calloc(1, sizeof(transfer_iterator_t));
   if (!transfer_iterator) {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
     return NULL;
   }
 
@@ -374,8 +364,7 @@ transfer_iterator_t* transfer_iterator_new(transfer_t* transfers[], size_t len,
   transfer_ctx = transfer_ctx_new();
   if (!transfer_ctx) {
     transfer_iterator_free(&transfer_iterator);
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Out of Memory.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Out of Memory.\n", __func__, __LINE__);
     return NULL;
   }
   if (transfer_ctx_init(transfer_ctx, transfers, len)) {
@@ -384,8 +373,7 @@ transfer_iterator_t* transfer_iterator_new(transfer_t* transfers[], size_t len,
     memcpy(transfer_iterator->bundle_hash, transfer_ctx->bundle,
            FLEX_TRIT_SIZE_243);
   } else {
-    log_error(TRANSFER_LOGGER_ID, "[%s:%d] Invalid transfers.\n", __func__,
-              __LINE__);
+    log_error(logger_id, "[%s:%d] Invalid transfers.\n", __func__, __LINE__);
   }
   transfer_ctx_free(transfer_ctx);
   transfer_iterator->iota_signature_gen = iota_flex_sign_signature_gen;

--- a/common/storage/BUILD
+++ b/common/storage/BUILD
@@ -22,6 +22,5 @@ cc_library(
     deps = [
         "//common:errors",
         "//common/trinary:trit_array",
-        "//utils:logger_helper",
     ],
 )

--- a/common/storage/pack.c
+++ b/common/storage/pack.c
@@ -9,9 +9,6 @@
 
 #include "common/storage/pack.h"
 #include "common/trinary/trit_array.h"
-#include "utils/logger_helper.h"
-
-#define STORAGE_PACKS_LOGGER_ID "storage_packs"
 
 retcode_t hash_pack_resize(iota_stor_pack_t *pack, size_t resize_factor) {
   if (resize_factor < 1) {
@@ -26,7 +23,6 @@ retcode_t hash_pack_resize(iota_stor_pack_t *pack, size_t resize_factor) {
   pack->capacity *= resize_factor;
   pack->models = realloc(pack->models, sizeof(flex_trit_t *) * pack->capacity);
   if (pack->models == NULL) {
-    log_error(STORAGE_PACKS_LOGGER_ID, "Failed in realloc\n");
     return RC_STORAGE_OOM;
   }
 
@@ -46,7 +42,6 @@ retcode_t hash_pack_init(iota_stor_pack_t *pack, size_t size) {
   pack->insufficient_capacity = false;
   pack->models = malloc(sizeof(flex_trit_t *) * pack->capacity);
   if (pack->models == NULL) {
-    log_error(STORAGE_PACKS_LOGGER_ID, "Failed in malloc\n");
     return RC_STORAGE_OOM;
   }
 

--- a/common/storage/sql/sqlite3/connection.c
+++ b/common/storage/sql/sqlite3/connection.c
@@ -17,6 +17,8 @@
 
 #define SQLITE3_LOGGER_ID "sqlite3"
 
+static logger_id_t logger_id;
+
 static retcode_t prepare_statements(sqlite3_connection_t* const connection) {
   retcode_t ret = RC_OK;
 
@@ -114,7 +116,7 @@ static retcode_t prepare_statements(sqlite3_connection_t* const connection) {
                            iota_statement_state_delta_load);
 
   if (ret != RC_OK) {
-    log_error(SQLITE3_LOGGER_ID, "Preparing statements failed\n");
+    log_error(logger_id, "Preparing statements failed\n");
   }
 
   return ret;
@@ -166,7 +168,7 @@ static retcode_t finalize_statements(sqlite3_connection_t* const connection) {
   ret |= finalize_statement(connection->statements.state_delta_load);
 
   if (ret != RC_OK) {
-    log_error(SQLITE3_LOGGER_ID, "Finalizing statements failed\n");
+    log_error(logger_id, "Finalizing statements failed\n");
   }
 
   return ret;
@@ -183,21 +185,22 @@ retcode_t connection_init(storage_connection_t* const connection,
     return RC_NULL_PARAM;
   }
 
+  logger_id = logger_helper_enable(SQLITE3_LOGGER_ID, LOGGER_DEBUG, true);
+
   if ((connection->actual = calloc(1, sizeof(sqlite3_connection_t))) == NULL) {
     return RC_OOM;
   }
   sqlite3_connection = (sqlite3_connection_t*)connection->actual;
 
   if (config->db_path == NULL) {
-    log_critical(SQLITE3_LOGGER_ID, "No path for db specified\n");
+    log_critical(logger_id, "No path for db specified\n");
     return RC_SQLITE3_NO_PATH_FOR_DB_SPECIFIED;
   }
 
   if ((rc = sqlite3_open_v2(config->db_path, &sqlite3_connection->db,
                             SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX,
                             NULL)) != SQLITE_OK) {
-    log_critical(SQLITE3_LOGGER_ID, "Failed to open db on path: %s\n",
-                 config->db_path);
+    log_critical(logger_id, "Failed to open db on path: %s\n", config->db_path);
     return RC_SQLITE3_FAILED_OPEN_DB;
   }
 

--- a/common/storage/sql/sqlite3/storage.c
+++ b/common/storage/sql/sqlite3/storage.c
@@ -24,14 +24,15 @@
 
 #define SQLITE3_LOGGER_ID "sqlite3"
 
+static logger_id_t logger_id;
+
 static void error_log_callback(void* const arg, int const err_code,
                                char const* const message) {
-  log_error(SQLITE3_LOGGER_ID, "Failed with error code %d: %s\n", err_code,
-            message);
+  log_error(logger_id, "Failed with error code %d: %s\n", err_code, message);
 }
 
 retcode_t storage_init() {
-  logger_helper_enable(SQLITE3_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(SQLITE3_LOGGER_ID, LOGGER_DEBUG, true);
 
   if (sqlite3_config(SQLITE_CONFIG_LOG, error_log_callback, NULL) !=
       SQLITE_OK) {
@@ -56,7 +57,7 @@ retcode_t storage_init() {
 }
 
 retcode_t storage_destroy() {
-  logger_helper_release(SQLITE3_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   if (sqlite3_shutdown() != SQLITE_OK) {
     return RC_SQLITE3_FAILED_SHUTDOWN;

--- a/consensus/conf.c
+++ b/consensus/conf.c
@@ -15,6 +15,8 @@
 
 #define CONSENSUS_CONF_LOGGER_ID "consensus_conf"
 
+static logger_id_t logger_id;
+
 retcode_t iota_snapshot_conf_init(iota_consensus_conf_t *const conf) {
   retcode_t ret = RC_OK;
   FILE *file = NULL;
@@ -24,16 +26,14 @@ retcode_t iota_snapshot_conf_init(iota_consensus_conf_t *const conf) {
         *coordinator = NULL;
 
   if ((file = fopen(conf->snapshot_conf_file, "r")) == NULL) {
-    log_error(CONSENSUS_CONF_LOGGER_ID,
-              "Snapshot configuration file not found\n");
+    log_error(logger_id, "Snapshot configuration file not found\n");
     ret = RC_SNAPSHOT_FILE_NOT_FOUND;
     goto done;
   }
 
   if (fseek(file, 0, SEEK_END) < 0 || (len = ftell(file)) <= 0 ||
       fseek(file, 0, SEEK_SET) < 0) {
-    log_error(CONSENSUS_CONF_LOGGER_ID,
-              "Invalid snapshot configuration file\n");
+    log_error(logger_id, "Invalid snapshot configuration file\n");
     ret = RC_SNAPSHOT_INVALID_FILE;
     goto done;
   }
@@ -44,8 +44,7 @@ retcode_t iota_snapshot_conf_init(iota_consensus_conf_t *const conf) {
   }
 
   if (fread(content, 1, len, file) < 0) {
-    log_error(CONSENSUS_CONF_LOGGER_ID,
-              "Invalid snapshot configuration file\n");
+    log_error(logger_id, "Invalid snapshot configuration file\n");
     ret = RC_SNAPSHOT_INVALID_FILE;
     goto done;
   }
@@ -112,7 +111,7 @@ retcode_t iota_snapshot_conf_init(iota_consensus_conf_t *const conf) {
 json_error : {
   const char *error_ptr = cJSON_GetErrorPtr();
   if (error_ptr != NULL) {
-    log_error(CONSENSUS_CONF_LOGGER_ID, "%s\n", error_ptr);
+    log_error(logger_id, "%s\n", error_ptr);
   }
   ret = RC_SNAPSHOT_FAILED_JSON_PARSING;
 }
@@ -137,7 +136,8 @@ retcode_t iota_consensus_conf_init(iota_consensus_conf_t *const conf) {
     return RC_NULL_PARAM;
   }
 
-  logger_helper_enable(CONSENSUS_CONF_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(CONSENSUS_CONF_LOGGER_ID, LOGGER_DEBUG, true);
 
   memset(conf->genesis_hash, FLEX_TRIT_NULL_VALUE, FLEX_TRIT_SIZE_243);
   conf->max_depth = DEFAULT_TIP_SELECTION_MAX_DEPTH;
@@ -151,7 +151,7 @@ retcode_t iota_consensus_conf_init(iota_consensus_conf_t *const conf) {
 
   ret = iota_snapshot_conf_init(conf);
 
-  logger_helper_release(CONSENSUS_CONF_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   return ret;
 }

--- a/consensus/consensus.c
+++ b/consensus/consensus.c
@@ -10,87 +10,84 @@
 
 #define CONSENSUS_LOGGER_ID "consensus"
 
+static logger_id_t logger_id;
+
 retcode_t iota_consensus_init(
     iota_consensus_t *const consensus, tangle_t *const tangle,
     transaction_requester_t *const transaction_requester,
     tips_cache_t *const tips) {
   retcode_t ret = RC_OK;
 
-  logger_helper_enable(CONSENSUS_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(CONSENSUS_LOGGER_ID, LOGGER_DEBUG, true);
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing bundle validator\n");
+  log_info(logger_id, "Initializing bundle validator\n");
   if ((ret = iota_consensus_bundle_validator_init()) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID, "Initializing bundle validator failed\n");
+    log_critical(logger_id, "Initializing bundle validator failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID,
-           "Initializing cumulative weight rating calculator\n");
+  log_info(logger_id, "Initializing cumulative weight rating calculator\n");
   if ((ret = iota_consensus_cw_rating_init(
            &consensus->cw_rating_calculator,
            DEFAULT_TIP_SELECTION_CW_CALC_IMPL)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
+    log_critical(logger_id,
                  "Initializing cumulative weight rating calculator failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing entry point selector\n");
+  log_info(logger_id, "Initializing entry point selector\n");
   if ((ret = iota_consensus_entry_point_selector_init(
            &consensus->entry_point_selector, &consensus->milestone_tracker)) !=
       RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
-                 "Initializing entry point selector failed\n");
+    log_critical(logger_id, "Initializing entry point selector failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing exit probability randomizer\n");
+  log_info(logger_id, "Initializing exit probability randomizer\n");
   if ((ret = iota_consensus_ep_randomizer_init(
            &consensus->ep_randomizer, &consensus->conf,
            DEFAULT_TIP_SELECTION_EP_RAND_IMPL)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
+    log_critical(logger_id,
                  "Initializing exit probability randomizer failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID,
-           "Initializing exit probability transaction validator\n");
+  log_info(logger_id, "Initializing exit probability transaction validator\n");
   if ((ret = iota_consensus_exit_prob_transaction_validator_init(
            &consensus->conf, &consensus->milestone_tracker,
            &consensus->ledger_validator,
            &consensus->exit_prob_transaction_validator)) != RC_OK) {
     log_critical(
-        CONSENSUS_LOGGER_ID,
+        logger_id,
         "Initializing exit probability transaction validator failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing snapshot\n");
+  log_info(logger_id, "Initializing snapshot\n");
   if ((ret = iota_snapshot_init(&consensus->snapshot, &consensus->conf)) !=
       RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID, "Initializing snapshot failed\n");
+    log_critical(logger_id, "Initializing snapshot failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing transaction solidifier\n");
+  log_info(logger_id, "Initializing transaction solidifier\n");
   if ((ret = iota_consensus_transaction_solidifier_init(
            &consensus->transaction_solidifier, &consensus->conf,
            transaction_requester, tips)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
-                 "Initializing transaction solidifier failed\n");
+    log_critical(logger_id, "Initializing transaction solidifier failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing milestone tracker\n");
+  log_info(logger_id, "Initializing milestone tracker\n");
   if ((ret = iota_milestone_tracker_init(
            &consensus->milestone_tracker, &consensus->conf,
            &consensus->snapshot, &consensus->ledger_validator,
            &consensus->transaction_solidifier)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
-                 "Initializing milestone tracker failed\n");
+    log_critical(logger_id, "Initializing milestone tracker failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing tip selector\n");
+  log_info(logger_id, "Initializing tip selector\n");
   if ((ret = iota_consensus_tip_selector_init(
            &consensus->tip_selector, &consensus->conf,
            &consensus->cw_rating_calculator, &consensus->entry_point_selector,
@@ -98,23 +95,22 @@ retcode_t iota_consensus_init(
            &consensus->exit_prob_transaction_validator,
            &consensus->ledger_validator, &consensus->milestone_tracker)) !=
       RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID, "Initializing tip selector failed\n");
+    log_critical(logger_id, "Initializing tip selector failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing transaction validator\n");
+  log_info(logger_id, "Initializing transaction validator\n");
   if ((ret = iota_consensus_transaction_validator_init(
            &consensus->transaction_validator, &consensus->conf)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
-                 "Initializing transaction validator failed\n");
+    log_critical(logger_id, "Initializing transaction validator failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Initializing ledger validator\n");
+  log_info(logger_id, "Initializing ledger validator\n");
   if ((ret = iota_consensus_ledger_validator_init(
            &consensus->ledger_validator, tangle, &consensus->conf,
            &consensus->milestone_tracker)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID, "Initializing ledger validator failed\n");
+    log_critical(logger_id, "Initializing ledger validator failed\n");
     return ret;
   }
 
@@ -125,18 +121,17 @@ retcode_t iota_consensus_start(iota_consensus_t *const consensus,
                                tangle_t *const tangle) {
   retcode_t ret = RC_OK;
 
-  log_info(CONSENSUS_LOGGER_ID, "Starting milestone tracker\n");
+  log_info(logger_id, "Starting milestone tracker\n");
   if ((ret = iota_milestone_tracker_start(&consensus->milestone_tracker,
                                           tangle)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID, "Starting milestone tracker failed\n");
+    log_critical(logger_id, "Starting milestone tracker failed\n");
     return ret;
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Starting transaction solidifier\n");
+  log_info(logger_id, "Starting transaction solidifier\n");
   if ((ret = iota_consensus_transaction_solidifier_start(
            &consensus->transaction_solidifier)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
-                 "Starting transaction solidifier failed\n");
+    log_critical(logger_id, "Starting transaction solidifier failed\n");
     return ret;
   }
 
@@ -146,17 +141,16 @@ retcode_t iota_consensus_start(iota_consensus_t *const consensus,
 retcode_t iota_consensus_stop(iota_consensus_t *const consensus) {
   retcode_t ret = RC_OK;
 
-  log_info(CONSENSUS_LOGGER_ID, "Stopping milestone tracker\n");
+  log_info(logger_id, "Stopping milestone tracker\n");
   if ((ret = iota_milestone_tracker_stop(&consensus->milestone_tracker)) !=
       RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID, "Stopping milestone tracker failed\n");
+    log_critical(logger_id, "Stopping milestone tracker failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Stopping transaction solidifier\n");
+  log_info(logger_id, "Stopping transaction solidifier\n");
   if ((ret = iota_consensus_transaction_solidifier_stop(
            &consensus->transaction_solidifier)) != RC_OK) {
-    log_critical(CONSENSUS_LOGGER_ID,
-                 "Stopping transaction solidifier failed\n");
+    log_critical(logger_id, "Stopping transaction solidifier failed\n");
   }
 
   return ret;
@@ -165,76 +159,72 @@ retcode_t iota_consensus_stop(iota_consensus_t *const consensus) {
 retcode_t iota_consensus_destroy(iota_consensus_t *const consensus) {
   retcode_t ret = RC_OK;
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying bundle validator\n");
+  log_info(logger_id, "Destroying bundle validator\n");
   if ((ret = iota_consensus_bundle_validator_destroy()) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying bundle validator failed\n");
+    log_error(logger_id, "Destroying bundle validator failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID,
-           "Destroying cumulative weight rating calculator\n");
+  log_info(logger_id, "Destroying cumulative weight rating calculator\n");
   if ((ret = iota_consensus_cw_rating_destroy(
            &consensus->cw_rating_calculator)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID,
+    log_error(logger_id,
               "Destroying cumulative weight rating calculator failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying entry point selector\n");
+  log_info(logger_id, "Destroying entry point selector\n");
   if ((ret = iota_consensus_entry_point_selector_destroy(
            &consensus->entry_point_selector)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying entry point selector failed\n");
+    log_error(logger_id, "Destroying entry point selector failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying exit probability randomizer\n");
+  log_info(logger_id, "Destroying exit probability randomizer\n");
   if ((ret = iota_consensus_ep_randomizer_destroy(&consensus->ep_randomizer)) !=
       RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID,
-              "Destroying exit probability randomizer failed\n");
+    log_error(logger_id, "Destroying exit probability randomizer failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID,
-           "Destroying exit probability transaction validator\n");
+  log_info(logger_id, "Destroying exit probability transaction validator\n");
   if ((ret = iota_consensus_exit_prob_transaction_validator_destroy(
            &consensus->exit_prob_transaction_validator)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID,
+    log_error(logger_id,
               "Destroying exit probability transaction validator failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying ledger validator\n");
+  log_info(logger_id, "Destroying ledger validator\n");
   if ((ret = iota_consensus_ledger_validator_destroy(
            &consensus->ledger_validator)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying ledger validator failed\n");
+    log_error(logger_id, "Destroying ledger validator failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying milestone tracker\n");
+  log_info(logger_id, "Destroying milestone tracker\n");
   if ((ret = iota_milestone_tracker_destroy(&consensus->milestone_tracker)) !=
       RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying milestone tracker failed\n");
+    log_error(logger_id, "Destroying milestone tracker failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying transaction solidifier\n");
+  log_info(logger_id, "Destroying transaction solidifier\n");
   if ((ret = iota_consensus_transaction_solidifier_destroy(
            &consensus->transaction_solidifier)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID,
-              "Destroying transaction solidifier failed\n");
+    log_error(logger_id, "Destroying transaction solidifier failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying snapshot\n");
+  log_info(logger_id, "Destroying snapshot\n");
   if ((ret = iota_snapshot_destroy(&consensus->snapshot)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying snapshot failed\n");
+    log_error(logger_id, "Destroying snapshot failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying tip selector\n");
+  log_info(logger_id, "Destroying tip selector\n");
   if ((ret = iota_consensus_tip_selector_destroy(&consensus->tip_selector))) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying tip selector failed\n");
+    log_error(logger_id, "Destroying tip selector failed\n");
   }
 
-  log_info(CONSENSUS_LOGGER_ID, "Destroying transaction validator\n");
+  log_info(logger_id, "Destroying transaction validator\n");
   if ((ret = iota_consensus_transaction_validator_destroy(
            &consensus->transaction_validator)) != RC_OK) {
-    log_error(CONSENSUS_LOGGER_ID, "Destroying transaction validator failed\n");
+    log_error(logger_id, "Destroying transaction validator failed\n");
   }
 
-  logger_helper_release(CONSENSUS_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   return ret;
 }

--- a/consensus/cw_rating_calculator/cw_rating_calculator.c
+++ b/consensus/cw_rating_calculator/cw_rating_calculator.c
@@ -9,9 +9,14 @@
 #include "consensus/cw_rating_calculator/cw_rating_dfs_impl.h"
 #include "utils/logger_helper.h"
 
+#define CW_RATING_CALCULATOR_LOGGER_ID "cw_rating_calculator"
+
+static logger_id_t logger_id;
+
 retcode_t iota_consensus_cw_rating_init(cw_rating_calculator_t *const cw_calc,
                                         cw_calculation_implementation_t impl) {
-  logger_helper_enable(CW_RATING_CALCULATOR_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(CW_RATING_CALCULATOR_LOGGER_ID, LOGGER_DEBUG, true);
   if (impl == DFS_FROM_ENTRY_POINT) {
     init_cw_calculator_dfs(&cw_calc->base);
     return RC_OK;
@@ -20,7 +25,7 @@ retcode_t iota_consensus_cw_rating_init(cw_rating_calculator_t *const cw_calc,
 }
 
 retcode_t iota_consensus_cw_rating_destroy(cw_rating_calculator_t *cw_calc) {
-  logger_helper_release(CW_RATING_CALCULATOR_LOGGER_ID);
+  logger_helper_release(logger_id);
   return RC_OK;
 }
 
@@ -28,7 +33,7 @@ retcode_t iota_consensus_cw_rating_calculate(
     cw_rating_calculator_t const *const calculator, tangle_t *const tangle,
     flex_trit_t const *entry_point, cw_calc_result *out) {
   if (calculator->base.vtable.cw_rating_calculate == NULL) {
-    log_error(CW_RATING_CALCULATOR_LOGGER_ID, "Vtable is not initialized\n");
+    log_error(logger_id, "Vtable is not initialized\n");
     return RC_CONSENSUS_NULL_PTR;
   }
   return calculator->base.vtable.cw_rating_calculate(calculator, tangle,

--- a/consensus/cw_rating_calculator/cw_rating_calculator.h
+++ b/consensus/cw_rating_calculator/cw_rating_calculator.h
@@ -19,8 +19,6 @@
 #include "utils/containers/hash/hash_int64_t_map.h"
 #include "utils/hash_indexed_map.h"
 
-#define CW_RATING_CALCULATOR_LOGGER_ID "consensus_cw_rating_calculator"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/consensus/entry_point_selector/entry_point_selector.c
+++ b/consensus/entry_point_selector/entry_point_selector.c
@@ -16,9 +16,12 @@
 
 #define ENTRY_POINT_SELECTOR_LOGGER_ID "entry_point_selector"
 
+static logger_id_t logger_id;
+
 retcode_t iota_consensus_entry_point_selector_init(
     entry_point_selector_t *const eps, milestone_tracker_t *const mt) {
-  logger_helper_enable(ENTRY_POINT_SELECTOR_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(ENTRY_POINT_SELECTOR_LOGGER_ID, LOGGER_DEBUG, true);
   eps->mt = mt;
   return RC_OK;
 }
@@ -32,7 +35,7 @@ retcode_t iota_consensus_entry_point_selector_get_entry_point(
   DECLARE_PACK_SINGLE_MILESTONE(milestone, milestone_ptr, pack);
 
   if ((ret = iota_tangle_milestone_load_next(tangle, milestone_index, &pack))) {
-    log_error(ENTRY_POINT_SELECTOR_LOGGER_ID,
+    log_error(logger_id,
               "Finding closest next milestone failed with error %" PRIu64 "\n",
               ret);
     return ret;
@@ -49,7 +52,7 @@ retcode_t iota_consensus_entry_point_selector_get_entry_point(
 
 retcode_t iota_consensus_entry_point_selector_destroy(
     entry_point_selector_t *const eps) {
-  logger_helper_release(ENTRY_POINT_SELECTOR_LOGGER_ID);
+  logger_helper_release(logger_id);
   eps->mt = NULL;
   return RC_OK;
 }

--- a/consensus/exit_probability_randomizer/exit_prob_map.c
+++ b/consensus/exit_probability_randomizer/exit_prob_map.c
@@ -14,7 +14,9 @@
 #include "utils/logger_helper.h"
 #include "utils/macros.h"
 
-#define EXIT_PROB_MAP_LOGGER_ID "consensus_exit_prob_map"
+#define EXIT_PROB_MAP_LOGGER_ID "exit_prob_map"
+
+static logger_id_t logger_id;
 
 /*
  * Private functions
@@ -45,8 +47,8 @@ static retcode_t iota_consensus_exit_prob_remove_invalid_tip_candidates(
     if ((ret = iota_consensus_exit_prob_transaction_validator_is_valid(
              ep_validator, tangle, tip_entry->hash, &has_valid_tail)) !=
         RC_OK) {
-      log_error(EXIT_PROB_MAP_LOGGER_ID,
-                "Tail transaction validation failed: %" PRIu64 "\n", ret);
+      log_error(logger_id, "Tail transaction validation failed: %" PRIu64 "\n",
+                ret);
       goto done;
     }
     if (!has_valid_tail) {
@@ -73,6 +75,7 @@ void iota_consensus_exit_prob_map_init(ep_randomizer_t *const randomizer) {
       (ep_prob_map_randomizer_t *const)randomizer;
   prob_randomizer->exit_probs = NULL;
   prob_randomizer->transition_probs = NULL;
+  logger_id = logger_helper_enable(EXIT_PROB_MAP_LOGGER_ID, LOGGER_DEBUG, true);
 }
 
 retcode_t iota_consensus_exit_prob_map_randomize(
@@ -134,11 +137,10 @@ retcode_t iota_consensus_exit_prob_map_calculate_probs(
 
   if ((ret = iota_consensus_exit_prob_transaction_validator_is_valid(
            ep_validator, tangle, ep, &ep_is_valid)) != RC_OK) {
-    log_error(EXIT_PROB_MAP_LOGGER_ID,
-              "Entry point validation failed: %" PRIu64 "\n", ret);
+    log_error(logger_id, "Entry point validation failed: %" PRIu64 "\n", ret);
     return ret;
   } else if (!ep_is_valid) {
-    log_error(EXIT_PROB_MAP_LOGGER_ID, "Invalid entry point\n");
+    log_error(logger_id, "Invalid entry point\n");
     return RC_CONSENSUS_EXIT_PROBABILITIES_INVALID_ENTRYPOINT;
   }
 
@@ -218,6 +220,7 @@ double iota_consensus_exit_prob_map_sum_probs(
 
 retcode_t iota_consensus_exit_prob_map_destroy(
     ep_randomizer_t *const exit_probability_randomizer) {
+  logger_helper_release(logger_id);
   return iota_consensus_exit_prob_map_reset(exit_probability_randomizer);
 }
 

--- a/consensus/exit_probability_randomizer/exit_probability_randomizer.c
+++ b/consensus/exit_probability_randomizer/exit_probability_randomizer.c
@@ -13,11 +13,13 @@
 
 #define EXIT_PROBABILITY_RANDOMIZER_LOGGER_ID "exit_probability_randomizer"
 
+static logger_id_t logger_id;
+
 retcode_t iota_consensus_ep_randomizer_init(
     ep_randomizer_t *const ep_randomizer, iota_consensus_conf_t *const conf,
     ep_randomizer_implementation_t impl) {
-  logger_helper_enable(EXIT_PROBABILITY_RANDOMIZER_LOGGER_ID, LOGGER_DEBUG,
-                       true);
+  logger_id = logger_helper_enable(EXIT_PROBABILITY_RANDOMIZER_LOGGER_ID,
+                                   LOGGER_DEBUG, true);
   rand_handle_seed(time(NULL));
   ep_randomizer->conf = conf;
   if (impl == EP_RANDOM_WALK) {
@@ -35,7 +37,7 @@ retcode_t iota_consensus_ep_randomizer_destroy(
   if (ep_randomizer->base.vtable.exit_probability_destroy != NULL) {
     ep_randomizer->base.vtable.exit_probability_destroy(ep_randomizer);
   }
-  logger_helper_release(EXIT_PROBABILITY_RANDOMIZER_LOGGER_ID);
+  logger_helper_release(logger_id);
   return RC_OK;
 }
 

--- a/consensus/exit_probability_validator/exit_probability_validator.c
+++ b/consensus/exit_probability_validator/exit_probability_validator.c
@@ -11,6 +11,8 @@
 
 #define WALKER_VALIDATOR_LOGGER_ID "walker_validator"
 
+static logger_id_t logger_id;
+
 /*
  * Private functions
  */
@@ -36,8 +38,7 @@ static retcode_t iota_consensus_exit_prob_transaction_validator_below_max_depth(
 
   while (non_analyzed_hashes != NULL) {
     if (hash243_set_size(&visited_hashes) == epv->conf->below_max_depth) {
-      log_error(WALKER_VALIDATOR_LOGGER_ID,
-                "Validation failed, exceeded num of transactions\n");
+      log_error(logger_id, "Validation failed, exceeded num of transactions\n");
       *below_max_depth = true;
       break;
     }
@@ -67,7 +68,7 @@ static retcode_t iota_consensus_exit_prob_transaction_validator_below_max_depth(
     }
 
     if (curr_snapshot_index < lowest_allowed_depth) {
-      log_error(WALKER_VALIDATOR_LOGGER_ID,
+      log_error(logger_id,
                 "Validation failed, transaction is below max depth\n");
       *below_max_depth = true;
       break;
@@ -102,7 +103,8 @@ static retcode_t iota_consensus_exit_prob_transaction_validator_below_max_depth(
 retcode_t iota_consensus_exit_prob_transaction_validator_init(
     iota_consensus_conf_t *const conf, milestone_tracker_t *const mt,
     ledger_validator_t *const lv, exit_prob_transaction_validator_t *epv) {
-  logger_helper_enable(WALKER_VALIDATOR_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(WALKER_VALIDATOR_LOGGER_ID, LOGGER_DEBUG, true);
   epv->conf = conf;
   epv->mt = mt;
   epv->lv = lv;
@@ -114,7 +116,7 @@ retcode_t iota_consensus_exit_prob_transaction_validator_init(
 
 retcode_t iota_consensus_exit_prob_transaction_validator_destroy(
     exit_prob_transaction_validator_t *epv) {
-  logger_helper_release(WALKER_VALIDATOR_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   hash243_set_free(&epv->max_depth_ok_memoization);
   hash243_set_free(&epv->analyzed_hashes);
@@ -141,14 +143,12 @@ retcode_t iota_consensus_exit_prob_transaction_validator_is_valid(
 
   if (tx_pack.num_loaded == 0) {
     *is_valid = false;
-    log_error(WALKER_VALIDATOR_LOGGER_ID,
-              "Validation failed, transaction is missing in db\n");
+    log_error(logger_id, "Validation failed, transaction is missing in db\n");
     return RC_OK;
   }
 
   if (transaction_current_index(&tx) != 0) {
-    log_error(WALKER_VALIDATOR_LOGGER_ID,
-              "Validation failed, transaction is not a tail\n");
+    log_error(logger_id, "Validation failed, transaction is not a tail\n");
     *is_valid = false;
     return RC_OK;
   }
@@ -161,8 +161,7 @@ retcode_t iota_consensus_exit_prob_transaction_validator_is_valid(
   }
 
   if (!*is_valid) {
-    log_error(WALKER_VALIDATOR_LOGGER_ID,
-              "Validation failed, tail is inconsistent\n");
+    log_error(logger_id, "Validation failed, tail is inconsistent\n");
     return RC_OK;
   }
 
@@ -182,8 +181,7 @@ retcode_t iota_consensus_exit_prob_transaction_validator_is_valid(
 
   if (below_max_depth) {
     *is_valid = false;
-    log_error(WALKER_VALIDATOR_LOGGER_ID,
-              "Validation failed, tail is below max depth\n");
+    log_error(logger_id, "Validation failed, tail is below max depth\n");
     return RC_OK;
   }
 

--- a/consensus/snapshot/snapshot.c
+++ b/consensus/snapshot/snapshot.c
@@ -13,6 +13,8 @@
 
 #define SNAPSHOT_LOGGER_ID "snapshot"
 
+static logger_id_t logger_id;
+
 /*
  * Private functions
  */
@@ -28,7 +30,7 @@ static retcode_t iota_snapshot_initial_state(snapshot_t *const snapshot,
   flex_trit_t hash[FLEX_TRIT_SIZE_243];
 
   if ((fp = fopen(snapshot_file, "r")) == NULL) {
-    log_critical(SNAPSHOT_LOGGER_ID, "Opening snapshot file failed\n");
+    log_critical(logger_id, "Opening snapshot file failed\n");
     ret = RC_SNAPSHOT_FILE_NOT_FOUND;
     goto done;
   }
@@ -36,7 +38,7 @@ static retcode_t iota_snapshot_initial_state(snapshot_t *const snapshot,
   while ((rd = getline(&line, &len, fp)) > 0) {
     line[--rd] = '\0';
     if ((delim = strchr(line, ';')) == NULL) {
-      log_critical(SNAPSHOT_LOGGER_ID, "Badly formatted snapshot file\n");
+      log_critical(logger_id, "Badly formatted snapshot file\n");
       ret = RC_SNAPSHOT_INVALID_FILE;
       goto done;
     }
@@ -51,13 +53,13 @@ static retcode_t iota_snapshot_initial_state(snapshot_t *const snapshot,
       supply += value;
     } else if (value < 0) {
       ret = RC_SNAPSHOT_INCONSISTENT_SNAPSHOT;
-      log_critical(SNAPSHOT_LOGGER_ID, "Inconsistent snapshot\n");
+      log_critical(logger_id, "Inconsistent snapshot\n");
       goto done;
     }
   }
   if (supply != IOTA_SUPPLY) {
     ret = RC_SNAPSHOT_INVALID_SUPPLY;
-    log_critical(SNAPSHOT_LOGGER_ID, "Invalid snapshot supply: %ld\n", supply);
+    log_critical(logger_id, "Invalid snapshot supply: %ld\n", supply);
     goto done;
   }
 
@@ -83,7 +85,7 @@ retcode_t iota_snapshot_init(snapshot_t *const snapshot,
     return RC_SNAPSHOT_NULL_SELF;
   }
 
-  logger_helper_enable(SNAPSHOT_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(SNAPSHOT_LOGGER_ID, LOGGER_DEBUG, true);
   rw_lock_handle_init(&snapshot->rw_lock);
   snapshot->conf = conf;
   snapshot->index = 0;
@@ -96,20 +98,18 @@ retcode_t iota_snapshot_init(snapshot_t *const snapshot,
              snapshot->conf->snapshot_signature_pubkey,
              snapshot->conf->snapshot_signature_depth,
              snapshot->conf->snapshot_signature_index, &valid)) != RC_OK) {
-      log_critical(SNAPSHOT_LOGGER_ID,
-                   "Validating snapshot signature failed\n");
+      log_critical(logger_id, "Validating snapshot signature failed\n");
       return ret;
     } else if (!valid) {
-      log_critical(SNAPSHOT_LOGGER_ID, "Invalid snapshot signature\n");
+      log_critical(logger_id, "Invalid snapshot signature\n");
       return RC_SNAPSHOT_INVALID_SIGNATURE;
     }
   }
   if ((ret = iota_snapshot_initial_state(snapshot, conf->snapshot_file))) {
-    log_critical(SNAPSHOT_LOGGER_ID,
-                 "Initializing snapshot initial state failed\n");
+    log_critical(logger_id, "Initializing snapshot initial state failed\n");
     return ret;
   }
-  log_info(SNAPSHOT_LOGGER_ID,
+  log_info(logger_id,
            "Consistent snapshot with %ld addresses and correct supply\n",
            HASH_COUNT(snapshot->state));
   return ret;
@@ -124,7 +124,7 @@ retcode_t iota_snapshot_destroy(snapshot_t *const snapshot) {
 
   state_delta_destroy(&snapshot->state);
   rw_lock_handle_destroy(&snapshot->rw_lock);
-  logger_helper_release(SNAPSHOT_LOGGER_ID);
+  logger_helper_release(logger_id);
   return ret;
 }
 
@@ -188,7 +188,7 @@ retcode_t iota_snapshot_apply_patch(snapshot_t *const snapshot,
   }
 
   if ((sum = state_delta_sum(patch)) != 0) {
-    log_warning(SNAPSHOT_LOGGER_ID, "Inconsistent snapshot patch\n");
+    log_warning(logger_id, "Inconsistent snapshot patch\n");
     return RC_SNAPSHOT_INCONSISTENT_PATCH;
   }
 

--- a/consensus/tangle/tangle.c
+++ b/consensus/tangle/tangle.c
@@ -12,14 +12,16 @@
 
 #define TANGLE_LOGGER_ID "tangle"
 
+static logger_id_t logger_id;
+
 retcode_t iota_tangle_init(tangle_t *const tangle,
                            connection_config_t const *const conf) {
-  logger_helper_enable(TANGLE_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(TANGLE_LOGGER_ID, LOGGER_DEBUG, true);
   return connection_init(&tangle->connection, conf);
 }
 
 retcode_t iota_tangle_destroy(tangle_t *const tangle) {
-  logger_helper_release(TANGLE_LOGGER_ID);
+  logger_helper_release(logger_id);
   return connection_destroy(&tangle->connection);
 }
 
@@ -76,7 +78,7 @@ retcode_t iota_tangle_transaction_load_hashes_of_approvers(
   }
 
   if (res != RC_OK) {
-    log_error(TANGLE_LOGGER_ID,
+    log_error(logger_id,
               "Failed in loading approvers, error code is: %" PRIu64 "\n", res);
   }
 
@@ -119,7 +121,7 @@ retcode_t iota_tangle_transaction_load_hashes_of_requests(
   }
 
   if (res != RC_OK) {
-    log_error(TANGLE_LOGGER_ID,
+    log_error(logger_id,
               "Failed in loading hash requests, error code is: %" PRIu64 "\n",
               res);
   }
@@ -144,7 +146,7 @@ retcode_t iota_tangle_transaction_load_hashes_of_tips(
   }
 
   if (res != RC_OK) {
-    log_error(TANGLE_LOGGER_ID,
+    log_error(logger_id,
               "Failed in loading hashes of tips, error code is: %" PRIu64 "\n",
               res);
   }
@@ -169,7 +171,7 @@ retcode_t iota_tangle_transaction_load_hashes_of_milestone_candidates(
   }
 
   if (res != RC_OK) {
-    log_error(TANGLE_LOGGER_ID,
+    log_error(logger_id,
               "Failed in loading hashes of milestone candidates, error code "
               "is: %" PRIu64 "\n",
               res);

--- a/consensus/tip_selector/tip_selector.c
+++ b/consensus/tip_selector/tip_selector.c
@@ -17,6 +17,8 @@
 
 #define TIP_SELECTOR_LOGGER_ID "tip_selector"
 
+static logger_id_t logger_id;
+
 retcode_t iota_consensus_tip_selector_init(
     tip_selector_t *const tip_selector, iota_consensus_conf_t *const conf,
     cw_rating_calculator_t *const cw_rating_calculator,
@@ -25,7 +27,7 @@ retcode_t iota_consensus_tip_selector_init(
     exit_prob_transaction_validator_t *const walker_validator,
     ledger_validator_t *const ledger_validator,
     milestone_tracker_t *const milestone_tracker) {
-  logger_helper_enable(TIP_SELECTOR_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(TIP_SELECTOR_LOGGER_ID, LOGGER_DEBUG, true);
   tip_selector->conf = conf;
   tip_selector->cw_rating_calculator = cw_rating_calculator;
   tip_selector->entry_point_selector = entry_point_selector;
@@ -52,15 +54,15 @@ retcode_t iota_consensus_tip_selector_get_transactions_to_approve(
 
   if ((ret = iota_consensus_entry_point_selector_get_entry_point(
            tip_selector->entry_point_selector, tangle, depth, ep_p)) != RC_OK) {
-    log_error(TIP_SELECTOR_LOGGER_ID,
-              "Getting entry point failed with error %" PRIu64 "\n", ret);
+    log_error(logger_id, "Getting entry point failed with error %" PRIu64 "\n",
+              ret);
     goto done;
   }
 
   if ((ret = iota_consensus_cw_rating_calculate(
            tip_selector->cw_rating_calculator, tangle, ep_p,
            &rating_results)) != RC_OK) {
-    log_error(TIP_SELECTOR_LOGGER_ID,
+    log_error(logger_id,
               "Calculating CW ratings failed with error %" PRIu64 "\n", ret);
     goto done;
   }
@@ -68,8 +70,8 @@ retcode_t iota_consensus_tip_selector_get_transactions_to_approve(
   if ((ret = iota_consensus_exit_probability_randomize(
            tip_selector->ep_randomizer, tangle, tip_selector->walker_validator,
            &rating_results, ep_p, tips->trunk)) != RC_OK) {
-    log_error(TIP_SELECTOR_LOGGER_ID,
-              "Getting trunk tip failed with error %" PRIu64 "\n", ret);
+    log_error(logger_id, "Getting trunk tip failed with error %" PRIu64 "\n",
+              ret);
     goto done;
   }
   if ((ret = hash243_stack_push(&tips_stack, tips->trunk)) != RC_OK) {
@@ -78,7 +80,7 @@ retcode_t iota_consensus_tip_selector_get_transactions_to_approve(
 
   if (reference != NULL) {
     if (!hash_to_int64_t_map_contains(&rating_results.cw_ratings, reference)) {
-      log_warning(TIP_SELECTOR_LOGGER_ID, "Reference is too old\n");
+      log_warning(logger_id, "Reference is too old\n");
       ret = RC_TIP_SELECTOR_REFERENCE_TOO_OLD;
       goto done;
     }
@@ -88,8 +90,8 @@ retcode_t iota_consensus_tip_selector_get_transactions_to_approve(
   if ((ret = iota_consensus_exit_probability_randomize(
            tip_selector->ep_randomizer, tangle, tip_selector->walker_validator,
            &rating_results, ep_p, tips->branch)) != RC_OK) {
-    log_error(TIP_SELECTOR_LOGGER_ID,
-              "Getting branch tip failed with error %" PRIu64 "\n", ret);
+    log_error(logger_id, "Getting branch tip failed with error %" PRIu64 "\n",
+              ret);
     goto done;
   }
   if ((ret = hash243_stack_push(&tips_stack, tips->branch)) != RC_OK) {
@@ -99,14 +101,14 @@ retcode_t iota_consensus_tip_selector_get_transactions_to_approve(
   if ((ret = iota_consensus_ledger_validator_check_consistency(
            tip_selector->ledger_validator, tangle, tips_stack, &consistent)) !=
       RC_OK) {
-    log_error(TIP_SELECTOR_LOGGER_ID,
+    log_error(logger_id,
               "Checking consistency of tips failed with error %" PRIu64 "\n",
               ret);
     goto done;
   }
 
   if (!consistent) {
-    log_warning(TIP_SELECTOR_LOGGER_ID, "Tips are not consistent\n");
+    log_warning(logger_id, "Tips are not consistent\n");
     ret = RC_TIP_SELECTOR_TIPS_NOT_CONSISTENT;
   }
 
@@ -126,6 +128,6 @@ retcode_t iota_consensus_tip_selector_destroy(
   tip_selector->walker_validator = NULL;
   tip_selector->ledger_validator = NULL;
   tip_selector->milestone_tracker = NULL;
-  logger_helper_release(TIP_SELECTOR_LOGGER_ID);
+  logger_helper_release(logger_id);
   return RC_OK;
 }

--- a/consensus/transaction_validator/transaction_validator.c
+++ b/consensus/transaction_validator/transaction_validator.c
@@ -13,6 +13,7 @@
 
 #define TRANSACTION_VALIDATOR_LOGGER_ID "transaction_validator"
 
+static logger_id_t logger_id;
 static uint64_t MAX_TIMESTAMP_FUTURE_MS = 2 * 60 * 60 * 1000;
 
 /*
@@ -60,7 +61,8 @@ static bool has_invalid_timestamp(transaction_validator_t const* const tv,
 
 retcode_t iota_consensus_transaction_validator_init(
     transaction_validator_t* const tv, iota_consensus_conf_t* const conf) {
-  logger_helper_enable(TRANSACTION_VALIDATOR_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(TRANSACTION_VALIDATOR_LOGGER_ID, LOGGER_DEBUG, true);
   tv->conf = conf;
 
   return RC_OK;
@@ -69,7 +71,7 @@ retcode_t iota_consensus_transaction_validator_init(
 retcode_t iota_consensus_transaction_validator_destroy(
     transaction_validator_t* const tv) {
   tv->conf = NULL;
-  logger_helper_release(TRANSACTION_VALIDATOR_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   return RC_OK;
 }
@@ -78,27 +80,25 @@ bool iota_consensus_transaction_validate(
     transaction_validator_t const* const tv,
     iota_transaction_t const* const transaction) {
   if (transaction_weight_magnitude(transaction) < tv->conf->mwm) {
-    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
+    log_debug(logger_id,
               "Validation failed: insufficient transaction weight\n");
     return false;
   }
 
   if (has_invalid_timestamp(tv, transaction)) {
-    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
-              "Validation failed: invalid timestamp\n");
+    log_debug(logger_id, "Validation failed: invalid timestamp\n");
     return false;
   }
 
   if (llabs(transaction_value(transaction)) > IOTA_SUPPLY) {
-    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
-              "Validation failed: invalid value\n");
+    log_debug(logger_id, "Validation failed: invalid value\n");
     return false;
   }
 
   if (transaction_value(transaction) != 0 &&
       flex_trits_at(transaction_address(transaction), NUM_TRITS_ADDRESS,
                     NUM_TRITS_ADDRESS - 1) != 0) {
-    log_debug(TRANSACTION_VALIDATOR_LOGGER_ID,
+    log_debug(logger_id,
               "Validation failed: invalid address for value transaction\n");
     return false;
   }

--- a/gossip/components/receiver.c
+++ b/gossip/components/receiver.c
@@ -13,6 +13,8 @@
 
 #define RECEIVER_COMPONENT_LOGGER_ID "receiver_component"
 
+static logger_id_t logger_id;
+
 retcode_t receiver_init(receiver_state_t *const state, node_t *const node,
                         uint16_t tcp_port, uint16_t udp_port) {
   if (state == NULL) {
@@ -21,7 +23,8 @@ retcode_t receiver_init(receiver_state_t *const state, node_t *const node,
     return RC_RECEIVER_COMPONENT_NULL_NODE;
   }
 
-  logger_helper_enable(RECEIVER_COMPONENT_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(RECEIVER_COMPONENT_LOGGER_ID, LOGGER_DEBUG, true);
   memset(state, 0, sizeof(receiver_state_t));
   state->running = false;
   state->tcp_service.port = tcp_port;
@@ -47,22 +50,20 @@ retcode_t receiver_start(receiver_state_t *const state) {
 
   state->running = true;
   if (state->tcp_service.port != 0) {
-    log_info(RECEIVER_COMPONENT_LOGGER_ID, "Spawning TCP receiver thread\n");
+    log_info(logger_id, "Spawning TCP receiver thread\n");
     if (thread_handle_create(&state->tcp_service.thread,
                              (thread_routine_t)receiver_service_start,
                              &state->tcp_service) != 0) {
-      log_critical(RECEIVER_COMPONENT_LOGGER_ID,
-                   "Spawning TCP receiver thread failed\n");
+      log_critical(logger_id, "Spawning TCP receiver thread failed\n");
       return RC_RECEIVER_COMPONENT_FAILED_THREAD_SPAWN;
     }
   }
   if (state->udp_service.port != 0) {
-    log_info(RECEIVER_COMPONENT_LOGGER_ID, "Spawning UDP receiver thread\n");
+    log_info(logger_id, "Spawning UDP receiver thread\n");
     if (thread_handle_create(&state->udp_service.thread,
                              (thread_routine_t)receiver_service_start,
                              &state->udp_service) != 0) {
-      log_critical(RECEIVER_COMPONENT_LOGGER_ID,
-                   "Spawning UDP receiver thread failed\n");
+      log_critical(logger_id, "Spawning UDP receiver thread failed\n");
       return RC_RECEIVER_COMPONENT_FAILED_THREAD_SPAWN;
     }
   }
@@ -79,18 +80,16 @@ retcode_t receiver_stop(receiver_state_t *const state) {
   }
 
   state->running = false;
-  log_info(RECEIVER_COMPONENT_LOGGER_ID, "Shutting down TCP receiver thread\n");
+  log_info(logger_id, "Shutting down TCP receiver thread\n");
   if (receiver_service_stop(&state->tcp_service) == false ||
       thread_handle_join(state->tcp_service.thread, NULL) != 0) {
-    log_error(RECEIVER_COMPONENT_LOGGER_ID,
-              "Shutting down TCP receiver thread failed\n");
+    log_error(logger_id, "Shutting down TCP receiver thread failed\n");
     ret = RC_RECEIVER_COMPONENT_FAILED_THREAD_JOIN;
   }
-  log_info(RECEIVER_COMPONENT_LOGGER_ID, "Shutting down UDP receiver thread\n");
+  log_info(logger_id, "Shutting down UDP receiver thread\n");
   if (receiver_service_stop(&state->udp_service) == false ||
       thread_handle_join(state->udp_service.thread, NULL) != 0) {
-    log_error(RECEIVER_COMPONENT_LOGGER_ID,
-              "Shutting down UDP receiver thread failed\n");
+    log_error(logger_id, "Shutting down UDP receiver thread failed\n");
     ret = RC_RECEIVER_COMPONENT_FAILED_THREAD_JOIN;
   }
   return ret;
@@ -103,6 +102,6 @@ retcode_t receiver_destroy(receiver_state_t *const state) {
     return RC_RECEIVER_COMPONENT_STILL_RUNNING;
   }
 
-  logger_helper_release(RECEIVER_COMPONENT_LOGGER_ID);
+  logger_helper_release(logger_id);
   return RC_OK;
 }

--- a/gossip/components/transaction_requester.c
+++ b/gossip/components/transaction_requester.c
@@ -14,6 +14,8 @@
 
 #define REQUESTER_LOGGER_ID "requester"
 
+static logger_id_t logger_id;
+
 /*
  * Public functions
  */
@@ -24,7 +26,7 @@ retcode_t requester_init(transaction_requester_t *const transaction_requester,
     return RC_NULL_PARAM;
   }
 
-  logger_helper_enable(REQUESTER_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(REQUESTER_LOGGER_ID, LOGGER_DEBUG, true);
   memset(transaction_requester, 0, sizeof(transaction_requester_t));
   transaction_requester->node = node;
   transaction_requester->running = false;
@@ -47,7 +49,7 @@ retcode_t requester_destroy(
   hash243_set_free(&transaction_requester->transactions);
   transaction_requester->node = NULL;
   rw_lock_handle_destroy(&transaction_requester->lock);
-  logger_helper_release(REQUESTER_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   return RC_OK;
 }

--- a/gossip/node.c
+++ b/gossip/node.c
@@ -11,6 +11,8 @@
 
 #define NODE_LOGGER_ID "node"
 
+static logger_id_t logger_id;
+
 /*
  * Private functions
  */
@@ -31,14 +33,14 @@ static retcode_t node_neighbors_init(node_t* const node) {
   ptr = cpy = strdup(node->conf.neighbors);
   while ((neighbor_uri = strsep(&cpy, " ")) != NULL) {
     if (neighbor_init_with_uri(&neighbor, neighbor_uri) != RC_OK) {
-      log_warning(NODE_LOGGER_ID, "Initializing neighbor with URI %s failed\n",
+      log_warning(logger_id, "Initializing neighbor with URI %s failed\n",
                   neighbor_uri);
       continue;
     }
-    log_info(NODE_LOGGER_ID, "Adding neighbor %s\n", neighbor_uri);
+    log_info(logger_id, "Adding neighbor %s\n", neighbor_uri);
     rw_lock_handle_wrlock(&node->neighbors_lock);
     if (neighbors_add(&node->neighbors, &neighbor) != RC_OK) {
-      log_warning(NODE_LOGGER_ID, "Adding neighbor %s failed\n", neighbor_uri);
+      log_warning(logger_id, "Adding neighbor %s failed\n", neighbor_uri);
     }
     rw_lock_handle_unlock(&node->neighbors_lock);
   }
@@ -57,14 +59,13 @@ static retcode_t node_transaction_requester_init(node_t* const node,
   }
 
   if ((ret = hash_pack_init(&pack, node->conf.requester_queue_size)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Initializing request hash pack failed\n");
+    log_error(logger_id, "Initializing request hash pack failed\n");
     goto done;
   }
 
   if ((ret = iota_tangle_transaction_load_hashes_of_requests(
            tangle, &pack, node->conf.requester_queue_size)) != RC_OK) {
-    log_error(NODE_LOGGER_ID,
-              "Loading hashes of transactions to request failed\n");
+    log_error(logger_id, "Loading hashes of transactions to request failed\n");
     goto done;
   }
 
@@ -72,13 +73,13 @@ static retcode_t node_transaction_requester_init(node_t* const node,
     if ((ret = request_transaction(&node->transaction_requester, tangle,
                                    ((flex_trit_t*)(pack.models[i])), false)) !=
         RC_OK) {
-      log_error(NODE_LOGGER_ID, "Requesting transaction failed\n");
+      log_error(logger_id, "Requesting transaction failed\n");
       goto done;
     }
   }
 
-  log_debug(NODE_LOGGER_ID, "Added %d transactions to request\n",
-            requester_size(&node->transaction_requester));
+  log_info(logger_id, "Added %d transactions to request\n",
+           requester_size(&node->transaction_requester));
 
 done:
   hash_pack_free(&pack);
@@ -100,26 +101,25 @@ static retcode_t node_tips_cache_init(node_t* const node,
   }
 
   if ((ret = hash_pack_init(&pack, node->conf.tips_cache_size)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Initializing tips pack failed\n");
+    log_error(logger_id, "Initializing tips pack failed\n");
     goto done;
   }
 
   if ((ret = iota_tangle_transaction_load_hashes_of_tips(
            tangle, &pack, node->conf.tips_cache_size)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Loading hashes of tips failed\n");
+    log_error(logger_id, "Loading hashes of tips failed\n");
     goto done;
   }
 
   for (size_t i = 0; i < pack.num_loaded; i++) {
     if ((ret = tips_cache_add(&node->tips, ((flex_trit_t*)(pack.models[i])))) !=
         RC_OK) {
-      log_error(NODE_LOGGER_ID, "Adding tip to cache failed\n");
+      log_error(logger_id, "Adding tip to cache failed\n");
       goto done;
     }
   }
 
-  log_debug(NODE_LOGGER_ID, "Added %d tips to cache\n",
-            tips_cache_size(&node->tips));
+  log_info(logger_id, "Added %d tips to cache\n", tips_cache_size(&node->tips));
 
 done:
   hash_pack_free(&pack);
@@ -140,70 +140,68 @@ retcode_t node_init(node_t* const node, core_t* const core,
     return RC_NODE_NULL_CORE;
   }
 
-  logger_helper_enable(NODE_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id = logger_helper_enable(NODE_LOGGER_ID, LOGGER_DEBUG, true);
   node->running = false;
   node->core = core;
 
-  log_info(NODE_LOGGER_ID, "Initializing neighbors\n");
+  log_info(logger_id, "Initializing neighbors\n");
   if (node_neighbors_init(node) != RC_OK) {
-    log_info(NODE_LOGGER_ID, "Initializing neighbors failed\n");
+    log_info(logger_id, "Initializing neighbors failed\n");
     return RC_NODE_FAILED_NEIGHBORS_INIT;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing broadcaster component\n");
+  log_info(logger_id, "Initializing broadcaster component\n");
   if (broadcaster_init(&node->broadcaster, node) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Initializing broadcaster component failed\n");
+    log_critical(logger_id, "Initializing broadcaster component failed\n");
     return RC_NODE_FAILED_BROADCASTER_INIT;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing processor component\n");
+  log_info(logger_id, "Initializing processor component\n");
   if (processor_init(&node->processor, node,
                      &core->consensus.transaction_validator,
                      &core->consensus.transaction_solidifier,
                      &core->consensus.milestone_tracker) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Initializing processor component failed\n");
+    log_critical(logger_id, "Initializing processor component failed\n");
     return RC_NODE_FAILED_PROCESSOR_INIT;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing receiver component\n");
+  log_info(logger_id, "Initializing receiver component\n");
   if (receiver_init(&node->receiver, node, node->conf.tcp_receiver_port,
                     node->conf.udp_receiver_port) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Initializing receiver component failed\n");
+    log_critical(logger_id, "Initializing receiver component failed\n");
     return RC_NODE_FAILED_RECEIVER_INIT;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing responder component\n");
+  log_info(logger_id, "Initializing responder component\n");
   if (responder_init(&node->responder, node) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Initializing responder component failed\n");
+    log_critical(logger_id, "Initializing responder component failed\n");
     return RC_NODE_FAILED_RESPONDER_INIT;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing tips requester component\n");
+  log_info(logger_id, "Initializing tips requester component\n");
   if ((ret = tips_requester_init(&node->tips_requester, node)) != RC_OK) {
-    log_critical(NODE_LOGGER_ID,
-                 "Initializing  tips requester component failed\n");
+    log_critical(logger_id, "Initializing  tips requester component failed\n");
     return ret;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing transaction requester component\n");
+  log_info(logger_id, "Initializing transaction requester component\n");
   if (node_transaction_requester_init(node, tangle) != RC_OK) {
-    log_critical(NODE_LOGGER_ID,
+    log_critical(logger_id,
                  "Initializing transaction requester component failed\n");
     return RC_NODE_FAILED_REQUESTER_INIT;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing tips solidifier component\n");
+  log_info(logger_id, "Initializing tips solidifier component\n");
   if ((ret = tips_solidifier_init(
            &node->tips_solidifier, &node->conf, &node->tips,
            &core->consensus.transaction_solidifier)) != RC_OK) {
-    log_critical(NODE_LOGGER_ID,
-                 "Initializing  tips solidifier component failed\n");
+    log_critical(logger_id, "Initializing  tips solidifier component failed\n");
     return ret;
   }
 
-  log_info(NODE_LOGGER_ID, "Initializing tips cache\n");
+  log_info(logger_id, "Initializing tips cache\n");
   if ((ret = node_tips_cache_init(node, tangle)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Initializing tips cache failed\n");
+    log_error(logger_id, "Initializing tips cache failed\n");
     return ret;
   }
 
@@ -217,46 +215,46 @@ retcode_t node_start(node_t* const node) {
     return RC_NODE_NULL_NODE;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting broadcaster component\n");
+  log_info(logger_id, "Starting broadcaster component\n");
   if (broadcaster_start(&node->broadcaster) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Starting broadcaster component failed\n");
+    log_critical(logger_id, "Starting broadcaster component failed\n");
     return RC_NODE_FAILED_BROADCASTER_START;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting processor component\n");
+  log_info(logger_id, "Starting processor component\n");
   if (processor_start(&node->processor) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Starting processor component failed\n");
+    log_critical(logger_id, "Starting processor component failed\n");
     return RC_NODE_FAILED_PROCESSOR_START;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting receiver component\n");
+  log_info(logger_id, "Starting receiver component\n");
   if (receiver_start(&node->receiver) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Starting receiver component failed\n");
+    log_critical(logger_id, "Starting receiver component failed\n");
     return RC_NODE_FAILED_RECEIVER_START;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting responder component\n");
+  log_info(logger_id, "Starting responder component\n");
   if (responder_start(&node->responder) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Starting responder component failed\n");
+    log_critical(logger_id, "Starting responder component failed\n");
     return RC_NODE_FAILED_RESPONDER_START;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting tips requester component\n");
+  log_info(logger_id, "Starting tips requester component\n");
   if ((ret = tips_requester_start(&node->tips_requester)) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Starting tips requester component failed\n");
+    log_critical(logger_id, "Starting tips requester component failed\n");
     return ret;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting transaction requester component\n");
+  log_info(logger_id, "Starting transaction requester component\n");
   if ((ret = requester_start(&node->transaction_requester)) != RC_OK) {
-    log_critical(NODE_LOGGER_ID,
+    log_critical(logger_id,
                  "Starting transaction requester component failed\n");
     return ret;
   }
 
-  log_info(NODE_LOGGER_ID, "Starting tips solidifier component\n");
+  log_info(logger_id, "Starting tips solidifier component\n");
   if ((ret = tips_solidifier_start(&node->tips_solidifier)) != RC_OK) {
-    log_critical(NODE_LOGGER_ID, "Starting tips solidifier component failed\n");
+    log_critical(logger_id, "Starting tips solidifier component failed\n");
     return ret;
   }
 
@@ -276,44 +274,43 @@ retcode_t node_stop(node_t* const node) {
 
   node->running = false;
 
-  log_info(NODE_LOGGER_ID, "Stopping broadcaster component\n");
+  log_info(logger_id, "Stopping broadcaster component\n");
   if (broadcaster_stop(&node->broadcaster) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Stopping broadcaster component failed\n");
+    log_error(logger_id, "Stopping broadcaster component failed\n");
     ret = RC_NODE_FAILED_BROADCASTER_STOP;
   }
 
-  log_info(NODE_LOGGER_ID, "Stopping processor component\n");
+  log_info(logger_id, "Stopping processor component\n");
   if (processor_stop(&node->processor) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Stopping processor component failed\n");
+    log_error(logger_id, "Stopping processor component failed\n");
     ret = RC_NODE_FAILED_PROCESSOR_STOP;
   }
 
-  log_info(NODE_LOGGER_ID, "Stopping responder component\n");
+  log_info(logger_id, "Stopping responder component\n");
   if (responder_stop(&node->responder) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Stopping responder component failed\n");
+    log_error(logger_id, "Stopping responder component failed\n");
     ret = RC_NODE_FAILED_RESPONDER_STOP;
   }
 
-  log_info(NODE_LOGGER_ID, "Stopping receiver component\n");
+  log_info(logger_id, "Stopping receiver component\n");
   if (receiver_stop(&node->receiver) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Stopping receiver component failed\n");
+    log_error(logger_id, "Stopping receiver component failed\n");
     ret = RC_NODE_FAILED_RECEIVER_STOP;
   }
 
-  log_info(NODE_LOGGER_ID, "Stopping tips requester component\n");
+  log_info(logger_id, "Stopping tips requester component\n");
   if ((ret = tips_requester_stop(&node->tips_requester)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Stopping tips requester component failed\n");
+    log_error(logger_id, "Stopping tips requester component failed\n");
   }
 
-  log_info(NODE_LOGGER_ID, "Stopping transaction requester component\n");
+  log_info(logger_id, "Stopping transaction requester component\n");
   if ((ret = requester_stop(&node->transaction_requester)) != RC_OK) {
-    log_error(NODE_LOGGER_ID,
-              "Stopping transaction requester component failed\n");
+    log_error(logger_id, "Stopping transaction requester component failed\n");
   }
 
-  log_info(NODE_LOGGER_ID, "Stopping tips solidifier component\n");
+  log_info(logger_id, "Stopping tips solidifier component\n");
   if ((ret = tips_solidifier_stop(&node->tips_solidifier)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Stopping tips solidifier component failed\n");
+    log_error(logger_id, "Stopping tips solidifier component failed\n");
   }
 
   return ret;
@@ -328,48 +325,47 @@ retcode_t node_destroy(node_t* const node) {
     return RC_NODE_STILL_RUNNING;
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying transaction requester component\n");
+  log_info(logger_id, "Destroying transaction requester component\n");
   if (requester_destroy(&node->transaction_requester) != RC_OK) {
-    log_error(NODE_LOGGER_ID,
-              "Destroying transaction requester component failed\n");
+    log_error(logger_id, "Destroying transaction requester component failed\n");
     ret = RC_NODE_FAILED_REQUESTER_DESTROY;
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying tips solidifier component\n");
+  log_info(logger_id, "Destroying tips solidifier component\n");
   if ((ret = tips_solidifier_destroy(&node->tips_solidifier)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Destroying tips solidifier component failed\n");
+    log_error(logger_id, "Destroying tips solidifier component failed\n");
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying tips requester component\n");
+  log_info(logger_id, "Destroying tips requester component\n");
   if ((ret = tips_requester_destroy(&node->tips_requester)) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Destroying tips requester component failed\n");
+    log_error(logger_id, "Destroying tips requester component failed\n");
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying broadcaster component\n");
+  log_info(logger_id, "Destroying broadcaster component\n");
   if (broadcaster_destroy(&node->broadcaster) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Destroying broadcaster component failed\n");
+    log_error(logger_id, "Destroying broadcaster component failed\n");
     ret = RC_NODE_FAILED_BROADCASTER_DESTROY;
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying receiver component\n");
+  log_info(logger_id, "Destroying receiver component\n");
   if (receiver_destroy(&node->receiver) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Destroying receiver component failed\n");
+    log_error(logger_id, "Destroying receiver component failed\n");
     ret = RC_NODE_FAILED_RECEIVER_DESTROY;
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying processor component\n");
+  log_info(logger_id, "Destroying processor component\n");
   if (processor_destroy(&node->processor) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Destroying processor component failed\n");
+    log_error(logger_id, "Destroying processor component failed\n");
     ret = RC_NODE_FAILED_PROCESSOR_DESTROY;
   }
 
-  log_info(NODE_LOGGER_ID, "Destroying responder component\n");
+  log_info(logger_id, "Destroying responder component\n");
   if (responder_destroy(&node->responder) != RC_OK) {
-    log_error(NODE_LOGGER_ID, "Destroying responder component failed\n");
+    log_error(logger_id, "Destroying responder component failed\n");
     ret = RC_NODE_FAILED_RESPONDER_DESTROY;
   }
 
-  log_debug(NODE_LOGGER_ID, "Destroying neighbors\n");
+  log_debug(logger_id, "Destroying neighbors\n");
   rw_lock_handle_wrlock(&node->neighbors_lock);
   neighbors_free(&node->neighbors);
   rw_lock_handle_unlock(&node->neighbors_lock);
@@ -378,7 +374,7 @@ retcode_t node_destroy(node_t* const node) {
   tips_cache_destroy(&node->tips);
   free(node->conf.neighbors);
 
-  logger_helper_release(NODE_LOGGER_ID);
+  logger_helper_release(logger_id);
 
   return ret;
 }

--- a/gossip/services/receiver.cc
+++ b/gossip/services/receiver.cc
@@ -12,32 +12,34 @@
 
 #define RECEIVER_SERVICE_LOGGER_ID "receiver_service"
 
+static logger_id_t logger_id;
+
 bool receiver_service_start(receiver_service_t* const service) {
   if (service == NULL) {
     return false;
   }
-  logger_helper_enable(RECEIVER_SERVICE_LOGGER_ID, LOGGER_DEBUG, true);
+  logger_id =
+      logger_helper_enable(RECEIVER_SERVICE_LOGGER_ID, LOGGER_DEBUG, true);
   try {
     boost::asio::io_context ctx;
     service->context = &ctx;
     if (service->protocol == PROTOCOL_TCP) {
-      log_info(RECEIVER_SERVICE_LOGGER_ID,
-               "Starting TCP receiver service on port %d\n", service->port);
+      log_info(logger_id, "Starting TCP receiver service on port %d\n",
+               service->port);
       TcpReceiverService tcpService(service, ctx, service->port);
       ctx.run();
     } else if (service->protocol == PROTOCOL_UDP) {
-      log_info(RECEIVER_SERVICE_LOGGER_ID,
-               "Starting UDP receiver service on port %d\n", service->port);
+      log_info(logger_id, "Starting UDP receiver service on port %d\n",
+               service->port);
       UdpReceiverService udpService(service, ctx, service->port);
       ctx.run();
     } else {
-      log_error(RECEIVER_SERVICE_LOGGER_ID,
+      log_error(logger_id,
                 "Starting receiver service failed: unknown protocol\n");
       return false;
     }
   } catch (std::exception const& e) {
-    log_error(RECEIVER_SERVICE_LOGGER_ID,
-              "Starting receiver service failed: %s\n", e.what());
+    log_error(logger_id, "Starting receiver service failed: %s\n", e.what());
     return false;
   }
   return true;
@@ -50,16 +52,15 @@ bool receiver_service_stop(receiver_service_t* const service) {
   try {
     auto ctx = reinterpret_cast<boost::asio::io_context*>(service->context);
     if (ctx == NULL) {
-      log_error(RECEIVER_SERVICE_LOGGER_ID,
+      log_error(logger_id,
                 "Stopping receiver service failed: invalid context\n");
       return false;
     }
     ctx->stop();
   } catch (std::exception const& e) {
-    log_error(RECEIVER_SERVICE_LOGGER_ID,
-              "Stopping receiver service failed: %s\n", e.what());
+    log_error(logger_id, "Stopping receiver service failed: %s\n", e.what());
     return false;
   }
-  logger_helper_release(RECEIVER_SERVICE_LOGGER_ID);
+  logger_helper_release(logger_id);
   return true;
 }

--- a/gossip/services/tcp_sender.cc
+++ b/gossip/services/tcp_sender.cc
@@ -10,7 +10,6 @@
 #include "gossip/iota_packet.h"
 #include "gossip/services/receiver.h"
 #include "gossip/services/tcp_sender.hpp"
-#include "utils/logger_helper.h"
 
 bool tcp_send(receiver_service_t *const service, endpoint_t *const endpoint,
               iota_packet_t const *const packet) {
@@ -24,8 +23,6 @@ bool tcp_send(receiver_service_t *const service, endpoint_t *const endpoint,
         *socket, boost::asio::buffer(packet->content, PACKET_SIZE),
         [](const boost::system::error_code &, std::size_t) {});
   } catch (std::exception const &e) {
-    log_error("Sending packet to tcp://%s:%d failed: %s", endpoint->host,
-              endpoint->port, e.what());
     return false;
   }
   return true;

--- a/gossip/services/udp_sender.cc
+++ b/gossip/services/udp_sender.cc
@@ -10,7 +10,6 @@
 #include "gossip/iota_packet.h"
 #include "gossip/services/receiver.h"
 #include "gossip/services/udp_sender.hpp"
-#include "utils/logger_helper.h"
 
 bool udp_endpoint_init(endpoint_t *const endpoint) {
   if (endpoint == NULL) {
@@ -26,8 +25,6 @@ bool udp_endpoint_init(endpoint_t *const endpoint) {
     endpoint->opaque_inetaddr = new boost::asio::ip::udp::endpoint(destination);
     strcpy(endpoint->ip, destination.address().to_string().c_str());
   } catch (std::exception const &e) {
-    log_error("Initiliazing endpoint udp://%s:%d failed: %s", endpoint->host,
-              endpoint->port, e.what());
     return false;
   }
   return true;
@@ -61,8 +58,6 @@ bool udp_send(receiver_service_t *const service, endpoint_t *const endpoint,
             endpoint->opaque_inetaddr),
         [](const boost::system::error_code &, std::size_t) {});
   } catch (std::exception const &e) {
-    log_error("Sending packet to udp://%s:%d failed: %s", endpoint->host,
-              endpoint->port, e.what());
     return false;
   }
   return true;

--- a/utils/files.c
+++ b/utils/files.c
@@ -17,9 +17,6 @@
 #include <inttypes.h>
 
 #include "utils/files.h"
-#include "utils/logger_helper.h"
-
-#define UTILS_FILES_LOGGER_ID "utils_files"
 
 retcode_t copy_file(const char *to, const char *from) {
   int fd_to, fd_from;
@@ -60,7 +57,6 @@ retcode_t copy_file(const char *to, const char *from) {
   }
 
 out_error:
-  log_error(UTILS_FILES_LOGGER_ID, "Failed with errno %" PRIu64 "\n", errno);
   saved_errno = errno;
 
   close(fd_from);
@@ -75,8 +71,6 @@ retcode_t remove_file(const char *file_path) {
 
   status = remove(file_path);
   if (status) {
-    log_error(UTILS_FILES_LOGGER_ID, "Failed with status %" PRIu64 "\n",
-              status);
     return RC_UTILS_FAILED_REMOVE_FILE;
   }
   return RC_OK;

--- a/utils/logger_helper.c
+++ b/utils/logger_helper.c
@@ -61,12 +61,17 @@ void logger_helper_release(char const* const logger_id) {
 void logger_helper_print(char const* const logger_id,
                          logger_level_t const level, char const* const format,
                          ...) {
-  logger_id_t id;
   va_list argp;
+  logger_id_t id;
+
+  if (level < logger_output_level_get(stdout)) {
+    return;
+  }
+
+  id = logger_id_request(logger_id);
 
   va_start(argp, format);
   lock_handle_lock(&lock);
-  id = logger_id_request(logger_id);
   logger_va(id, level, format, argp);
   lock_handle_unlock(&lock);
   va_end(argp);

--- a/utils/logger_helper.c
+++ b/utils/logger_helper.c
@@ -27,7 +27,7 @@ retcode_t logger_helper_init() {
 }
 
 retcode_t logger_helper_destroy() {
-  lock_handle_unlock(&lock);
+  lock_handle_destroy(&lock);
 
   return RC_OK;
 }

--- a/utils/logger_helper.h
+++ b/utils/logger_helper.h
@@ -33,12 +33,11 @@ typedef struct logger_t logger_t;
 
 retcode_t logger_helper_init();
 retcode_t logger_helper_destroy();
-
-void logger_helper_enable(char const* const logger_id,
-                          logger_level_t const level, bool const enable_color);
-void logger_helper_release(char const* const logger_id);
-
-void logger_helper_print(char const* const logger_id,
+logger_id_t logger_helper_enable(char const* const logger_name,
+                                 logger_level_t const level,
+                                 bool const enable_color);
+void logger_helper_release(logger_id_t const logger_id);
+void logger_helper_print(logger_id_t const logger_id,
                          logger_level_t const level, char const* const format,
                          ...);
 


### PR DESCRIPTION
At the cost of a redundant check (the log level is already checked by `logger_va`), this PR locks only when the log level actually allows to log.
Starting from log level `INFO`, there is almost no lock anymore.

# Test Plan:
CI
