### PR TITLE
mam/msg: rename send/recv functions and types

### DIFF
--- a/mam/api/BUILD
+++ b/mam/api/BUILD
@@ -7,8 +7,8 @@ cc_library(
     srcs = ["api.c"],
     hdrs = ["api.h"],
     deps = [
-        ":trit_t_to_mam_msg_recv_context_t_map",
-        ":trit_t_to_mam_msg_send_context_t_map",
+        ":trit_t_to_mam_msg_read_context_t_map",
+        ":trit_t_to_mam_msg_write_context_t_map",
         "//common:errors",
         "//common/model:bundle",
         "//mam/mam:message",
@@ -26,7 +26,7 @@ map_generate(
     additional_include_path = "mam/mam/message.h",
     key_type = "trit_t",
     parent_directory = "mam/api",
-    value_type = "mam_msg_send_context_t",
+    value_type = "mam_msg_write_context_t",
 )
 
 map_generate(
@@ -34,5 +34,5 @@ map_generate(
     additional_include_path = "mam/mam/message.h",
     key_type = "trit_t",
     parent_directory = "mam/api",
-    value_type = "mam_msg_recv_context_t",
+    value_type = "mam_msg_read_context_t",
 )

--- a/mam/api/api.c
+++ b/mam/api/api.c
@@ -298,7 +298,7 @@ static retcode_t mam_api_bundle_read_packet_from_msg(
   *is_last_packet = false;
 
   {
-    mam_msg_recv_context_t rollback_ctx = *ctx;
+    mam_msg_read_context_t rollback_ctx = *ctx;
 
     if ((ret = mam_msg_read_packet(ctx, &msg, &payload_trits)) != RC_OK) {
       *ctx = rollback_ctx;

--- a/mam/api/api.h
+++ b/mam/api/api.h
@@ -14,8 +14,8 @@
 #include "common/errors.h"
 #include "common/model/bundle.h"
 #include "common/trinary/flex_trit.h"
-#include "mam/api/trit_t_to_mam_msg_recv_context_t_map.h"
-#include "mam/api/trit_t_to_mam_msg_send_context_t_map.h"
+#include "mam/api/trit_t_to_mam_msg_read_context_t_map.h"
+#include "mam/api/trit_t_to_mam_msg_write_context_t_map.h"
 #include "mam/mam/message.h"
 #include "mam/ntru/ntru_types.h"
 #include "mam/prng/prng_types.h"
@@ -30,8 +30,8 @@ typedef struct mam_api_s {
   mam_ntru_sk_t_set_t ntru_sks;
   mam_ntru_pk_t_set_t ntru_pks;
   mam_psk_t_set_t psks;
-  trit_t_to_mam_msg_send_context_t_map_t send_ctxs;
-  trit_t_to_mam_msg_recv_context_t_map_t recv_ctxs;
+  trit_t_to_mam_msg_write_context_t_map_t write_ctxs;
+  trit_t_to_mam_msg_read_context_t_map_t read_ctxs;
   mam_channel_t_set_t channels;
 } mam_api_t;
 

--- a/mam/api/tests/test_api.c
+++ b/mam/api/tests/test_api.c
@@ -391,13 +391,13 @@ static void test_api_generic() {
       for (mam_msg_checksum_t checksum = 0; (int)checksum < 3; ++checksum) {
         bundle_transactions_new(&bundle);
 
-        /* send header and packet */
+        /* write header and packet */
         test_api_write_header(&api, pska, pskb, &ntru->public_key, pubkey,
                               keyload, cha, epa, ch1a, ep1a, bundle, msg_id);
         test_api_write_packet(&api, bundle, msg_id, pubkey, checksum, cha, epa,
                               ch1a, ep1a, PAYLOAD, true);
 
-        /* recv header and packet */
+        /* read header and packet */
         test_api_read_msg(&api, bundle, pskb, ntru, cha, &payload2,
                           &is_last_packet);
         TEST_ASSERT(is_last_packet);
@@ -437,7 +437,7 @@ static void test_api_multiple_packets() {
   size_t payload_out_size = 0;
   bool is_last_packet;
 
-  // send and receive header
+  // write and read header
   {
     bundle_transactions_new(&bundle);
     TEST_ASSERT(mam_api_bundle_write_header(&api, cha, NULL, NULL, NULL, NULL,
@@ -450,7 +450,7 @@ static void test_api_multiple_packets() {
     bundle_transactions_free(&bundle);
   }
 
-  // send and receive packets
+  // write and read packets
   const size_t num_packets = 256;
   for (size_t i = 0; i < num_packets; i++) {
     bundle_transactions_new(&bundle);
@@ -491,10 +491,10 @@ static void test_api_serialization() {
   TEST_ASSERT_TRUE(
       mam_ntru_pk_t_set_cmp(&deserialized_api.ntru_pks, &api.ntru_pks));
   TEST_ASSERT_TRUE(mam_psk_t_set_cmp(&deserialized_api.psks, &api.psks));
-  TEST_ASSERT_TRUE(trit_t_to_mam_msg_send_context_t_map_cmp(
-      &deserialized_api.send_ctxs, &api.send_ctxs));
-  TEST_ASSERT_TRUE(trit_t_to_mam_msg_recv_context_t_map_cmp(
-      &deserialized_api.recv_ctxs, &api.recv_ctxs));
+  TEST_ASSERT_TRUE(trit_t_to_mam_msg_write_context_t_map_cmp(
+      &deserialized_api.write_ctxs, &api.write_ctxs));
+  TEST_ASSERT_TRUE(trit_t_to_mam_msg_read_context_t_map_cmp(
+      &deserialized_api.read_ctxs, &api.read_ctxs));
   TEST_ASSERT_TRUE(
       mam_channel_t_set_cmp(&deserialized_api.channels, &api.channels));
 
@@ -511,10 +511,10 @@ static void test_api_save_load() {
   TEST_ASSERT_TRUE(mam_ntru_sk_t_set_cmp(&loaded_api.ntru_sks, &api.ntru_sks));
   TEST_ASSERT_TRUE(mam_ntru_pk_t_set_cmp(&loaded_api.ntru_pks, &api.ntru_pks));
   TEST_ASSERT_TRUE(mam_psk_t_set_cmp(&loaded_api.psks, &api.psks));
-  TEST_ASSERT_TRUE(trit_t_to_mam_msg_send_context_t_map_cmp(
-      &loaded_api.send_ctxs, &api.send_ctxs));
-  TEST_ASSERT_TRUE(trit_t_to_mam_msg_recv_context_t_map_cmp(
-      &loaded_api.recv_ctxs, &api.recv_ctxs));
+  TEST_ASSERT_TRUE(trit_t_to_mam_msg_write_context_t_map_cmp(
+      &loaded_api.write_ctxs, &api.write_ctxs));
+  TEST_ASSERT_TRUE(trit_t_to_mam_msg_read_context_t_map_cmp(
+      &loaded_api.read_ctxs, &api.read_ctxs));
   TEST_ASSERT_TRUE(mam_channel_t_set_cmp(&loaded_api.channels, &api.channels));
 
   mam_api_destroy(&loaded_api);

--- a/mam/mam/message.c
+++ b/mam/mam/message.c
@@ -493,7 +493,7 @@ size_t mam_msg_header_size(mam_channel_t *ch, mam_endpoint_t *ep,
   return sz;
 }
 
-void mam_msg_write_header(mam_msg_send_context_t *ctx, mam_prng_t *prng,
+void mam_msg_write_header(mam_msg_write_context_t *ctx, mam_prng_t *prng,
                           mam_channel_t *ch, mam_endpoint_t *ep,
                           mam_channel_t *ch1, mam_endpoint_t *ep1,
                           trits_t msg_id, trint9_t msg_type_id,
@@ -646,7 +646,7 @@ size_t mam_msg_packet_size(mam_msg_checksum_t checksum, mam_mss_t *mss,
   return sz;
 }
 
-void mam_msg_write_packet(mam_msg_send_context_t *ctx,
+void mam_msg_write_packet(mam_msg_write_context_t *ctx,
                           mam_msg_checksum_t checksum, trits_t payload,
                           trits_t *b) {
   MAM_ASSERT(ctx);
@@ -686,7 +686,7 @@ void mam_msg_write_packet(mam_msg_send_context_t *ctx,
   mam_spongos_commit(&ctx->spongos);
 }
 
-retcode_t mam_msg_read_header(mam_msg_recv_context_t *ctx,
+retcode_t mam_msg_read_header(mam_msg_read_context_t *ctx,
                               trits_t const *const msg, mam_psk_t_set_t psks,
                               mam_ntru_sk_t_set_t ntru_sks, trits_t msg_id) {
   retcode_t e = RC_OK;
@@ -814,7 +814,7 @@ retcode_t mam_msg_read_header(mam_msg_recv_context_t *ctx,
   return e;
 }
 
-retcode_t mam_msg_read_packet(mam_msg_recv_context_t *ctx, trits_t *b,
+retcode_t mam_msg_read_packet(mam_msg_read_context_t *ctx, trits_t *b,
                               trits_t *payload) {
   retcode_t e = RC_OK;
   trits_t p = trits_null();
@@ -881,22 +881,22 @@ cleanup:
   return e;
 }
 
-size_t mam_msg_send_ctx_serialized_size(
-    mam_msg_send_context_t const *const ctx) {
+size_t mam_msg_write_ctx_serialized_size(
+    mam_msg_write_context_t const *const ctx) {
   return mam_spongos_serialized_size(&ctx->spongos) + MAM_MSG_ORD_SIZE +
          MAM_MSS_PK_SIZE;
 }
 
-void mam_msg_send_ctx_serialize(mam_msg_send_context_t const *const ctx,
-                                trits_t *const buffer) {
+void mam_msg_write_ctx_serialize(mam_msg_write_context_t const *const ctx,
+                                 trits_t *const buffer) {
   mam_spongos_serialize(&ctx->spongos, buffer);
   trits_put18(*buffer, ctx->ord);
   trits_advance(buffer, MAM_MSG_ORD_SIZE);
   pb3_encode_ntrytes(trits_from_rep(MAM_MSS_PK_SIZE, ctx->mss->root), buffer);
 }
 
-retcode_t mam_msg_send_ctx_deserialize(trits_t *const buffer,
-                                       mam_msg_send_context_t *const ctx) {
+retcode_t mam_msg_write_ctx_deserialize(trits_t *const buffer,
+                                        mam_msg_write_context_t *const ctx) {
   retcode_t ret;
   ERR_BIND_RETURN(mam_spongos_deserialize(buffer, &ctx->spongos), ret);
   ctx->ord = trits_get18(*buffer);
@@ -907,13 +907,13 @@ retcode_t mam_msg_send_ctx_deserialize(trits_t *const buffer,
   return ret;
 }
 
-size_t mam_msg_recv_ctx_serialized_size(
-    mam_msg_recv_context_t const *const ctx) {
+size_t mam_msg_read_ctx_serialized_size(
+    mam_msg_read_context_t const *const ctx) {
   return mam_spongos_serialized_size(&ctx->spongos) + MAM_CHANNEL_ID_SIZE +
          MAM_MSG_ORD_SIZE;
 }
 
-void mam_msg_recv_ctx_serialize(mam_msg_recv_context_t const *const ctx,
+void mam_msg_read_ctx_serialize(mam_msg_read_context_t const *const ctx,
                                 trits_t *const buffer) {
   mam_spongos_serialize(&ctx->spongos, buffer);
   pb3_encode_ntrytes(trits_from_rep(MAM_CHANNEL_ID_SIZE, ctx->pk), buffer);
@@ -921,8 +921,8 @@ void mam_msg_recv_ctx_serialize(mam_msg_recv_context_t const *const ctx,
   trits_advance(buffer, MAM_MSG_ORD_SIZE);
 }
 
-retcode_t mam_msg_recv_ctx_deserialize(trits_t *const buffer,
-                                       mam_msg_recv_context_t *const ctx) {
+retcode_t mam_msg_read_ctx_deserialize(trits_t *const buffer,
+                                       mam_msg_read_context_t *const ctx) {
   retcode_t ret;
   ERR_BIND_RETURN(mam_spongos_deserialize(buffer, &ctx->spongos), ret);
   ERR_BIND_RETURN(

--- a/mam/mam/message.h
+++ b/mam/mam/message.h
@@ -50,26 +50,26 @@ typedef enum mam_msg_checksum_e {
   mam_msg_checksum_mssig = 2,
 } mam_msg_checksum_t;
 
-typedef struct mam_msg_send_context_s {
+typedef struct mam_msg_write_context_s {
   mam_spongos_t spongos;
   trint18_t ord;
   mam_mss_t *mss;
   trit_t mss_root[MAM_MSS_PK_SIZE];
-} mam_msg_send_context_t;
+} mam_msg_write_context_t;
 
-typedef struct mam_msg_recv_context_s {
+typedef struct mam_msg_read_context_s {
   mam_spongos_t spongos; /*!< Main Spongos interface */
   trit_t pk[MAM_CHANNEL_ID_SIZE];
   /*TODO: check for trusted chid/epid*/
   /*TODO: handle (add to trusted list) new chid1*/
   trint18_t ord; /*!< Packet ordinal number. */
-} mam_msg_recv_context_t;
+} mam_msg_read_context_t;
 
 size_t mam_msg_header_size(mam_channel_t *ch, mam_endpoint_t *ep,
                            mam_channel_t *ch1, mam_endpoint_t *ep1,
                            mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks);
 
-void mam_msg_write_header(mam_msg_send_context_t *ctx, mam_prng_t *prng,
+void mam_msg_write_header(mam_msg_write_context_t *ctx, mam_prng_t *prng,
                           mam_channel_t *ch, mam_endpoint_t *ep,
                           mam_channel_t *ch1, mam_endpoint_t *ep1,
                           trits_t msg_id, trint9_t msg_type_id,
@@ -79,34 +79,34 @@ void mam_msg_write_header(mam_msg_send_context_t *ctx, mam_prng_t *prng,
 size_t mam_msg_packet_size(mam_msg_checksum_t checksum, mam_mss_t *mss,
                            size_t payload_size);
 
-void mam_msg_write_packet(mam_msg_send_context_t *ctx,
+void mam_msg_write_packet(mam_msg_write_context_t *ctx,
                           mam_msg_checksum_t checksum, trits_t payload,
                           trits_t *b);
 
-retcode_t mam_msg_read_header(mam_msg_recv_context_t *ctx,
+retcode_t mam_msg_read_header(mam_msg_read_context_t *ctx,
                               trits_t const *const msg, mam_psk_t_set_t psks,
                               mam_ntru_sk_t_set_t ntru_sks, trits_t msg_id);
 
-retcode_t mam_msg_read_packet(mam_msg_recv_context_t *ctx, trits_t *packet,
+retcode_t mam_msg_read_packet(mam_msg_read_context_t *ctx, trits_t *packet,
                               trits_t *payload);
 
-size_t mam_msg_send_ctx_serialized_size(
-    mam_msg_send_context_t const *const ctx);
+size_t mam_msg_write_ctx_serialized_size(
+    mam_msg_write_context_t const *const ctx);
 
-void mam_msg_send_ctx_serialize(mam_msg_send_context_t const *const ctx,
+void mam_msg_write_ctx_serialize(mam_msg_write_context_t const *const ctx,
+                                 trits_t *const buffer);
+
+retcode_t mam_msg_write_ctx_deserialize(trits_t *const buffer,
+                                        mam_msg_write_context_t *const ctx);
+
+size_t mam_msg_read_ctx_serialized_size(
+    mam_msg_read_context_t const *const ctx);
+
+void mam_msg_read_ctx_serialize(mam_msg_read_context_t const *const ctx,
                                 trits_t *const buffer);
 
-retcode_t mam_msg_send_ctx_deserialize(trits_t *const buffer,
-                                       mam_msg_send_context_t *const ctx);
-
-size_t mam_msg_recv_ctx_serialized_size(
-    mam_msg_recv_context_t const *const ctx);
-
-void mam_msg_recv_ctx_serialize(mam_msg_recv_context_t const *const ctx,
-                                trits_t *const buffer);
-
-retcode_t mam_msg_recv_ctx_deserialize(trits_t *const buffer,
-                                       mam_msg_recv_context_t *const ctx);
+retcode_t mam_msg_read_ctx_deserialize(trits_t *const buffer,
+                                       mam_msg_read_context_t *const ctx);
 
 #ifdef __cplusplus
 }

--- a/mam/mam/message.h
+++ b/mam/mam/message.h
@@ -65,28 +65,29 @@ typedef struct mam_msg_recv_context_s {
   trint18_t ord; /*!< Packet ordinal number. */
 } mam_msg_recv_context_t;
 
-size_t mam_msg_send_size(mam_channel_t *ch, mam_endpoint_t *ep,
-                         mam_channel_t *ch1, mam_endpoint_t *ep1,
-                         mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks);
+size_t mam_msg_header_size(mam_channel_t *ch, mam_endpoint_t *ep,
+                           mam_channel_t *ch1, mam_endpoint_t *ep1,
+                           mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks);
 
-void mam_msg_send(mam_msg_send_context_t *ctx, mam_prng_t *prng,
-                  mam_channel_t *ch, mam_endpoint_t *ep, mam_channel_t *ch1,
-                  mam_endpoint_t *ep1, trits_t msg_id, trint9_t msg_type_id,
-                  mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks,
-                  trits_t *msg);
+void mam_msg_write_header(mam_msg_send_context_t *ctx, mam_prng_t *prng,
+                          mam_channel_t *ch, mam_endpoint_t *ep,
+                          mam_channel_t *ch1, mam_endpoint_t *ep1,
+                          trits_t msg_id, trint9_t msg_type_id,
+                          mam_psk_t_set_t psks, mam_ntru_pk_t_set_t ntru_pks,
+                          trits_t *msg);
 
-size_t mam_msg_send_packet_size(mam_msg_checksum_t checksum, mam_mss_t *mss,
-                                size_t payload_size);
+size_t mam_msg_packet_size(mam_msg_checksum_t checksum, mam_mss_t *mss,
+                           size_t payload_size);
 
-void mam_msg_send_packet(mam_msg_send_context_t *ctx,
-                         mam_msg_checksum_t checksum, trits_t payload,
-                         trits_t *b);
+void mam_msg_write_packet(mam_msg_send_context_t *ctx,
+                          mam_msg_checksum_t checksum, trits_t payload,
+                          trits_t *b);
 
-retcode_t mam_msg_recv(mam_msg_recv_context_t *ctx, trits_t const *const msg,
-                       mam_psk_t_set_t psks, mam_ntru_sk_t_set_t ntru_sks,
-                       trits_t msg_id);
+retcode_t mam_msg_read_header(mam_msg_recv_context_t *ctx,
+                              trits_t const *const msg, mam_psk_t_set_t psks,
+                              mam_ntru_sk_t_set_t ntru_sks, trits_t msg_id);
 
-retcode_t mam_msg_recv_packet(mam_msg_recv_context_t *ctx, trits_t *packet,
+retcode_t mam_msg_read_packet(mam_msg_recv_context_t *ctx, trits_t *packet,
                               trits_t *payload);
 
 size_t mam_msg_send_ctx_serialized_size(

--- a/mam/mam/tests/test_message.c
+++ b/mam/mam/tests/test_message.c
@@ -37,12 +37,12 @@
 
 // TODO - Test functions should take set of prng_t instead of raw ptrs
 
-static trits_t message_test_generic_send_msg(
+static trits_t message_test_generic_write_msg(
     mam_prng_t *prng, mam_psk_t const *const pska, mam_psk_t const *const pskb,
     mam_ntru_pk_t const *const ntru_pk, mam_msg_pubkey_t pubkey,
     mam_msg_keyload_t keyload, mam_channel_t *const cha,
     mam_endpoint_t *const epa, mam_channel_t *const ch1a,
-    mam_endpoint_t *const ep1a, mam_msg_send_context_t *const send_ctx,
+    mam_endpoint_t *const ep1a, mam_msg_write_context_t *const write_ctx,
     trits_t msg_id) {
   trits_t msg = trits_null();
   mam_channel_t *ch = cha;
@@ -73,7 +73,7 @@ static trits_t message_test_generic_send_msg(
   msg = trits_alloc(sz);
   TEST_ASSERT(!trits_is_null(msg));
 
-  mam_msg_write_header(send_ctx, prng, ch, ep, ch1, ep1, msg_id, msg_type_id,
+  mam_msg_write_header(write_ctx, prng, ch, ep, ch1, ep1, msg_id, msg_type_id,
                        psks, ntru_pks, &msg);
   TEST_ASSERT(trits_is_empty(msg));
   msg = trits_pickup(msg, sz);
@@ -83,23 +83,23 @@ static trits_t message_test_generic_send_msg(
   return msg;
 }
 
-static trits_t message_test_generic_send_first_packet(
+static trits_t message_test_generic_write_first_packet(
     mam_msg_pubkey_t pubkey, mam_msg_checksum_t checksum,
     mam_channel_t *const cha, mam_endpoint_t *const epa,
     mam_channel_t *const ch1a, mam_endpoint_t *const ep1a,
-    mam_msg_send_context_t *const send_ctx, char const *payload_str) {
+    mam_msg_write_context_t *const write_ctx, char const *payload_str) {
   trits_t packet = trits_null();
   trits_t payload = trits_null();
 
   if (mam_msg_checksum_mssig == checksum) {
     if (mam_msg_pubkey_chid == pubkey) {
-      send_ctx->mss = &cha->mss;
+      write_ctx->mss = &cha->mss;
     } else if (mam_msg_pubkey_epid == pubkey) {
-      send_ctx->mss = &epa->mss;
+      write_ctx->mss = &epa->mss;
     } else if (mam_msg_pubkey_chid1 == pubkey) {
-      send_ctx->mss = &ch1a->mss;
+      write_ctx->mss = &ch1a->mss;
     } else if (mam_msg_pubkey_epid1 == pubkey) {
-      send_ctx->mss = &ep1a->mss;
+      write_ctx->mss = &ep1a->mss;
     }
   }
 
@@ -108,11 +108,11 @@ static trits_t message_test_generic_send_first_packet(
   TEST_ASSERT(!trits_is_null(payload));
   trits_from_str(payload, payload_str);
 
-  sz = mam_msg_packet_size(checksum, send_ctx->mss, trits_size(payload));
+  sz = mam_msg_packet_size(checksum, write_ctx->mss, trits_size(payload));
   packet = trits_alloc(sz);
   TEST_ASSERT(!trits_is_null(packet));
 
-  mam_msg_write_packet(send_ctx, checksum, payload, &packet);
+  mam_msg_write_packet(write_ctx, checksum, payload, &packet);
   TEST_ASSERT(trits_is_empty(packet));
   packet = trits_pickup(packet, sz);
   trits_set_zero(payload);
@@ -121,14 +121,14 @@ static trits_t message_test_generic_send_first_packet(
   return packet;
 }
 
-static void message_test_generic_receive_msg(
+static void message_test_generic_read_msg(
     mam_psk_t const *const pre_shared_key, mam_ntru_sk_t const *const ntru,
     mam_channel_t *const cha, trits_t *const msg,
-    mam_msg_recv_context_t *const cfg_msg_recv, trits_t msg_id) {
+    mam_msg_read_context_t *const cfg_msg_read, trits_t msg_id) {
   retcode_t e = RC_MAM_INTERNAL_ERROR;
 
-  /* init recv msg context */
-  mam_msg_recv_context_t *cfg = cfg_msg_recv;
+  /* init read msg context */
+  mam_msg_read_context_t *cfg = cfg_msg_read;
   mam_psk_t_set_t psks = NULL;
   mam_ntru_sk_t_set_t ntru_sks = NULL;
 
@@ -137,7 +137,7 @@ static void message_test_generic_receive_msg(
 
   trits_copy(mam_channel_id(cha), trits_from_rep(MAM_CHANNEL_ID_SIZE, cfg->pk));
 
-  e = mam_msg_read_header(cfg_msg_recv, msg, psks, ntru_sks, msg_id);
+  e = mam_msg_read_header(cfg_msg_read, msg, psks, ntru_sks, msg_id);
 
   TEST_ASSERT(RC_OK == e);
   TEST_ASSERT(trits_is_empty(*msg));
@@ -146,9 +146,9 @@ static void message_test_generic_receive_msg(
   mam_psk_t_set_free(&psks);
 }
 
-static void message_test_generic_receive_packet(
-    mam_msg_recv_context_t *const ctx, trits_t const *const packet,
-    trits_t *const payload) {
+static void message_test_generic_read_packet(mam_msg_read_context_t *const ctx,
+                                             trits_t const *const packet,
+                                             trits_t *const payload) {
   retcode_t e = RC_MAM_INTERNAL_ERROR;
   ctx->ord = 0;
 
@@ -225,12 +225,12 @@ static void message_test_generic(mam_prng_t *prng_sender,
   mam_channel_t *cha = NULL, *ch1a = NULL;
   mam_endpoint_t *epa = NULL, *ep1a = NULL;
 
-  mam_msg_send_context_t send_ctx;
-  mam_spongos_init(&send_ctx.spongos);
-  send_ctx.ord = 0;
-  send_ctx.mss = NULL;
+  mam_msg_write_context_t write_ctx;
+  mam_spongos_init(&write_ctx.spongos);
+  write_ctx.ord = 0;
+  write_ctx.mss = NULL;
 
-  mam_msg_recv_context_t cfg_msg_recv[1];
+  mam_msg_read_context_t cfg_msg_read[1];
 
   mam_msg_pubkey_t pubkey;     /* chid=0, epid=1, chid1=2, epid1=3 */
   mam_msg_keyload_t keyload;   /* psk=1, ntru=2 */
@@ -279,22 +279,22 @@ static void message_test_generic(mam_prng_t *prng_sender,
       for (checksum = 0; (int)checksum < 3; ++checksum)
       /* none=0, mac=1, mssig=2 */
       {
-        /* send msg and packet */
+        /* write msg and packet */
         {
-          msg = message_test_generic_send_msg(
+          msg = message_test_generic_write_msg(
               prng_sender, pska, pskb, &ntru->public_key, pubkey, keyload, cha,
-              epa, ch1a, ep1a, &send_ctx, msg_id);
+              epa, ch1a, ep1a, &write_ctx, msg_id);
 
-          packet = message_test_generic_send_first_packet(
-              pubkey, checksum, cha, epa, ch1a, ep1a, &send_ctx, payload_str);
+          packet = message_test_generic_write_first_packet(
+              pubkey, checksum, cha, epa, ch1a, ep1a, &write_ctx, payload_str);
         }
 
-        /* recv msg and packet */
+        /* read msg and packet */
         {
-          message_test_generic_receive_msg(pskb, ntru, cha, &msg, cfg_msg_recv,
-                                           msg_id);
+          message_test_generic_read_msg(pskb, ntru, cha, &msg, cfg_msg_read,
+                                        msg_id);
 
-          message_test_generic_receive_packet(cfg_msg_recv, &packet, &payload);
+          message_test_generic_read_packet(cfg_msg_read, &packet, &payload);
           TEST_ASSERT(trits_cmp_eq_str(payload, payload_str));
         }
 
@@ -344,75 +344,75 @@ void message_test() {
   message_test_generic(&prng_sender, &prng_receiver);
 }
 
-void serialize_send_ctx_test() {
-  mam_msg_send_context_t send_ctx;
-  mam_msg_send_context_t deserialized_ctx;
+void serialize_write_ctx_test() {
+  mam_msg_write_context_t write_ctx;
+  mam_msg_write_context_t deserialized_ctx;
   mam_mss_t mss;
 
-  mam_spongos_init(&send_ctx.spongos);
-  send_ctx.ord = 0;
+  mam_spongos_init(&write_ctx.spongos);
+  write_ctx.ord = 0;
 
   //"Random" root
   for (size_t i = 0; i < MAM_MSS_PK_SIZE; ++i) {
     mss.root[i] = -1 + rand() % 3;
   }
-  send_ctx.mss = &mss;
+  write_ctx.mss = &mss;
 
   MAM_TRITS_DEF0(rand_msg, strlen(TEST_PLAINTEXT1));
   rand_msg = MAM_TRITS_INIT(rand_msg, strlen(TEST_PLAINTEXT1));
   trits_from_str(rand_msg, TEST_PLAINTEXT1);
-  mam_spongos_absorb(&send_ctx.spongos, rand_msg);
-  MAM_TRITS_DEF0(ctx_buffer, mam_msg_send_ctx_serialized_size(&send_ctx));
+  mam_spongos_absorb(&write_ctx.spongos, rand_msg);
+  MAM_TRITS_DEF0(ctx_buffer, mam_msg_write_ctx_serialized_size(&write_ctx));
   ctx_buffer =
-      MAM_TRITS_INIT(ctx_buffer, mam_msg_send_ctx_serialized_size(&send_ctx));
-  mam_msg_send_ctx_serialize(&send_ctx, &ctx_buffer);
+      MAM_TRITS_INIT(ctx_buffer, mam_msg_write_ctx_serialized_size(&write_ctx));
+  mam_msg_write_ctx_serialize(&write_ctx, &ctx_buffer);
   ctx_buffer = trits_pickup_all(ctx_buffer);
-  mam_msg_send_ctx_deserialize(&ctx_buffer, &deserialized_ctx);
-  TEST_ASSERT_EQUAL_INT(send_ctx.spongos.pos, deserialized_ctx.spongos.pos);
-  TEST_ASSERT_EQUAL_MEMORY(&send_ctx.spongos.sponge,
+  mam_msg_write_ctx_deserialize(&ctx_buffer, &deserialized_ctx);
+  TEST_ASSERT_EQUAL_INT(write_ctx.spongos.pos, deserialized_ctx.spongos.pos);
+  TEST_ASSERT_EQUAL_MEMORY(&write_ctx.spongos.sponge,
                            &deserialized_ctx.spongos.sponge, MAM_SPONGE_WIDTH);
 
-  TEST_ASSERT_EQUAL_MEMORY(&send_ctx.mss->root, &deserialized_ctx.mss_root,
+  TEST_ASSERT_EQUAL_MEMORY(&write_ctx.mss->root, &deserialized_ctx.mss_root,
                            MAM_MSS_PK_SIZE);
-  TEST_ASSERT_EQUAL_INT(send_ctx.ord, deserialized_ctx.ord);
+  TEST_ASSERT_EQUAL_INT(write_ctx.ord, deserialized_ctx.ord);
 }
 
-void serialize_recv_ctx_test() {
-  mam_msg_recv_context_t recv_context;
-  mam_msg_recv_context_t deserialized_ctx;
-  mam_spongos_init(&recv_context.spongos);
-  recv_context.ord = 0;
+void serialize_read_ctx_test() {
+  mam_msg_read_context_t read_ctx;
+  mam_msg_read_context_t deserialized_ctx;
+  mam_spongos_init(&read_ctx.spongos);
+  read_ctx.ord = 0;
 
   //"Random" root
   for (size_t i = 0; i < MAM_CHANNEL_ID_SIZE; ++i) {
-    recv_context.pk[i] = -1 + rand() % 3;
+    read_ctx.pk[i] = -1 + rand() % 3;
   }
 
   MAM_TRITS_DEF0(rand_msg, strlen(TEST_PLAINTEXT1));
   rand_msg = MAM_TRITS_INIT(rand_msg, strlen(TEST_PLAINTEXT1));
   trits_from_str(rand_msg, TEST_PLAINTEXT1);
-  mam_spongos_absorb(&recv_context.spongos, rand_msg);
-  MAM_TRITS_DEF0(ctx_buffer, mam_msg_recv_ctx_serialized_size(&recv_context));
-  ctx_buffer = MAM_TRITS_INIT(ctx_buffer,
-                              mam_msg_recv_ctx_serialized_size(&recv_context));
-  mam_msg_recv_ctx_serialize(&recv_context, &ctx_buffer);
+  mam_spongos_absorb(&read_ctx.spongos, rand_msg);
+  MAM_TRITS_DEF0(ctx_buffer, mam_msg_read_ctx_serialized_size(&read_ctx));
+  ctx_buffer =
+      MAM_TRITS_INIT(ctx_buffer, mam_msg_read_ctx_serialized_size(&read_ctx));
+  mam_msg_read_ctx_serialize(&read_ctx, &ctx_buffer);
   ctx_buffer = trits_pickup_all(ctx_buffer);
-  mam_msg_recv_ctx_deserialize(&ctx_buffer, &deserialized_ctx);
-  TEST_ASSERT_EQUAL_INT(recv_context.spongos.pos, deserialized_ctx.spongos.pos);
-  TEST_ASSERT_EQUAL_MEMORY(&recv_context.spongos.sponge,
+  mam_msg_read_ctx_deserialize(&ctx_buffer, &deserialized_ctx);
+  TEST_ASSERT_EQUAL_INT(read_ctx.spongos.pos, deserialized_ctx.spongos.pos);
+  TEST_ASSERT_EQUAL_MEMORY(&read_ctx.spongos.sponge,
                            &deserialized_ctx.spongos.sponge, MAM_SPONGE_WIDTH);
 
-  TEST_ASSERT_EQUAL_MEMORY(&recv_context.pk, &deserialized_ctx.pk,
+  TEST_ASSERT_EQUAL_MEMORY(&read_ctx.pk, &deserialized_ctx.pk,
                            MAM_CHANNEL_ID_SIZE);
-  TEST_ASSERT_EQUAL_INT(recv_context.ord, deserialized_ctx.ord);
+  TEST_ASSERT_EQUAL_INT(read_ctx.ord, deserialized_ctx.ord);
 }
 
 int main(void) {
   UNITY_BEGIN();
 
   RUN_TEST(message_test);
-  RUN_TEST(serialize_send_ctx_test);
-  RUN_TEST(serialize_recv_ctx_test);
+  RUN_TEST(serialize_write_ctx_test);
+  RUN_TEST(serialize_read_ctx_test);
 
   return UNITY_END();
 }

--- a/mam/mam/tests/test_message.c
+++ b/mam/mam/tests/test_message.c
@@ -69,12 +69,12 @@ static trits_t message_test_generic_send_msg(
   }
 
   size_t sz;
-  sz = mam_msg_send_size(ch, ep, ch1, ep1, psks, ntru_pks);
+  sz = mam_msg_header_size(ch, ep, ch1, ep1, psks, ntru_pks);
   msg = trits_alloc(sz);
   TEST_ASSERT(!trits_is_null(msg));
 
-  mam_msg_send(send_ctx, prng, ch, ep, ch1, ep1, msg_id, msg_type_id, psks,
-               ntru_pks, &msg);
+  mam_msg_write_header(send_ctx, prng, ch, ep, ch1, ep1, msg_id, msg_type_id,
+                       psks, ntru_pks, &msg);
   TEST_ASSERT(trits_is_empty(msg));
   msg = trits_pickup(msg, sz);
   mam_psk_t_set_free(&psks);
@@ -108,11 +108,11 @@ static trits_t message_test_generic_send_first_packet(
   TEST_ASSERT(!trits_is_null(payload));
   trits_from_str(payload, payload_str);
 
-  sz = mam_msg_send_packet_size(checksum, send_ctx->mss, trits_size(payload));
+  sz = mam_msg_packet_size(checksum, send_ctx->mss, trits_size(payload));
   packet = trits_alloc(sz);
   TEST_ASSERT(!trits_is_null(packet));
 
-  mam_msg_send_packet(send_ctx, checksum, payload, &packet);
+  mam_msg_write_packet(send_ctx, checksum, payload, &packet);
   TEST_ASSERT(trits_is_empty(packet));
   packet = trits_pickup(packet, sz);
   trits_set_zero(payload);
@@ -137,7 +137,7 @@ static void message_test_generic_receive_msg(
 
   trits_copy(mam_channel_id(cha), trits_from_rep(MAM_CHANNEL_ID_SIZE, cfg->pk));
 
-  e = mam_msg_recv(cfg_msg_recv, msg, psks, ntru_sks, msg_id);
+  e = mam_msg_read_header(cfg_msg_recv, msg, psks, ntru_sks, msg_id);
 
   TEST_ASSERT(RC_OK == e);
   TEST_ASSERT(trits_is_empty(*msg));
@@ -152,7 +152,7 @@ static void message_test_generic_receive_packet(
   retcode_t e = RC_MAM_INTERNAL_ERROR;
   ctx->ord = 0;
 
-  e = mam_msg_recv_packet(ctx, packet, payload);
+  e = mam_msg_read_packet(ctx, packet, payload);
   TEST_ASSERT(RC_OK == e);
   TEST_ASSERT(trits_is_empty(*packet));
   TEST_ASSERT(trits_is_empty(*payload));


### PR DESCRIPTION
Rename misleading send/recv functions and types to write/read