### PR TITLE
gossip: fix random tip request condition

### DIFF
--- a/gossip/components/responder.c
+++ b/gossip/components/responder.c
@@ -48,8 +48,8 @@ static retcode_t get_transaction_for_request(responder_t const *const responder,
     flex_trit_t tip[FLEX_TRIT_SIZE_243];
 
     log_debug(logger_id, "Responding to random tip request\n");
-    if (rand_handle_probability() < responder->node->conf.p_reply_random_tip &&
-        !requester_is_empty(&responder->node->transaction_requester)) {
+    if (!requester_is_empty(&responder->node->transaction_requester) ||
+        rand_handle_probability() < responder->node->conf.p_reply_random_tip) {
       neighbor->nbr_random_tx_reqs++;
       if ((ret = tips_cache_random_tip(&responder->node->tips, tip)) != RC_OK) {
         return ret;


### PR DESCRIPTION
The condition didn't match the definition of the `p_reply_random_tip` variable which is `Probability of replying to a random transaction request, even though your node doesn't have anything to request.`