### PR TITLE
consensus: rename local snapshot metadata file extension

### DIFF
--- a/consensus/snapshot/snapshot.c
+++ b/consensus/snapshot/snapshot.c
@@ -16,7 +16,7 @@
 #include "utils/signed_files.h"
 
 #define SNAPSHOT_STATE_EXT ".state"
-#define SNAPSHOT_METADATA_EXT ".metadata"
+#define SNAPSHOT_METADATA_EXT ".meta"
 
 #define SNAPSHOT_LOGGER_ID "snapshot"
 


### PR DESCRIPTION
QoL change of snapshot metadata extension, so it follows as same as IRI and doesn't need to rename every time.

# Test Plan:
CI pass