### PR TITLE
ciri: fix json_logger_id MacOS link

### DIFF
--- a/cclient/serialization/BUILD
+++ b/cclient/serialization/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "@cJSON",
         "@com_github_uthash//:uthash",
     ],
+    alwayslink = True,
 )
 
 cc_library(


### PR DESCRIPTION
Fixes #970 