### PR TITLE
consensus/milestone_validator: load obsolete tag only for candidate

### DIFF
--- a/common/storage/sql/sqlite3/connection.c
+++ b/common/storage/sql/sqlite3/connection.c
@@ -87,6 +87,10 @@ static retcode_t prepare_statements(sqlite3_connection_t* const connection) {
   ret |= prepare_statement(connection->db,
                            &connection->statements.transaction_select_metadata,
                            iota_statement_transaction_select_metadata);
+  ret |= prepare_statement(
+      connection->db,
+      &connection->statements.transaction_select_obsolete_tag,
+      iota_statement_transaction_select_obsolete_tag);
   ret |= prepare_statement(connection->db,
                            &connection->statements.milestone_insert,
                            iota_statement_milestone_insert);
@@ -157,6 +161,8 @@ static retcode_t finalize_statements(sqlite3_connection_t* const connection) {
   ret |= finalize_statement(
       connection->statements.transaction_select_essence_and_consensus);
   ret |= finalize_statement(connection->statements.transaction_select_metadata);
+  ret |= finalize_statement(
+      connection->statements.transaction_select_obsolete_tag);
   ret |= finalize_statement(connection->statements.milestone_insert);
   ret |= finalize_statement(connection->statements.milestone_select_by_hash);
   ret |= finalize_statement(connection->statements.milestone_select_first);

--- a/common/storage/sql/statements.c
+++ b/common/storage/sql/statements.c
@@ -165,6 +165,10 @@ char *iota_statement_transaction_select_metadata =
     "," TRANSACTION_COL_ARRIVAL_TIME " FROM " TRANSACTION_TABLE_NAME
     " WHERE " TRANSACTION_COL_HASH "=?";
 
+char *iota_statement_transaction_select_obsolete_tag =
+    "SELECT " TRANSACTION_COL_OBSOLETE_TAG " FROM " TRANSACTION_TABLE_NAME
+    " WHERE " TRANSACTION_COL_HASH "=?";
+
 /*
  * Transaction statement builders
  */

--- a/common/storage/sql/statements.h
+++ b/common/storage/sql/statements.h
@@ -35,6 +35,7 @@ typedef struct iota_statements_s {
   sqlite3_stmt* transaction_select_essence_attachment_and_metadata;
   sqlite3_stmt* transaction_select_essence_and_consensus;
   sqlite3_stmt* transaction_select_metadata;
+  sqlite3_stmt* transaction_select_obsolete_tag;
   sqlite3_stmt* milestone_insert;
   sqlite3_stmt* milestone_select_by_hash;
   sqlite3_stmt* milestone_select_first;
@@ -81,6 +82,7 @@ extern char* iota_statement_transaction_select_essence_and_metadata;
 extern char* iota_statement_transaction_select_essence_attachment_and_metadata;
 extern char* iota_statement_transaction_select_essence_and_consensus;
 extern char* iota_statement_transaction_select_metadata;
+extern char* iota_statement_transaction_select_obsolete_tag;
 
 /*
  * Transaction statement builders

--- a/common/storage/storage.h
+++ b/common/storage/storage.h
@@ -82,6 +82,10 @@ extern retcode_t iota_stor_transaction_load_metadata(
     storage_connection_t const* const connection, flex_trit_t const* const hash,
     iota_stor_pack_t* const pack);
 
+extern retcode_t iota_stor_transaction_load_obsolete_tag(
+    storage_connection_t const* const connection, flex_trit_t const* const hash,
+    iota_stor_pack_t* const pack);
+
 extern retcode_t iota_stor_transaction_exist(
     storage_connection_t const* const connection,
     transaction_field_t const field, flex_trit_t const* const key,

--- a/consensus/milestone_tracker/milestone_tracker.c
+++ b/consensus/milestone_tracker/milestone_tracker.c
@@ -184,7 +184,7 @@ static void* milestone_validator(void* arg) {
       hash_pack_reset(&pack);
       if (iota_tangle_transaction_load_partial(
               &tangle, candidate.hash, &pack,
-              PARTIAL_TX_MODEL_ESSENCE_CONSENSUS) == RC_OK &&
+              PARTIAL_TX_MODEL_OBSOLETE_TAG) == RC_OK &&
           pack.num_loaded != 0) {
         candidate.index = get_milestone_index(&tx);
         if (validate_milestone(mt, &tangle, &candidate, &milestone_status) !=

--- a/consensus/tangle/tangle.c
+++ b/consensus/tangle/tangle.c
@@ -99,6 +99,9 @@ retcode_t iota_tangle_transaction_load_partial(
   } else if (models_mask == PARTIAL_TX_MODEL_ESSENCE_CONSENSUS) {
     return iota_stor_transaction_load_essence_and_consensus(&tangle->connection,
                                                             hash, pack);
+  } else if (models_mask == PARTIAL_TX_MODEL_OBSOLETE_TAG) {
+    return iota_stor_transaction_load_obsolete_tag(&tangle->connection, hash,
+                                                   pack);
   } else {
     return RC_CONSENSUS_NOT_IMPLEMENTED;
   }

--- a/consensus/tangle/tangle.h
+++ b/consensus/tangle/tangle.h
@@ -36,6 +36,7 @@ typedef enum _partial_transaction_model {
   PARTIAL_TX_MODEL_ESSENCE_METADATA,
   PARTIAL_TX_MODEL_ESSENCE_ATTACHMENT_METADATA,
   PARTIAL_TX_MODEL_ESSENCE_CONSENSUS,
+  PARTIAL_TX_MODEL_OBSOLETE_TAG,
 } partial_transaction_model_e;
 
 retcode_t iota_tangle_init(tangle_t *const tangle,


### PR DESCRIPTION
When validating a new milestone candidate, the corresponding transaction needs to be loaded from the tangle, but only the transaction obsolete tag is actually needed. Thus, we can avoid loading unnecessary fields in the transaction by loading the obsolete tag only.

Resolves #600.

# Test Plan:

Launch ciri, wait for new milestone candidate to be received and validated.