### PR TITLE
infra: Update Android SDK and NDK to API level 27

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,12 +29,12 @@ new_git_repository(
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 19,
+    api_level = 27,
 )
 
 android_ndk_repository(
     name = "androidndk",
-    api_level = 14,
+    api_level = 27,
 )
 
 load("@rules_iota//:defs.bzl", "iota_deps")


### PR DESCRIPTION
Updates Android SDK and NDK to API level 27 (Android Oreo)

# Test Plan:
`bazel build //mobile/android:dummy` runs successfully