### PR TITLE
ciri: use condvars to signal running threads

### DIFF
--- a/consensus/milestone_tracker/BUILD
+++ b/consensus/milestone_tracker/BUILD
@@ -6,6 +6,7 @@ cc_library(
         "//common:errors",
         "//common/crypto/sponge",
         "//utils/containers/hash:hash243_queue",
+        "//utils/handles:cond",
         "//utils/handles:thread",
     ],
 )

--- a/consensus/milestone_tracker/milestone_tracker.h
+++ b/consensus/milestone_tracker/milestone_tracker.h
@@ -16,6 +16,7 @@
 #include "common/model/transaction.h"
 #include "consensus/conf.h"
 #include "utils/containers/hash/hash243_queue.h"
+#include "utils/handles/cond.h"
 #include "utils/handles/rw_lock.h"
 #include "utils/handles/thread.h"
 
@@ -26,7 +27,6 @@ extern "C" {
 // Foward declarations
 typedef struct tangle_s tangle_t;
 typedef struct snapshot_s snapshot_t;
-typedef struct _trit_array* trit_array_p;
 typedef struct ledger_validator_s ledger_validator_t;
 typedef struct transaction_solidifier_s transaction_solidifier_t;
 
@@ -43,9 +43,11 @@ typedef struct milestone_tracker_s {
   snapshot_t* latest_snapshot;
   uint64_t milestone_start_index;
   thread_handle_t milestone_validator;
+  cond_handle_t cond_validator;
   uint64_t latest_milestone_index;
   flex_trit_t latest_milestone[FLEX_TRIT_SIZE_243];
   thread_handle_t milestone_solidifier;
+  cond_handle_t cond_solidifier;
   uint64_t latest_solid_subtangle_milestone_index;
   flex_trit_t latest_solid_subtangle_milestone[FLEX_TRIT_SIZE_243];
   ledger_validator_t* ledger_validator;

--- a/consensus/transaction_solidifier/BUILD
+++ b/consensus/transaction_solidifier/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "//gossip/components:transaction_requester",
         "//utils:logger_helper",
         "//utils/containers/hash:hash243_set",
+        "//utils/handles:cond",
         "//utils/handles:lock",
         "//utils/handles:thread",
     ],

--- a/consensus/transaction_solidifier/transaction_solidifier.h
+++ b/consensus/transaction_solidifier/transaction_solidifier.h
@@ -20,6 +20,7 @@
 #include "gossip/tips_cache.h"
 #include "utils/containers/hash/hash243_set.h"
 #include "utils/containers/hash/hash243_stack.h"
+#include "utils/handles/cond.h"
 #include "utils/handles/lock.h"
 #include "utils/handles/thread.h"
 
@@ -35,6 +36,7 @@ typedef struct transaction_solidifier_s {
   lock_handle_t lock;
   hash243_set_t newly_set_solid_transactions;
   tips_cache_t *tips;
+  cond_handle_t cond;
 } transaction_solidifier_t;
 
 retcode_t iota_consensus_transaction_solidifier_init(transaction_solidifier_t *const ts,

--- a/gossip/components/BUILD
+++ b/gossip/components/BUILD
@@ -141,6 +141,7 @@ cc_library(
     hdrs = ["tips_requester.h"],
     deps = [
         "//common:errors",
+        "//utils/handles:cond",
         "//utils/handles:thread",
     ],
 )

--- a/gossip/components/BUILD
+++ b/gossip/components/BUILD
@@ -166,6 +166,7 @@ cc_library(
         "//common:errors",
         "//gossip:conf",
         "//gossip:tips_cache",
+        "//utils/handles:cond",
         "//utils/handles:thread",
     ],
 )

--- a/gossip/components/BUILD
+++ b/gossip/components/BUILD
@@ -93,6 +93,7 @@ cc_library(
     deps = [
         "//common:errors",
         "//utils/containers/hash:hash243_set",
+        "//utils/handles:cond",
         "//utils/handles:rw_lock",
         "//utils/handles:thread",
     ],

--- a/gossip/components/broadcaster.c
+++ b/gossip/components/broadcaster.c
@@ -13,7 +13,7 @@
 #include "utils/logger_helper.h"
 
 #define BROADCASTER_LOGGER_ID "broadcaster"
-#define BROADCASTER_TIMEOUT_MS 5000
+#define BROADCASTER_TIMEOUT_MS 5000ULL
 
 static logger_id_t logger_id;
 

--- a/gossip/components/broadcaster.c
+++ b/gossip/components/broadcaster.c
@@ -13,7 +13,7 @@
 #include "utils/logger_helper.h"
 
 #define BROADCASTER_LOGGER_ID "broadcaster"
-#define BROADCASTER_TIMEOUT_SEC 5
+#define BROADCASTER_TIMEOUT_MS 5000
 
 static logger_id_t logger_id;
 
@@ -43,7 +43,7 @@ static void *broadcaster_routine(broadcaster_t *const broadcaster) {
 
   while (broadcaster->running) {
     if (broadcaster_is_empty(broadcaster)) {
-      cond_handle_timedwait(&broadcaster->cond, &lock_cond, BROADCASTER_TIMEOUT_SEC);
+      cond_handle_timedwait(&broadcaster->cond, &lock_cond, BROADCASTER_TIMEOUT_MS);
     }
 
     rw_lock_handle_wrlock(&broadcaster->lock);

--- a/gossip/components/processor.c
+++ b/gossip/components/processor.c
@@ -17,7 +17,7 @@
 #include "utils/logger_helper.h"
 
 #define PROCESSOR_LOGGER_ID "processor"
-#define PROCESSOR_TIMEOUT_SEC 1
+#define PROCESSOR_TIMEOUT_MS 1000
 
 static logger_id_t logger_id;
 
@@ -258,7 +258,7 @@ static void *processor_routine(processor_t *const processor) {
 
   while (processor->running) {
     if (processor_is_empty(processor)) {
-      cond_handle_timedwait(&processor->cond, &lock_cond, PROCESSOR_TIMEOUT_SEC);
+      cond_handle_timedwait(&processor->cond, &lock_cond, PROCESSOR_TIMEOUT_MS);
     }
 
     rw_lock_handle_wrlock(&processor->lock);

--- a/gossip/components/processor.c
+++ b/gossip/components/processor.c
@@ -17,7 +17,7 @@
 #include "utils/logger_helper.h"
 
 #define PROCESSOR_LOGGER_ID "processor"
-#define PROCESSOR_TIMEOUT_MS 1000
+#define PROCESSOR_TIMEOUT_MS 1000ULL
 
 static logger_id_t logger_id;
 

--- a/gossip/components/receiver.c
+++ b/gossip/components/receiver.c
@@ -11,7 +11,7 @@
 #include "gossip/node.h"
 #include "utils/logger_helper.h"
 
-#define RECEIVER_COMPONENT_LOGGER_ID "receiver_component"
+#define RECEIVER_COMPONENT_LOGGER_ID "receiver"
 
 static logger_id_t logger_id;
 

--- a/gossip/components/responder.c
+++ b/gossip/components/responder.c
@@ -13,7 +13,7 @@
 #include "utils/logger_helper.h"
 
 #define RESPONDER_LOGGER_ID "responder"
-#define RESPONDER_TIMEOUT_MS 1000
+#define RESPONDER_TIMEOUT_MS 1000ULL
 
 static logger_id_t logger_id;
 

--- a/gossip/components/responder.c
+++ b/gossip/components/responder.c
@@ -13,7 +13,7 @@
 #include "utils/logger_helper.h"
 
 #define RESPONDER_LOGGER_ID "responder"
-#define RESPONDER_TIMEOUT_SEC 1
+#define RESPONDER_TIMEOUT_MS 1000
 
 static logger_id_t logger_id;
 
@@ -148,7 +148,7 @@ static void *responder_routine(responder_t *const responder) {
 
   while (responder->running) {
     if (responder_is_empty(responder)) {
-      cond_handle_timedwait(&responder->cond, &lock_cond, RESPONDER_TIMEOUT_SEC);
+      cond_handle_timedwait(&responder->cond, &lock_cond, RESPONDER_TIMEOUT_MS);
     }
 
     rw_lock_handle_wrlock(&responder->lock);

--- a/gossip/components/responder.c
+++ b/gossip/components/responder.c
@@ -226,6 +226,7 @@ retcode_t responder_stop(responder_t *const responder) {
 
   log_info(logger_id, "Shutting down responder thread\n");
   responder->running = false;
+  cond_handle_signal(&responder->cond);
   if (thread_handle_join(responder->thread, NULL) != 0) {
     log_error(logger_id, "Shutting down responder thread failed\n");
     ret = RC_FAILED_THREAD_JOIN;

--- a/gossip/components/tips_requester.h
+++ b/gossip/components/tips_requester.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 
 #include "common/errors.h"
+#include "utils/handles/cond.h"
 #include "utils/handles/thread.h"
 
 // Forward declarations
@@ -21,6 +22,7 @@ typedef struct tips_requester_s {
   thread_handle_t thread;
   bool running;
   node_t *node;
+  cond_handle_t cond;
 } tips_requester_t;
 
 #ifdef __cplusplus

--- a/gossip/components/tips_solidifier.h
+++ b/gossip/components/tips_solidifier.h
@@ -13,6 +13,7 @@
 #include "common/errors.h"
 #include "gossip/conf.h"
 #include "gossip/tips_cache.h"
+#include "utils/handles/cond.h"
 #include "utils/handles/thread.h"
 
 #ifdef __cplusplus
@@ -31,6 +32,7 @@ typedef struct tips_solidifier_s {
   bool running;
   tips_cache_t *tips;
   transaction_solidifier_t *transaction_solidifier;
+  cond_handle_t cond;
 } tips_solidifier_t;
 
 /**

--- a/gossip/components/transaction_requester.c
+++ b/gossip/components/transaction_requester.c
@@ -31,6 +31,7 @@ retcode_t requester_init(transaction_requester_t *const transaction_requester, n
   transaction_requester->milestones = NULL;
   transaction_requester->transactions = NULL;
   rw_lock_handle_init(&transaction_requester->lock);
+  cond_handle_init(&transaction_requester->cond);
 
   return RC_OK;
 }
@@ -46,6 +47,7 @@ retcode_t requester_destroy(transaction_requester_t *const transaction_requester
   hash243_set_free(&transaction_requester->transactions);
   transaction_requester->node = NULL;
   rw_lock_handle_destroy(&transaction_requester->lock);
+  cond_handle_destroy(&transaction_requester->cond);
   logger_helper_release(logger_id);
 
   return RC_OK;

--- a/gossip/components/transaction_requester.h
+++ b/gossip/components/transaction_requester.h
@@ -12,6 +12,7 @@
 
 #include "common/errors.h"
 #include "utils/containers/hash/hash243_set.h"
+#include "utils/handles/cond.h"
 #include "utils/handles/rw_lock.h"
 #include "utils/handles/thread.h"
 
@@ -26,6 +27,7 @@ typedef struct transaction_requester_s {
   hash243_set_t transactions;
   node_t *node;
   rw_lock_handle_t lock;
+  cond_handle_t cond;
 } transaction_requester_t;
 
 #ifdef __cplusplus

--- a/utils/handles/cond.h
+++ b/utils/handles/cond.h
@@ -25,6 +25,8 @@ extern "C" {
 #include <Windows.h>
 #endif
 
+#include <stdint.h>
+
 #include "utils/handles/lock.h"
 
 #ifdef _POSIX_THREADS

--- a/utils/handles/cond.h
+++ b/utils/handles/cond.h
@@ -43,7 +43,8 @@ static inline int cond_handle_wait(cond_handle_t* const cond, lock_handle_t* con
   return pthread_cond_wait(cond, lock);
 }
 
-static inline int cond_handle_timedwait(cond_handle_t* const cond, lock_handle_t* const lock, unsigned int timeout_ms) {
+static inline int cond_handle_timedwait(cond_handle_t* const cond, lock_handle_t* const lock,
+                                        uint64_t const timeout_ms) {
   struct timespec ts;
   struct timeval tv;
 
@@ -80,7 +81,8 @@ static inline int cond_handle_wait(cond_handle_t* const cond, lock_handle_t* con
   return 0;
 }
 
-static inline int cond_handle_timedwait(cond_handle_t* const cond, lock_handle_t* const lock, unsigned int timeout_ms) {
+static inline int cond_handle_timedwait(cond_handle_t* const cond, lock_handle_t* const lock,
+                                        uint64_t const timeout_ms) {
   if (!SleepConditionVariableCS(cond, lock, timeout_ms)) {
     return ETIMEDOUT;
   }
@@ -145,7 +147,8 @@ static inline int cond_handle_wait(cond_handle_t* const cond, lock_handle_t* con
  *
  * @return exit status
  */
-static inline int cond_handle_timedwait(cond_handle_t* const cond, lock_handle_t* const lock, unsigned int timeout_ms);
+static inline int cond_handle_timedwait(cond_handle_t* const cond, lock_handle_t* const lock,
+                                        uint64_t const timeout_ms);
 
 /**
  * Destroys the condition variable specified by cond


### PR DESCRIPTION
This PR adds consistency in the way running threads are signaled to stop their execution.

By adding condition variables in the state of running threads, we can bypass the threads timeout intervals allowing an almost instantaneous cIRI shutdown.

Having condition variables will also allow threads to be notified that new data to be analyzed is available, allowing to resume threads only when needed. This will be done in another PR and should consume less CPU (no useless polling).