### PR TITLE
cclient: fix potential double free on send trytes

### DIFF
--- a/cclient/api/extended/send_trytes.c
+++ b/cclient/api/extended/send_trytes.c
@@ -61,13 +61,14 @@ retcode_t iota_client_send_trytes(iota_client_service_t const* const serv, hash8
 
   // attach to tangle
   ret_code = iota_client_attach_to_tangle(local_pow ? NULL : serv, attach_req, attach_res);
+
+  attach_req->trytes = NULL;
+  attach_to_tangle_req_free(&attach_req);
+
   if (ret_code) {
     log_error(client_extended_logger_id, "sending attach to tangle failed: %s\n", error_2_string(ret_code));
     goto done;
   }
-
-  attach_req->trytes = NULL;
-  attach_to_tangle_req_free(&attach_req);
 
   // store and broadcast
   ret_code = iota_client_store_and_broadcast(serv, (store_transactions_req_t*)attach_res);


### PR DESCRIPTION
Fixes #1181 

Due to the `goto` before nulling the trytes.