### PR TITLE
cclient: fix include prefixes

### DIFF
--- a/cclient/iota_client_core_api.h
+++ b/cclient/iota_client_core_api.h
@@ -8,9 +8,9 @@
 #ifndef CCLIENT_IOTA_CORE_API_H_
 #define CCLIENT_IOTA_CORE_API_H_
 
+#include "cclient/response/responses.h"
 #include "cclient/service.h"
 #include "request/requests.h"
-#include "response/responses.h"
 #include "utils/logger_helper.h"
 
 #ifdef __cplusplus

--- a/cclient/iota_client_core_api.h
+++ b/cclient/iota_client_core_api.h
@@ -8,9 +8,9 @@
 #ifndef CCLIENT_IOTA_CORE_API_H_
 #define CCLIENT_IOTA_CORE_API_H_
 
+#include "cclient/request/requests.h"
 #include "cclient/response/responses.h"
 #include "cclient/service.h"
-#include "request/requests.h"
 #include "utils/logger_helper.h"
 
 #ifdef __cplusplus

--- a/cclient/request/BUILD
+++ b/cclient/request/BUILD
@@ -6,7 +6,6 @@ cc_library(
     hdrs = glob([
         "*.h",
     ]),
-    include_prefix = "request",
     visibility = ["//visibility:public"],
     deps = [
         "//cclient/types",

--- a/cclient/request/add_neighbors.c
+++ b/cclient/request/add_neighbors.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/add_neighbors.h"
+#include "add_neighbors.h"
 
 add_neighbors_req_t* add_neighbors_req_new() {
   add_neighbors_req_t* req =

--- a/cclient/request/add_neighbors.h
+++ b/cclient/request/add_neighbors.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_ADD_NEIGHBORS_H
 #define CCLIENT_REQUEST_ADD_NEIGHBORS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/attach_to_tangle.c
+++ b/cclient/request/attach_to_tangle.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/attach_to_tangle.h"
+#include "attach_to_tangle.h"
 
 attach_to_tangle_req_t* attach_to_tangle_req_new() {
   attach_to_tangle_req_t* req =

--- a/cclient/request/attach_to_tangle.h
+++ b/cclient/request/attach_to_tangle.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_ATTACH_TO_TANGLE_H
 #define CCLIENT_REQUEST_ATTACH_TO_TANGLE_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/broadcast_transactions.c
+++ b/cclient/request/broadcast_transactions.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/broadcast_transactions.h"
+#include "broadcast_transactions.h"
 
 broadcast_transactions_req_t* broadcast_transactions_req_new() {
   broadcast_transactions_req_t* req = (broadcast_transactions_req_t*)malloc(

--- a/cclient/request/broadcast_transactions.h
+++ b/cclient/request/broadcast_transactions.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_BROADCAST_TRANSACTIONS_H
 #define CCLIENT_REQUEST_BROADCAST_TRANSACTIONS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/check_consistency.c
+++ b/cclient/request/check_consistency.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/check_consistency.h"
+#include "check_consistency.h"
 
 check_consistency_req_t* check_consistency_req_new() {
   check_consistency_req_t* req =

--- a/cclient/request/check_consistency.h
+++ b/cclient/request/check_consistency.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_CHECK_CONSISTENCY_H
 #define CCLIENT_REQUEST_CHECK_CONSISTENCY_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/find_transactions.c
+++ b/cclient/request/find_transactions.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/find_transactions.h"
+#include "find_transactions.h"
 
 find_transactions_req_t* find_transactions_req_new() {
   find_transactions_req_t* req =

--- a/cclient/request/find_transactions.h
+++ b/cclient/request/find_transactions.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_FIND_TRANSACTIONS_H
 #define CCLIENT_REQUEST_FIND_TRANSACTIONS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/get_balances.c
+++ b/cclient/request/get_balances.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/get_balances.h"
+#include "get_balances.h"
 
 get_balances_req_t* get_balances_req_new() {
   get_balances_req_t* req =

--- a/cclient/request/get_balances.h
+++ b/cclient/request/get_balances.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_GET_BALANCES_H
 #define CCLIENT_REQUEST_GET_BALANCES_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/get_inclusion_state.c
+++ b/cclient/request/get_inclusion_state.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/get_inclusion_state.h"
+#include "get_inclusion_state.h"
 
 get_inclusion_state_req_t* get_inclusion_state_req_new() {
   get_inclusion_state_req_t* req =

--- a/cclient/request/get_inclusion_state.h
+++ b/cclient/request/get_inclusion_state.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_GET_INCLUSION_STATE_H
 #define CCLIENT_REQUEST_GET_INCLUSION_STATE_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/get_transactions_to_approve.c
+++ b/cclient/request/get_transactions_to_approve.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/get_transactions_to_approve.h"
+#include "get_transactions_to_approve.h"
 
 get_transactions_to_approve_req_t* get_transactions_to_approve_req_new() {
   get_transactions_to_approve_req_t* req =

--- a/cclient/request/get_transactions_to_approve.h
+++ b/cclient/request/get_transactions_to_approve.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_GET_TRANSACTIONS_TO_APPROVE_H
 #define CCLIENT_REQUEST_GET_TRANSACTIONS_TO_APPROVE_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/get_trytes.c
+++ b/cclient/request/get_trytes.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/get_trytes.h"
+#include "get_trytes.h"
 
 get_trytes_req_t* get_trytes_req_new() {
   get_trytes_req_t* req = (get_trytes_req_t*)malloc(sizeof(get_trytes_req_t));

--- a/cclient/request/get_trytes.h
+++ b/cclient/request/get_trytes.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_GET_TRYTES_H
 #define CCLIENT_REQUEST_GET_TRYTES_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/remove_neighbors.c
+++ b/cclient/request/remove_neighbors.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/remove_neighbors.h"
+#include "remove_neighbors.h"
 
 remove_neighbors_req_t* remove_neighbors_req_new() {
   remove_neighbors_req_t* req =

--- a/cclient/request/remove_neighbors.h
+++ b/cclient/request/remove_neighbors.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_REMOVE_NEIGHBORS_H
 #define CCLIENT_REQUEST_REMOVE_NEIGHBORS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/request/requests.h
+++ b/cclient/request/requests.h
@@ -8,16 +8,16 @@
 #ifndef CCLIENT_REQUEST_REQUESTS_H
 #define CCLIENT_REQUEST_REQUESTS_H
 
-#include "request/add_neighbors.h"
-#include "request/attach_to_tangle.h"
-#include "request/broadcast_transactions.h"
-#include "request/check_consistency.h"
-#include "request/find_transactions.h"
-#include "request/get_balances.h"
-#include "request/get_inclusion_state.h"
-#include "request/get_transactions_to_approve.h"
-#include "request/get_trytes.h"
-#include "request/remove_neighbors.h"
-#include "request/store_transactions.h"
+#include "add_neighbors.h"
+#include "attach_to_tangle.h"
+#include "broadcast_transactions.h"
+#include "check_consistency.h"
+#include "find_transactions.h"
+#include "get_balances.h"
+#include "get_inclusion_state.h"
+#include "get_transactions_to_approve.h"
+#include "get_trytes.h"
+#include "remove_neighbors.h"
+#include "store_transactions.h"
 
 #endif  // CCLIENT_REQUEST_REQUESTS_H

--- a/cclient/request/store_transactions.c
+++ b/cclient/request/store_transactions.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "request/store_transactions.h"
+#include "store_transactions.h"
 
 store_transactions_req_t* store_transactions_req_new() {
   store_transactions_req_t* req =

--- a/cclient/request/store_transactions.h
+++ b/cclient/request/store_transactions.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_REQUEST_STORE_TRANSACTIONS_H
 #define CCLIENT_REQUEST_STORE_TRANSACTIONS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/BUILD
+++ b/cclient/response/BUILD
@@ -6,7 +6,6 @@ cc_library(
     hdrs = glob([
         "*.h",
     ]),
-    include_prefix = "response",
     visibility = ["//visibility:public"],
     deps = [
         "//cclient/types",

--- a/cclient/response/add_neighbors.c
+++ b/cclient/response/add_neighbors.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/add_neighbors.h"
+#include "add_neighbors.h"
 
 add_neighbors_res_t* add_neighbors_res_new() {
   add_neighbors_res_t* res =

--- a/cclient/response/add_neighbors.h
+++ b/cclient/response/add_neighbors.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_ADD_NEIGHBORS_H
 #define CCLIENT_RESPONSE_ADD_NEIGHBORS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/attach_to_tangle.c
+++ b/cclient/response/attach_to_tangle.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/attach_to_tangle.h"
+#include "attach_to_tangle.h"
 
 attach_to_tangle_res_t* attach_to_tangle_res_new() {
   attach_to_tangle_res_t* res =

--- a/cclient/response/attach_to_tangle.h
+++ b/cclient/response/attach_to_tangle.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_ATTACH_TO_TANGLE_H
 #define CCLIENT_RESPONSE_ATTACH_TO_TANGLE_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/check_consistency.c
+++ b/cclient/response/check_consistency.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/check_consistency.h"
+#include "check_consistency.h"
 
 check_consistency_res_t* check_consistency_res_new() {
   check_consistency_res_t* res =

--- a/cclient/response/check_consistency.h
+++ b/cclient/response/check_consistency.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_CHECK_CONSISTENCY_H
 #define CCLIENT_RESPONSE_CHECK_CONSISTENCY_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/find_transactions.c
+++ b/cclient/response/find_transactions.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/find_transactions.h"
+#include "find_transactions.h"
 
 find_transactions_res_t* find_transactions_res_new() {
   find_transactions_res_t* res =

--- a/cclient/response/find_transactions.h
+++ b/cclient/response/find_transactions.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_FIND_TRANSACTIONS_H
 #define CCLIENT_RESPONSE_FIND_TRANSACTIONS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_balances.c
+++ b/cclient/response/get_balances.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_balances.h"
+#include "get_balances.h"
 
 get_balances_res_t* get_balances_res_new() {
   get_balances_res_t* res =

--- a/cclient/response/get_balances.h
+++ b/cclient/response/get_balances.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_BALANCES_H
 #define CCLIENT_RESPONSE_GET_BALANCES_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_inclusion_state.c
+++ b/cclient/response/get_inclusion_state.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_inclusion_state.h"
+#include "get_inclusion_state.h"
 
 get_inclusion_state_res_t* get_inclusion_state_res_new() {
   get_inclusion_state_res_t* res =

--- a/cclient/response/get_inclusion_state.h
+++ b/cclient/response/get_inclusion_state.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_INCLUSION_STATE_H
 #define CCLIENT_RESPONSE_GET_INCLUSION_STATE_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_neighbors.c
+++ b/cclient/response/get_neighbors.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_neighbors.h"
+#include "get_neighbors.h"
 
 void neighbor_info_t_copy(void* _dst, const void* _src) {
   neighbor_info_t *dst = (neighbor_info_t*)_dst, *src = (neighbor_info_t*)_src;

--- a/cclient/response/get_neighbors.h
+++ b/cclient/response/get_neighbors.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_NEIGHBORS_H
 #define CCLIENT_RESPONSE_GET_NEIGHBORS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_node_info.c
+++ b/cclient/response/get_node_info.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_node_info.h"
+#include "get_node_info.h"
 
 get_node_info_res_t* get_node_info_res_new() {
   get_node_info_res_t* res =

--- a/cclient/response/get_node_info.h
+++ b/cclient/response/get_node_info.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_NODE_INFO_H
 #define CCLIENT_RESPONSE_GET_NODE_INFO_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_tips.c
+++ b/cclient/response/get_tips.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_tips.h"
+#include "get_tips.h"
 
 get_tips_res_t* get_tips_res_new() {
   get_tips_res_t* res = (get_tips_res_t*)malloc(sizeof(get_tips_res_t));

--- a/cclient/response/get_tips.h
+++ b/cclient/response/get_tips.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_TIPS_H
 #define CCLIENT_RESPONSE_GET_TIPS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_transactions_to_approve.c
+++ b/cclient/response/get_transactions_to_approve.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_transactions_to_approve.h"
+#include "get_transactions_to_approve.h"
 
 get_transactions_to_approve_res_t* get_transactions_to_approve_res_new() {
   get_transactions_to_approve_res_t* res =

--- a/cclient/response/get_transactions_to_approve.h
+++ b/cclient/response/get_transactions_to_approve.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_TRANSACTIONS_TO_APPROVE_H
 #define CCLIENT_RESPONSE_GET_TRANSACTIONS_TO_APPROVE_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/get_trytes.c
+++ b/cclient/response/get_trytes.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/get_trytes.h"
+#include "get_trytes.h"
 
 get_trytes_res_t* get_trytes_res_new() {
   get_trytes_res_t* res = (get_trytes_res_t*)malloc(sizeof(get_trytes_res_t));

--- a/cclient/response/get_trytes.h
+++ b/cclient/response/get_trytes.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_GET_TRYTES_H
 #define CCLIENT_RESPONSE_GET_TRYTES_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/remove_neighbors.c
+++ b/cclient/response/remove_neighbors.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "response/remove_neighbors.h"
+#include "remove_neighbors.h"
 
 remove_neighbors_res_t* remove_neighbors_res_new() {
   remove_neighbors_res_t* res =

--- a/cclient/response/remove_neighbors.h
+++ b/cclient/response/remove_neighbors.h
@@ -8,7 +8,7 @@
 #ifndef CCLIENT_RESPONSE_REMOVE_NEIGHBORS_H
 #define CCLIENT_RESPONSE_REMOVE_NEIGHBORS_H
 
-#include "types/types.h"
+#include "cclient/types/types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/response/responses.h
+++ b/cclient/response/responses.h
@@ -8,17 +8,17 @@
 #ifndef CCLIENT_RESPONSE_RESPONSES_H
 #define CCLIENT_RESPONSE_RESPONSES_H
 
-#include "response/add_neighbors.h"
-#include "response/attach_to_tangle.h"
-#include "response/check_consistency.h"
-#include "response/find_transactions.h"
-#include "response/get_balances.h"
-#include "response/get_inclusion_state.h"
-#include "response/get_neighbors.h"
-#include "response/get_node_info.h"
-#include "response/get_tips.h"
-#include "response/get_transactions_to_approve.h"
-#include "response/get_trytes.h"
-#include "response/remove_neighbors.h"
+#include "add_neighbors.h"
+#include "attach_to_tangle.h"
+#include "check_consistency.h"
+#include "find_transactions.h"
+#include "get_balances.h"
+#include "get_inclusion_state.h"
+#include "get_neighbors.h"
+#include "get_node_info.h"
+#include "get_tips.h"
+#include "get_transactions_to_approve.h"
+#include "get_trytes.h"
+#include "remove_neighbors.h"
 
 #endif  // CCLIENT_RESPONSE_RESPONSES_H

--- a/cclient/serialization/serializer.h
+++ b/cclient/serialization/serializer.h
@@ -9,8 +9,8 @@
 #define CCLIENT_SERIALIZATION_SERIALIZER_H
 
 #include <stdlib.h>
+#include "cclient/response/responses.h"
 #include "request/requests.h"
-#include "response/responses.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/serialization/serializer.h
+++ b/cclient/serialization/serializer.h
@@ -9,8 +9,8 @@
 #define CCLIENT_SERIALIZATION_SERIALIZER_H
 
 #include <stdlib.h>
+#include "cclient/request/requests.h"
 #include "cclient/response/responses.h"
-#include "request/requests.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cclient/types/BUILD
+++ b/cclient/types/BUILD
@@ -6,7 +6,6 @@ cc_library(
     hdrs = [
         "types.h",
     ],
-    include_prefix = "types",
     visibility = ["//visibility:public"],
     deps = [
         "//common:errors",

--- a/cclient/types/types.c
+++ b/cclient/types/types.c
@@ -5,7 +5,7 @@
  * Refer to the LICENSE file for licensing information
  */
 
-#include "types/types.h"
+#include "types.h"
 
 #define TYPES_LOGGER_ID "types"
 

--- a/ciri/api/api.c
+++ b/ciri/api/api.c
@@ -7,11 +7,11 @@
 
 #include <string.h>
 
+#include "cclient/request/requests.h"
 #include "cclient/response/responses.h"
 #include "cclient/serialization/json/json_serializer.h"
 #include "ciri/api/api.h"
 #include "gossip/node.h"
-#include "request/requests.h"
 #include "utils/logger_helper.h"
 #include "utils/time.h"
 

--- a/ciri/api/api.c
+++ b/ciri/api/api.c
@@ -7,11 +7,11 @@
 
 #include <string.h>
 
+#include "cclient/response/responses.h"
 #include "cclient/serialization/json/json_serializer.h"
 #include "ciri/api/api.h"
 #include "gossip/node.h"
 #include "request/requests.h"
-#include "response/responses.h"
 #include "utils/logger_helper.h"
 #include "utils/time.h"
 


### PR DESCRIPTION
Remove include prefixes for types/request/response.

Fix #719 

# Test Plan:
CI