### PR TITLE
mobile/android: Build with -ldl flag to prevent crash on Android 5.0/5.1

### DIFF
--- a/mobile/android/BUILD
+++ b/mobile/android/BUILD
@@ -5,7 +5,10 @@ cc_library(
         "jni.h",
     ],
     hdrs = ["Interface.h"],
-    linkopts = ["-lm"],
+    linkopts = [
+        "-lm",
+        "-ldl",
+    ],
     deps = [
         "//common/helpers",
         "//utils:memset_safe",


### PR DESCRIPTION
Adds `-ldl` flag to `linkopts` to prevent a crash on Android 5.0/5.1 (API 21/22)

See iotaledger/trinity-wallet#1463 and https://github.com/bazelbuild/bazel/issues/6959 for more info

# Test Plan:
Tested on Google Nexus 6, Android 5.0.1 and 5.1.1