### PR TITLE
infra: remove bazel.rc from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Bazel
-bazel*
+bazel-*
 user.bazelrc
 
 # cIRI


### PR DESCRIPTION
Only the bazel directories should be ignored: `bazel-bin`, `bazel-entangled`, `bazel-genfiles`, `out` and  `bazel-testlogs`. `bazel.rc` was wrongly ignored.