### PR TITLE
mam2: mss clean and test serialization

### DIFF
--- a/mam/v2/mam/channel.c
+++ b/mam/v2/mam/channel.c
@@ -173,7 +173,7 @@ retcode_t mam_channel_deserialize(trits_t *const buffer, mam_prng_t *const prng,
 
   mss_init(&channel->mss, prng, height, channel->name, trits_null());
 
-  if ((ret = mss_deserialize(&channel->mss, buffer)) != RC_OK) {
+  if ((ret = mss_deserialize(buffer, &channel->mss)) != RC_OK) {
     return ret;
   }
 

--- a/mam/v2/mam/channel.c
+++ b/mam/v2/mam/channel.c
@@ -104,7 +104,7 @@ retcode_t mam_channel_unwrap(mam_spongos_t *const spongos,
 }
 
 size_t mam_channel_serialized_size(mam_channel_t const *const channel) {
-  size_t mss_size = mss_stored_size(&channel->mss);
+  size_t mss_size = mss_serialized_size(&channel->mss);
   size_t endpoints_size = mam_endpoints_serialized_size(channel->endpoints);
 
   return pb3_sizeof_ntrytes(MAM2_CHANNEL_ID_SIZE /
@@ -120,14 +120,14 @@ size_t mam_channel_serialized_size(mam_channel_t const *const channel) {
 
 retcode_t mam_channel_serialize(mam_channel_t const *const channel,
                                 trits_t *const buffer) {
-  size_t mss_size = mss_stored_size(&channel->mss);
+  size_t mss_size = mss_serialized_size(&channel->mss);
 
   pb3_encode_ntrytes(trits_from_rep(MAM2_CHANNEL_ID_SIZE, channel->id),
-                     buffer);                              // id
-  pb3_encode_size_t(trits_size(channel->name), buffer);    // name size
-  pb3_encode_ntrytes(channel->name, buffer);               // name
-  pb3_encode_size_t(mss_size, buffer);                     // mss size
-  mss_save(&channel->mss, trits_take(*buffer, mss_size));  // mss
+                     buffer);                                   // id
+  pb3_encode_size_t(trits_size(channel->name), buffer);         // name size
+  pb3_encode_ntrytes(channel->name, buffer);                    // name
+  pb3_encode_size_t(mss_size, buffer);                          // mss size
+  mss_serialize(&channel->mss, trits_take(*buffer, mss_size));  // mss
   trits_advance(buffer, mss_size);
   mam_endpoints_serialize(channel->endpoints, buffer);  // endpoints
 
@@ -173,7 +173,7 @@ retcode_t mam_channel_deserialize(trits_t *const buffer, mam_prng_t *const prng,
 
   mss_init(&channel->mss, prng, height, channel->name, trits_null());
 
-  if ((ret = mss_load(&channel->mss, buffer)) != RC_OK) {
+  if ((ret = mss_deserialize(&channel->mss, buffer)) != RC_OK) {
     return ret;
   }
 

--- a/mam/v2/mam/endpoint.c
+++ b/mam/v2/mam/endpoint.c
@@ -143,7 +143,7 @@ retcode_t mam_endpoint_deserialize(trits_t *const buffer,
 
   mss_init(&endpoint->mss, prng, height, channel_name, endpoint->name);
 
-  if ((ret = mss_deserialize(&endpoint->mss, buffer)) != RC_OK) {
+  if ((ret = mss_deserialize(buffer, &endpoint->mss)) != RC_OK) {
     return ret;
   }
 

--- a/mam/v2/mam/endpoint.c
+++ b/mam/v2/mam/endpoint.c
@@ -74,7 +74,7 @@ retcode_t mam_endpoints_destroy(mam_endpoint_t_set_t *const endpoints) {
 }
 
 size_t mam_endpoint_serialized_size(mam_endpoint_t const *const endpoint) {
-  size_t mss_size = mss_stored_size(&endpoint->mss);
+  size_t mss_size = mss_serialized_size(&endpoint->mss);
 
   return pb3_sizeof_ntrytes(MAM2_ENDPOINT_ID_SIZE /
                             NUMBER_OF_TRITS_IN_A_TRYTE) +  // id
@@ -87,14 +87,14 @@ size_t mam_endpoint_serialized_size(mam_endpoint_t const *const endpoint) {
 
 retcode_t mam_endpoint_serialize(mam_endpoint_t const *const endpoint,
                                  trits_t *const buffer) {
-  size_t mss_size = mss_stored_size(&endpoint->mss);
+  size_t mss_size = mss_serialized_size(&endpoint->mss);
 
   pb3_encode_ntrytes(trits_from_rep(MAM2_ENDPOINT_ID_SIZE, endpoint->id),
-                     buffer);                               // id
-  pb3_encode_size_t(trits_size(endpoint->name), buffer);    // name size
-  pb3_encode_ntrytes(endpoint->name, buffer);               // name
-  pb3_encode_size_t(mss_size, buffer);                      // mss size
-  mss_save(&endpoint->mss, trits_take(*buffer, mss_size));  // mss
+                     buffer);                                    // id
+  pb3_encode_size_t(trits_size(endpoint->name), buffer);         // name size
+  pb3_encode_ntrytes(endpoint->name, buffer);                    // name
+  pb3_encode_size_t(mss_size, buffer);                           // mss size
+  mss_serialize(&endpoint->mss, trits_take(*buffer, mss_size));  // mss
   trits_advance(buffer, mss_size);
 
   return RC_OK;
@@ -143,7 +143,7 @@ retcode_t mam_endpoint_deserialize(trits_t *const buffer,
 
   mss_init(&endpoint->mss, prng, height, channel_name, endpoint->name);
 
-  if ((ret = mss_load(&endpoint->mss, buffer)) != RC_OK) {
+  if ((ret = mss_deserialize(&endpoint->mss, buffer)) != RC_OK) {
     return ret;
   }
 

--- a/mam/v2/mam/tests/test_channel.c
+++ b/mam/v2/mam/tests/test_channel.c
@@ -25,6 +25,12 @@ static bool mam_channel_t_set_cmp(mam_channel_t_set_t const channels_1,
   mam_channel_t_set_entry_t *entry_2 = NULL;
   mam_channel_t_set_entry_t *tmp_2 = NULL;
   size_t match = 0;
+  MAM2_TRITS_DEF0(hash, MAM2_MSS_HASH_SIZE);
+  hash = MAM2_TRITS_INIT(hash, MAM2_MSS_HASH_SIZE);
+  trits_from_str(hash,
+                 "ABCNKOZWYSDF9OABCNKOZWYSDF9"
+                 "ABCNKOZWYSDF9QABCNKOZWYSDF9"
+                 "ABCNKOZWYSDF9CABCNKOZWYSDF9");
 
   if (mam_channel_t_set_size(channels_1) !=
       mam_channel_t_set_size(channels_2)) {
@@ -36,9 +42,19 @@ static bool mam_channel_t_set_cmp(mam_channel_t_set_t const channels_1,
       if (memcmp(entry_1->value.id, entry_2->value.id, MAM2_ENDPOINT_ID_SIZE) ==
               0 &&
           trits_cmp_eq(entry_1->value.name, entry_2->value.name)) {
-        // TODO check MSS
+        MAM2_TRITS_DEF0(sig1, MAM2_MSS_SIG_SIZE(entry_1->value.mss.height));
+        MAM2_TRITS_DEF0(sig2, MAM2_MSS_SIG_SIZE(entry_2->value.mss.height));
+        sig1 =
+            MAM2_TRITS_INIT(sig1, MAM2_MSS_SIG_SIZE(entry_1->value.mss.height));
+        sig2 =
+            MAM2_TRITS_INIT(sig2, MAM2_MSS_SIG_SIZE(entry_2->value.mss.height));
+        mss_sign(&entry_1->value.mss, hash, sig1);
+        mss_sign(&entry_2->value.mss, hash, sig2);
+        if (trits_cmp_eq(sig1, sig2)) {
+          match++;
+          break;
+        }
         // TODO check endpoints
-        match++;
       }
     }
   }

--- a/mam/v2/mam/tests/test_endpoint.c
+++ b/mam/v2/mam/tests/test_endpoint.c
@@ -27,6 +27,12 @@ static bool mam_endpoint_t_set_cmp(mam_endpoint_t_set_t const endpoints_1,
   mam_endpoint_t_set_entry_t *entry_2 = NULL;
   mam_endpoint_t_set_entry_t *tmp_2 = NULL;
   size_t match = 0;
+  MAM2_TRITS_DEF0(hash, MAM2_MSS_HASH_SIZE);
+  hash = MAM2_TRITS_INIT(hash, MAM2_MSS_HASH_SIZE);
+  trits_from_str(hash,
+                 "ABCNKOZWYSDF9OABCNKOZWYSDF9"
+                 "ABCNKOZWYSDF9QABCNKOZWYSDF9"
+                 "ABCNKOZWYSDF9CABCNKOZWYSDF9");
 
   if (mam_endpoint_t_set_size(endpoints_1) !=
       mam_endpoint_t_set_size(endpoints_2)) {
@@ -38,8 +44,18 @@ static bool mam_endpoint_t_set_cmp(mam_endpoint_t_set_t const endpoints_1,
       if (memcmp(entry_1->value.id, entry_2->value.id, MAM2_ENDPOINT_ID_SIZE) ==
               0 &&
           trits_cmp_eq(entry_1->value.name, entry_2->value.name)) {
-        // TODO check MSS
-        match++;
+        MAM2_TRITS_DEF0(sig1, MAM2_MSS_SIG_SIZE(entry_1->value.mss.height));
+        MAM2_TRITS_DEF0(sig2, MAM2_MSS_SIG_SIZE(entry_2->value.mss.height));
+        sig1 =
+            MAM2_TRITS_INIT(sig1, MAM2_MSS_SIG_SIZE(entry_1->value.mss.height));
+        sig2 =
+            MAM2_TRITS_INIT(sig2, MAM2_MSS_SIG_SIZE(entry_2->value.mss.height));
+        mss_sign(&entry_1->value.mss, hash, sig1);
+        mss_sign(&entry_2->value.mss, hash, sig2);
+        if (trits_cmp_eq(sig1, sig2)) {
+          match++;
+          break;
+        }
       }
     }
   }

--- a/mam/v2/mss/mss.c
+++ b/mam/v2/mss/mss.c
@@ -612,7 +612,7 @@ void mss_destroy(mss_t *mss) {
 #endif
 }
 
-static size_t mss_mt_stored_size(mss_t const *const mss) {
+static size_t mss_mt_serialized_size(mss_t const *const mss) {
   size_t size = 0;
 #if defined(MAM2_MSS_TRAVERSAL)
   mss_mt_height_t height;
@@ -625,11 +625,11 @@ static size_t mss_mt_stored_size(mss_t const *const mss) {
   return size;
 }
 
-static void mss_mt_save(mss_t const *const mss, trits_t buffer) {
+static void mss_mt_serialize(mss_t const *const mss, trits_t buffer) {
   mss_mt_height_t height;
   mss_mt_idx_t i;
 
-  MAM2_ASSERT(trits_size(buffer) == mss_mt_stored_size(mss));
+  MAM2_ASSERT(trits_size(buffer) == mss_mt_serialized_size(mss));
 
 #if defined(MAM2_MSS_TRAVERSAL)
   /* <apath> */
@@ -662,11 +662,11 @@ static void mss_mt_save(mss_t const *const mss, trits_t buffer) {
  * \note `mss_mt_rewind` must be called prior `mss_mt_load`.
  */
 
-static void mss_mt_load(mss_t *mss, trits_t buffer) {
+static void mss_mt_deserialize(mss_t *mss, trits_t buffer) {
   mss_mt_height_t height;
   mss_mt_idx_t i;
 
-  MAM2_ASSERT(trits_size(buffer) == mss_mt_stored_size(mss));
+  MAM2_ASSERT(trits_size(buffer) == mss_mt_serialized_size(mss));
 
 #if defined(MAM2_MSS_TRAVERSAL)
   /* <apath> */
@@ -696,18 +696,18 @@ static void mss_mt_load(mss_t *mss, trits_t buffer) {
 #endif
 }
 
-size_t mss_stored_size(mss_t const *const mss) {
-  return 4 + 14 + mss_mt_stored_size(mss);
+size_t mss_serialized_size(mss_t const *const mss) {
+  return 4 + 14 + mss_mt_serialized_size(mss);
 }
 
-void mss_save(mss_t const *const mss, trits_t buffer) {
-  MAM2_ASSERT(mss_stored_size(mss) == trits_size(buffer));
+void mss_serialize(mss_t const *const mss, trits_t buffer) {
+  MAM2_ASSERT(mss_serialized_size(mss) == trits_size(buffer));
 
   mss_skn(mss, trits_take(buffer, MAM2_MSS_SKN_SIZE));
-  mss_mt_save(mss, trits_drop(buffer, MAM2_MSS_SKN_SIZE));
+  mss_mt_serialize(mss, trits_drop(buffer, MAM2_MSS_SKN_SIZE));
 }
 
-retcode_t mss_load(mss_t *mss, trits_t *b) {
+retcode_t mss_deserialize(mss_t *mss, trits_t *b) {
   retcode_t e = RC_OK;
 
   mss_mt_height_t height;
@@ -723,9 +723,9 @@ retcode_t mss_load(mss_t *mss, trits_t *b) {
 #else
   mss->skn = skn;
 #endif
-  ERR_GUARD_RETURN(mss_mt_stored_size(mss) <= trits_size(*b),
+  ERR_GUARD_RETURN(mss_mt_serialized_size(mss) <= trits_size(*b),
                    RC_MAM2_BUFFER_TOO_SMALL, e);
-  mss_mt_load(mss, trits_advance(b, mss_mt_stored_size(mss)));
+  mss_mt_deserialize(mss, trits_advance(b, mss_mt_serialized_size(mss)));
 
   return e;
 }

--- a/mam/v2/mss/mss.c
+++ b/mam/v2/mss/mss.c
@@ -666,7 +666,7 @@ static void mss_mt_serialize(mss_t const *const mss, trits_t buffer) {
  * \note `mss_mt_rewind` must be called prior `mss_mt_load`.
  */
 
-static void mss_mt_deserialize(mss_t *mss, trits_t buffer) {
+static void mss_mt_deserialize(trits_t buffer, mss_t *mss) {
   mss_mt_height_t height;
   mss_mt_idx_t i;
 
@@ -712,7 +712,7 @@ void mss_serialize(mss_t const *const mss, trits_t buffer) {
   mss_mt_serialize(mss, trits_drop(buffer, MAM2_MSS_SKN_SIZE));
 }
 
-retcode_t mss_deserialize(mss_t *mss, trits_t *b) {
+retcode_t mss_deserialize(trits_t *b, mss_t *mss) {
   retcode_t e = RC_OK;
 
   mss_mt_height_t height;
@@ -736,7 +736,7 @@ retcode_t mss_deserialize(mss_t *mss, trits_t *b) {
 #endif
   ERR_GUARD_RETURN(mss_mt_serialized_size(mss) <= trits_size(*b),
                    RC_MAM2_BUFFER_TOO_SMALL, e);
-  mss_mt_deserialize(mss, trits_advance(b, mss_mt_serialized_size(mss)));
+  mss_mt_deserialize(trits_advance(b, mss_mt_serialized_size(mss)), mss);
 
   return e;
 }

--- a/mam/v2/mss/mss.h
+++ b/mam/v2/mss/mss.h
@@ -272,7 +272,7 @@ void mss_serialize(mss_t const *const mss, trits_t buffer);
  *
  * @return void
  */
-retcode_t mss_deserialize(mss_t *mss, trits_t *buffer);
+retcode_t mss_deserialize(trits_t *buffer, mss_t *mss);
 
 #ifdef __cplusplus
 }

--- a/mam/v2/mss/mss.h
+++ b/mam/v2/mss/mss.h
@@ -251,7 +251,7 @@ void mss_destroy(mss_t *mss);
  * @return size_t The size for stored MT
  */
 
-size_t mss_stored_size(mss_t const *const mss);
+size_t mss_serialized_size(mss_t const *const mss);
 
 /**
  * Serialize Merkle tree.
@@ -262,7 +262,7 @@ size_t mss_stored_size(mss_t const *const mss);
  * @return void
  */
 
-void mss_save(mss_t const *const mss, trits_t buffer);
+void mss_serialize(mss_t const *const mss, trits_t buffer);
 
 /**
  * Deerialize Merkle tree.
@@ -272,7 +272,7 @@ void mss_save(mss_t const *const mss, trits_t buffer);
  *
  * @return void
  */
-retcode_t mss_load(mss_t *mss, trits_t *buffer);
+retcode_t mss_deserialize(mss_t *mss, trits_t *buffer);
 
 #ifdef __cplusplus
 }

--- a/mam/v2/mss/tests/test_mss.c
+++ b/mam/v2/mss/tests/test_mss.c
@@ -148,9 +148,9 @@ static bool mss_store_test(mss_t *mss1, mss_t *mss2, mam_prng_t *prng,
     do {
       mss_sign(mss1, hash, sig);
 
-      store = trits_take(store_, mss_stored_size(mss1));
-      mss_save(mss1, store);
-      e = mss_load(mss2, &store);
+      store = trits_take(store_, mss_serialized_size(mss1));
+      mss_serialize(mss1, store);
+      e = mss_deserialize(mss2, &store);
       MAM2_ASSERT(RC_OK == e);
       mss_sign(mss2, hash, sig2);
 

--- a/mam/v2/mss/tests/test_mss.c
+++ b/mam/v2/mss/tests/test_mss.c
@@ -150,7 +150,7 @@ static bool mss_store_test(mss_t *mss1, mss_t *mss2, mam_prng_t *prng,
 
       store = trits_take(store_, mss_serialized_size(mss1));
       mss_serialize(mss1, store);
-      e = mss_deserialize(mss2, &store);
+      e = mss_deserialize(&store, mss2);
       MAM2_ASSERT(RC_OK == e);
       mss_sign(mss2, hash, sig2);
 


### PR DESCRIPTION
- Renames serialization methods for consistency
- Tests endpoint MSS and channel MSS serializations methods
- Replaces hardcoded values with some defines

# Test Plan:
Existing and improved tests
