### PR TITLE
common/curl-p/trit: fix wrong C++ extern C guards

### DIFF
--- a/common/curl-p/trit.h
+++ b/common/curl-p/trit.h
@@ -27,8 +27,8 @@ void curl_absorb(Curl* const ctx, trit_t const* const trits, size_t length);
 void curl_squeeze(Curl* const ctx, trit_t* const trits, size_t length);
 void curl_reset(Curl* const ctx);
 
-#endif
 #ifdef __cplusplus
 }
+#endif
 
 #endif  // __COMMON_CURL_P_TRIT_H_


### PR DESCRIPTION
A wrong C++ extern C closing guard was making C++ compilation of the file to fail.
Address #696 

# Test Plan:
CI
