### PR TITLE
mobile/android: Use API level 19 to prevent a crash on some devices

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,12 +29,12 @@ new_git_repository(
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 27,
+    api_level = 19,
 )
 
 android_ndk_repository(
     name = "androidndk",
-    api_level = 27,
+    api_level = 19,
 )
 
 load("@rules_iota//:defs.bzl", "iota_deps")

--- a/mobile/android/AndroidManifest.xml
+++ b/mobile/android/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <uses-sdk
         android:minSdkVersion="16"
-        android:targetSdkVersion="16" />
+        android:targetSdkVersion="27" />
 
     <application
         android:label="Bazel App"

--- a/mobile/android/BUILD
+++ b/mobile/android/BUILD
@@ -5,6 +5,10 @@ cc_library(
         "jni.h",
     ],
     hdrs = ["Interface.h"],
+    defines = [
+        "APP_PLATFORM=android-19",
+        "ANDROID_NATIVE_API_LEVEL=19",
+    ],
     linkopts = ["-lm"],
     deps = ["//common/helpers"],
 )


### PR DESCRIPTION
Original issue: https://github.com/iotaledger/trinity-wallet/issues/1135

In optimized builds for `armeabi-v7a`, the `memcpy` function is sometimes replaced with ARM's [`__aeabi_memcpy`](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka3934.html). Because of changes in later versions of the Android NDK, crashes can sometimes occur where this function is undefined. This is fixed by using API level 19 (see https://github.com/android-ndk/ndk/issues/126#issuecomment-334672371).

# Test Plan:
No longer crashes on Motorola Moto G4 (Android 6.0.1) and LG K3 (Android 6.0.1), which were previously affected by this issue
