### PR TITLE
infra: Use API level 19 for Android NDK

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,7 @@ android_sdk_repository(
 
 android_ndk_repository(
     name = "androidndk",
-    api_level = 14,
+    api_level = 19,
 )
 
 load("@rules_iota//:defs.bzl", "iota_deps")


### PR DESCRIPTION
Uses API level 19 for Android NDK. This will allow later versions of NDK to be used. Previous versions, such as the last one to support API level 14, have issues such as `SIZE_MAX` being defined in another header, causing the build to fail. This will also sync with the API level already defined in `android_sdk_repository`: https://github.com/iotaledger/entangled/blob/6b187bcbc5075f66d22d00cfdff423c8444f42b8/WORKSPACE#L30-L33

# Test Plan:
- `//mobile/android:dummy` builds successfully
