### PR TITLE
common/trinary: fix test case names

### DIFF
--- a/common/trinary/tests/test_trit_tryte.c
+++ b/common/trinary/tests/test_trit_tryte.c
@@ -13,7 +13,7 @@
 #define TRYTES_IN "AZN9"
 #define EXP 1, 0, 0, -1, 0, 0, -1, -1, -1, 0, 0, 0
 
-void test_trit_to_tryte(void) {
+void test_trits_to_trytes(void) {
   trit_t trits[] = {EXP};
   tryte_t trytes[12];
   tryte_t exp[] = {TRYTES_IN};
@@ -22,7 +22,7 @@ void test_trit_to_tryte(void) {
   TEST_ASSERT_EQUAL_MEMORY(exp, trits, sizeof(exp));
 }
 
-void test_tryte_to_trit(void) {
+void test_trytes_to_trits(void) {
   tryte_t trytes[] = {TRYTES_IN};
   trit_t trits[12];
   trit_t exp[] = {EXP};
@@ -56,7 +56,8 @@ void test_set_trit_at(void) {
 int main(void) {
   UNITY_BEGIN();
 
-  RUN_TEST(test_trit_to_tryte);
+  RUN_TEST(test_trits_to_trytes);
+  RUN_TEST(test_trytes_to_trits);
   RUN_TEST(test_get_trit_at);
   RUN_TEST(test_set_trit_at);
 

--- a/common/trinary/tests/test_trit_tryte.c
+++ b/common/trinary/tests/test_trit_tryte.c
@@ -13,7 +13,7 @@
 #define TRYTES_IN "AZN9"
 #define EXP 1, 0, 0, -1, 0, 0, -1, -1, -1, 0, 0, 0
 
-void test_tryte_to_trit(void) {
+void test_trit_to_tryte(void) {
   trit_t trits[] = {EXP};
   tryte_t trytes[12];
   tryte_t exp[] = {TRYTES_IN};
@@ -22,7 +22,7 @@ void test_tryte_to_trit(void) {
   TEST_ASSERT_EQUAL_MEMORY(exp, trits, sizeof(exp));
 }
 
-void test_trit_to_tryte(void) {
+void test_tryte_to_trit(void) {
   tryte_t trytes[] = {TRYTES_IN};
   trit_t trits[12];
   trit_t exp[] = {EXP};

--- a/common/trinary/tests/test_trit_tryte.c
+++ b/common/trinary/tests/test_trit_tryte.c
@@ -15,11 +15,10 @@
 
 void test_trits_to_trytes(void) {
   trit_t trits[] = {EXP};
-  tryte_t trytes[12];
+  tryte_t trytes[4];
   tryte_t exp[] = {TRYTES_IN};
   trits_to_trytes(trits, trytes, 12);
-  TEST_ASSERT_EQUAL(strlen((const char *)trytes), 12);
-  TEST_ASSERT_EQUAL_MEMORY(exp, trits, sizeof(exp));
+  TEST_ASSERT_EQUAL_MEMORY(exp, trytes, 4);
 }
 
 void test_trytes_to_trits(void) {
@@ -27,7 +26,7 @@ void test_trytes_to_trits(void) {
   trit_t trits[12];
   trit_t exp[] = {EXP};
   trytes_to_trits(trytes, trits, 4);
-  TEST_ASSERT_EQUAL_MEMORY(exp, trits, sizeof(exp));
+  TEST_ASSERT_EQUAL_MEMORY(exp, trits, 12);
 }
 
 void test_get_trit_at(void) {


### PR DESCRIPTION
in common/trinary/tests/test_trit_tryte.c the names of the test functions for trit-tryte and tryte-trit conversion have been mixed up. this is fixed by this commit



# Test Plan:
No need to test, since its just a switch in test function names
