### PR TITLE
Optimized curl transform formulas

### DIFF
--- a/common/curl-p/ptrit.c
+++ b/common/curl-p/ptrit.c
@@ -9,17 +9,16 @@
 #include "utils/forced_inline.h"
 
 static FORCED_INLINE void ptrit_sbox(ptrit_t *const c, ptrit_t const *const s) {
-  ptrit_s alpha, beta, gamma, delta;
+  ptrit_s alpha, beta, delta;
   size_t i = 0;
 
   for (; i < STATE_LENGTH; ++i) {
     alpha = s[CURL_INDEX[i]].low;
     beta = s[CURL_INDEX[i]].high;
-    gamma = s[CURL_INDEX[i + 1]].high;
-    delta = (alpha | (~gamma)) & (s[CURL_INDEX[i + 1]].low ^ beta);
+    delta = beta ^ s[CURL_INDEX[i + 1]].low;
 
-    c[i].low = ~delta;
-    c[i].high = (alpha ^ gamma) | delta;
+    c[i].low = ~(delta & alpha);
+    c[i].high = delta | (alpha ^ s[CURL_INDEX[i + 1]].high);
   }
 }
 

--- a/common/curl-p/ptrit.c
+++ b/common/curl-p/ptrit.c
@@ -17,7 +17,7 @@ static FORCED_INLINE void ptrit_sbox(ptrit_t *const c, ptrit_t const *const s) {
     beta = s[CURL_INDEX[i]].high;
     delta = alpha & (s[CURL_INDEX[i + 1]].low ^ beta);
 
-    c[i].low = ~(delta & alpha);
+    c[i].low = ~delta;
     c[i].high = (alpha ^ s[CURL_INDEX[i + 1]].high) | delta;
   }
 }

--- a/common/curl-p/ptrit.c
+++ b/common/curl-p/ptrit.c
@@ -18,7 +18,7 @@ static FORCED_INLINE void ptrit_sbox(ptrit_t *const c, ptrit_t const *const s) {
     delta = beta ^ s[CURL_INDEX[i + 1]].low;
 
     c[i].low = ~(delta & alpha);
-    c[i].high = delta | (alpha ^ s[CURL_INDEX[i + 1]].high);
+    c[i].high = (alpha ^ s[CURL_INDEX[i + 1]].high) | delta;
   }
 }
 

--- a/common/curl-p/ptrit.c
+++ b/common/curl-p/ptrit.c
@@ -15,7 +15,7 @@ static FORCED_INLINE void ptrit_sbox(ptrit_t *const c, ptrit_t const *const s) {
   for (; i < STATE_LENGTH; ++i) {
     alpha = s[CURL_INDEX[i]].low;
     beta = s[CURL_INDEX[i]].high;
-    delta = beta ^ s[CURL_INDEX[i + 1]].low;
+    delta = alpha & (s[CURL_INDEX[i + 1]].low ^ beta);
 
     c[i].low = ~(delta & alpha);
     c[i].high = (alpha ^ s[CURL_INDEX[i + 1]].high) | delta;


### PR DESCRIPTION
powsrv.io Team optimized the curl transform formulas.

On my machine it's around 7% faster than before.

# Test Plan:
To benchmark the results I changed the test_curlp_ptrit.c locally on my machine:
```
int main(void) {
  UNITY_BEGIN();

  RUN_TEST(test_curl_p_27_works);
  for(size_t i = 0; i < 50000; i++)
  {
    RUN_TEST(test_curl_p_81_works);
  } 

  return UNITY_END();
}
```
