### PR TITLE
mam/v2/bundle: create API and stubs

### DIFF
--- a/mam/v2/bundle/BUILD
+++ b/mam/v2/bundle/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "bundle",
+    srcs = ["bundle.c"],
+    hdrs = ["bundle.h"],
+    deps = [
+        "//common:errors",
+        "//common/model:bundle",
+        "//mam/v2/mam",
+        "//mam/v2/state",
+    ],
+)

--- a/mam/v2/bundle/bundle.c
+++ b/mam/v2/bundle/bundle.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * MAM is based on an original implementation & specification by apmi.bsu.by
+ * [ITSec Lab]
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "mam/v2/bundle/bundle.h"
+
+retcode_t mam_bundle_write_msg(
+    mam_state_t *const state, mam_msg_pubkey_t pubkey,
+    mam_msg_keyload_t keyload, mam_msg_checksum_t checksum,
+    mam_channel_t const *const cha, mam_endpoint_t const *const epa,
+    mam_channel_t const *const ch1a, mam_endpoint_t const *const ep1a,
+    flex_trit_t const *const payload, bundle_transactions_t *const bundle) {
+  return RC_MAM2_NOT_IMPLEMENTED;
+}
+
+retcode_t mam_bundle_write_packet(
+    mam_state_t *const state, mam_msg_pubkey_t pubkey,
+    mam_msg_keyload_t keyload, mam_msg_checksum_t checksum,
+    mam_channel_t const *const cha, mam_endpoint_t const *const epa,
+    mam_channel_t const *const ch1a, mam_endpoint_t const *const ep1a,
+    flex_trit_t const *const payload, bundle_transactions_t *const bundle) {
+  return RC_MAM2_NOT_IMPLEMENTED;
+}
+
+retcode_t mam_bundle_read(mam_state_t *const state,
+                          mam_channel_t const *const cha,
+                          bundle_transactions_t const *const bundle,
+                          flex_trit_t *const payload) {
+  return RC_MAM2_NOT_IMPLEMENTED;
+}

--- a/mam/v2/bundle/bundle.h
+++ b/mam/v2/bundle/bundle.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * MAM is based on an original implementation & specification by apmi.bsu.by
+ * [ITSec Lab]
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef __MAM_V2_BUNDLE_BUNDLE_H__
+#define __MAM_V2_BUNDLE_BUNDLE_H__
+
+#include "common/errors.h"
+#include "common/model/bundle.h"
+#include "common/trinary/flex_trit.h"
+#include "mam/v2/mam/mam.h"
+#include "mam/v2/state/state.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+retcode_t mam_bundle_write_msg(
+    mam_state_t *const state, mam_msg_pubkey_t pubkey,
+    mam_msg_keyload_t keyload, mam_msg_checksum_t checksum,
+    mam_channel_t const *const cha, mam_endpoint_t const *const epa,
+    mam_channel_t const *const ch1a, mam_endpoint_t const *const ep1a,
+    flex_trit_t const *const payload, bundle_transactions_t *const bundle);
+
+retcode_t mam_bundle_write_packet(
+    mam_state_t *const state, mam_msg_pubkey_t pubkey,
+    mam_msg_keyload_t keyload, mam_msg_checksum_t checksum,
+    mam_channel_t const *const cha, mam_endpoint_t const *const epa,
+    mam_channel_t const *const ch1a, mam_endpoint_t const *const ep1a,
+    flex_trit_t const *const payload, bundle_transactions_t *const bundle);
+
+retcode_t mam_bundle_read(mam_state_t *const state,
+                          mam_channel_t const *const cha,
+                          bundle_transactions_t const *const bundle,
+                          flex_trit_t *const payload);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __MAM_V2_BUNDLE_BUNDLE_H__

--- a/mam/v2/trits/tests/test_trits.c
+++ b/mam/v2/trits/tests/test_trits.c
@@ -74,32 +74,6 @@ static void trits_add_sub_test(void) {
     }
 }
 
-static void trits_bytes_test(void) {
-  trits_t x, y;
-  byte b[3];
-  size_t n, k;
-
-  MAM2_TRITS_DEF0(x0, 5 * 3);
-  MAM2_TRITS_DEF0(y0, 5 * 3);
-
-  x0 = MAM2_TRITS_INIT(x0, 5 * 3);
-  y0 = MAM2_TRITS_INIT(y0, 5 * 3);
-
-  for (n = 0; n < 11; ++n) {
-    x = trits_take(x0, n);
-    y = trits_take(y0, n);
-    trits_set_zero(x);
-    k = 0;
-    do {
-      trits_to_bytes(x, b);
-      trits_set_zero(y);
-      TEST_ASSERT_TRUE(trits_from_bytes(y, b));
-      TEST_ASSERT_TRUE(trits_cmp_eq(x, y));
-      k++;
-    } while (trits_inc(x));
-  }
-}
-
 static bool trits_trytes(trits_t x, char *s, char *t) {
   bool r = true;
   size_t n = trits_size(x) / 3;
@@ -171,7 +145,6 @@ int main(void) {
 
   RUN_TEST(trits_put_get_test);
   RUN_TEST(trits_add_sub_test);
-  RUN_TEST(trits_bytes_test);
   RUN_TEST(trits_test);
 
   return UNITY_END();

--- a/mam/v2/trits/trits.c
+++ b/mam/v2/trits/trits.c
@@ -300,20 +300,6 @@ bool trits_from_str(trits_t x, char const *s) {
   return r;
 }
 
-void trits_to_bytes(trits_t x, byte *bs) {
-  for (; !trits_is_empty(x); x = trits_drop_min(x, 5))
-    *bs++ = trits_get_byte(x);
-}
-
-bool trits_from_bytes(trits_t x, byte const *bs) {
-  bool r = true;
-
-  for (; r && !trits_is_empty(x); x = trits_drop_min(x, 5))
-    r = trits_put_byte(x, *bs++);
-
-  return r;
-}
-
 void trits_set1(trits_t x, trit_t t) {
   MAM2_ASSERT_TRINT1(t);
   for (; !trits_is_empty(x); x = trits_drop(x, 1)) trits_put1(x, t);

--- a/mam/v2/trits/trits.h
+++ b/mam/v2/trits/trits.h
@@ -115,16 +115,6 @@ Size of `s` must be equal `trits_size(x)/3`.
 */
 bool trits_from_str(trits_t x, char const *s);
 
-/*! \brief Convert trits to bytes.
-Size of `bs` must be equal `ceil(trits_size(x)/5)`.
-*/
-void trits_to_bytes(trits_t x, byte *bs);
-
-/*! \brief Convert trits from bytes.
-Size of `bs` must be equal `ceil(trits_size(x)/5)`.
-*/
-bool trits_from_bytes(trits_t x, byte const *bs);
-
 /*! \brief Set zero trits: `x` := t^n. */
 void trits_set1(trits_t x, trit_t t);
 


### PR DESCRIPTION
- remove trit_byte since it collided with flex_trit deps and it is not needed (no need to rename)
- add Stubs for mam-bundle functions