### PR TITLE
ciri/api: add milestone candidates on store_transactions

### DIFF
--- a/ciri/api/api.c
+++ b/ciri/api/api.c
@@ -370,6 +370,11 @@ retcode_t iota_api_store_transactions(iota_api_t const *const api, tangle_t *con
       log_warning(logger_id, "Updating transaction status failed\n");
       return ret;
     }
+    if (transaction_current_index(&tx) == 0 &&
+        memcmp(transaction_address(&tx), api->core->consensus.milestone_tracker.conf->coordinator_address,
+               FLEX_TRIT_SIZE_243) == 0) {
+      ret = iota_milestone_tracker_add_candidate(&api->core->consensus.milestone_tracker, transaction_hash(&tx));
+    }
     // TODO store metadata: arrival_time, status, sender (#407)
   }
 

--- a/ciri/api/tests/test_store_transactions.c
+++ b/ciri/api/tests/test_store_transactions.c
@@ -121,6 +121,8 @@ int main(void) {
   tips_cache_init(&api.core->node.tips, 5000);
   iota_consensus_transaction_solidifier_init(&api.core->consensus.transaction_solidifier, &api.core->consensus.conf,
                                              &api.core->node.transaction_requester, &api.core->node.tips);
+  iota_milestone_tracker_init(&core.consensus.milestone_tracker, &core.consensus.conf, &core.consensus.snapshot,
+                              &core.consensus.ledger_validator, &core.consensus.transaction_solidifier);
 
   RUN_TEST(test_store_transactions_empty);
   RUN_TEST(test_store_transactions_invalid_tx);


### PR DESCRIPTION
Unlike IRI, cIRI analyzes milestones as soon as they arrive, that means we need to send candidates to the tracker when processing them from the gossip AND from `storeTransactions` API. The latter was previously forgotten.

# Test Plan:
Tested with CLI commands
