### PR TITLE
CClient: Initialize cclient serialization ret_code to RC_ERROR

### DIFF
--- a/cclient/serialization/json/add_neighbors.c
+++ b/cclient/serialization/json/add_neighbors.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_add_neighbors_serialize_request(const add_neighbors_req_t *const req, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -43,7 +43,7 @@ retcode_t json_add_neighbors_serialize_request(const add_neighbors_req_t *const 
 }
 
 retcode_t json_add_neighbors_serialize_response(const add_neighbors_res_t *const res, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
 
@@ -72,7 +72,7 @@ retcode_t json_add_neighbors_serialize_response(const add_neighbors_res_t *const
 }
 
 retcode_t json_add_neighbors_deserialize_request(const char *const obj, add_neighbors_req_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 
@@ -87,7 +87,7 @@ retcode_t json_add_neighbors_deserialize_request(const char *const obj, add_neig
 }
 
 retcode_t json_add_neighbors_deserialize_response(const char *const obj, add_neighbors_res_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/attach_to_tangle.c
+++ b/cclient/serialization/json/attach_to_tangle.c
@@ -16,7 +16,7 @@ static const char *kTrytes = "trytes";
 static const char *kMwm = "minWeightMagnitude";
 
 retcode_t json_attach_to_tangle_serialize_request(const attach_to_tangle_req_t *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -60,7 +60,7 @@ done:
 }
 
 retcode_t json_attach_to_tangle_serialize_response(const attach_to_tangle_res_t *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
   cJSON *json_root = cJSON_CreateObject();
@@ -88,7 +88,7 @@ done:
 }
 
 retcode_t json_attach_to_tangle_deserialize_request(const char *const obj, attach_to_tangle_req_t *const out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
 
   if (out->trytes == NULL) {
     out->trytes = hash8019_array_new();
@@ -118,7 +118,7 @@ done:
 }
 
 retcode_t json_attach_to_tangle_deserialize_response(const char *const obj, attach_to_tangle_res_t *const out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
   log_debug(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);

--- a/cclient/serialization/json/broadcast_transactions.c
+++ b/cclient/serialization/json/broadcast_transactions.c
@@ -13,7 +13,7 @@ static const char *kCmdName = "broadcastTransactions";
 static const char *kTrytes = "trytes";
 
 retcode_t json_broadcast_transactions_serialize_request(broadcast_transactions_req_t *const req, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -47,7 +47,7 @@ retcode_t json_broadcast_transactions_serialize_request(broadcast_transactions_r
 
 retcode_t json_broadcast_transactions_deserialize_request(const char *const obj,
                                                           broadcast_transactions_req_t *const out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
 
   if (out->trytes == NULL) {
     out->trytes = hash8019_array_new();

--- a/cclient/serialization/json/check_consistency.c
+++ b/cclient/serialization/json/check_consistency.c
@@ -15,7 +15,7 @@ static const char *kInfo = "info";
 static const char *kState = "state";
 
 retcode_t json_check_consistency_serialize_request(check_consistency_req_t *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -49,7 +49,7 @@ retcode_t json_check_consistency_serialize_request(check_consistency_req_t *cons
 }
 
 retcode_t json_check_consistency_serialize_response(check_consistency_res_t *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   size_t len = 0;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -81,7 +81,7 @@ retcode_t json_check_consistency_serialize_response(check_consistency_res_t *con
 }
 
 retcode_t json_check_consistency_deserialize_request(const char *const obj, check_consistency_req_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 
@@ -96,7 +96,7 @@ retcode_t json_check_consistency_deserialize_request(const char *const obj, chec
 }
 
 retcode_t json_check_consistency_deserialize_response(const char *const obj, check_consistency_res_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/error.c
+++ b/cclient/serialization/json/error.c
@@ -10,7 +10,6 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_error_serialize_response(error_res_t *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
   char const *json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
 
@@ -29,5 +28,5 @@ retcode_t json_error_serialize_response(error_res_t *const obj, char_buffer_t *o
   }
 
   cJSON_Delete(json_root);
-  return ret;
+  return RC_OK;
 }

--- a/cclient/serialization/json/find_transactions.c
+++ b/cclient/serialization/json/find_transactions.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_find_transactions_serialize_request(find_transactions_req_t const* const obj, char_buffer_t* out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const* json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
@@ -66,7 +66,7 @@ end:
 }
 
 retcode_t json_find_transactions_deserialize_request(char const* const obj, find_transactions_req_t* out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
 
@@ -113,7 +113,7 @@ end:
 }
 
 retcode_t json_find_transactions_serialize_response(find_transactions_res_t const* const obj, char_buffer_t* out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const* json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON* json_root = cJSON_CreateObject();
@@ -141,7 +141,7 @@ end:
 }
 
 retcode_t json_find_transactions_deserialize_response(char const* const obj, find_transactions_res_t* out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON* json_obj = cJSON_Parse(obj);
   cJSON* json_item = NULL;
 

--- a/cclient/serialization/json/get_balances.c
+++ b/cclient/serialization/json/get_balances.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_get_balances_serialize_request(get_balances_req_t const *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   cJSON *json_root = cJSON_CreateObject();
   if (json_root == NULL) {
@@ -45,7 +45,7 @@ err:
 }
 
 retcode_t json_get_balances_deserialize_request(char const *const obj, get_balances_req_t *const req) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
   log_debug(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
@@ -74,7 +74,7 @@ end:
 }
 
 retcode_t json_get_balances_serialize_response(get_balances_res_t const *const res, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON *json_root = cJSON_CreateObject();
@@ -107,7 +107,7 @@ err:
 }
 
 retcode_t json_get_balances_deserialize_response(char const *const obj, get_balances_res_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/get_inclusion_states.c
+++ b/cclient/serialization/json/get_inclusion_states.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_get_inclusion_states_serialize_request(get_inclusion_states_req_t const *const req, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON *json_root = cJSON_CreateObject();
@@ -43,7 +43,7 @@ done:
 }
 
 retcode_t json_get_inclusion_states_deserialize_request(char const *const obj, get_inclusion_states_req_t *const req) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 
@@ -66,7 +66,7 @@ done:
 
 retcode_t json_get_inclusion_states_serialize_response(get_inclusion_states_res_t const *const res,
                                                        char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -93,7 +93,7 @@ done:
 }
 
 retcode_t json_get_inclusion_states_deserialize_response(char const *const obj, get_inclusion_states_res_t *const res) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/get_missing_transactions.c
+++ b/cclient/serialization/json/get_missing_transactions.c
@@ -11,7 +11,7 @@
 
 retcode_t json_get_missing_transactions_serialize_response(get_missing_transactions_res_t const *const res,
                                                            char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   cJSON *json_root = cJSON_CreateObject();

--- a/cclient/serialization/json/get_neighbors.c
+++ b/cclient/serialization/json/get_neighbors.c
@@ -44,16 +44,14 @@ static retcode_t neighbor_info_utarray_to_json_array(UT_array const *const ut, c
 }
 
 retcode_t json_get_neighbors_serialize_request(char_buffer_t *out) {
-  retcode_t ret = RC_OK;
   char const *req_text = "{\"command\":\"getNeighbors\"}";
   log_info(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
 
-  ret = char_buffer_set(out, req_text);
-  return ret;
+  return char_buffer_set(out, req_text);
 }
 
 retcode_t json_get_neighbors_serialize_response(get_neighbors_res_t const *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   cJSON *json_root = cJSON_CreateObject();
@@ -79,7 +77,7 @@ err:
 }
 
 retcode_t json_get_neighbors_deserialize_response(char const *const obj, get_neighbors_res_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
   char_buffer_t *addr = char_buffer_new();

--- a/cclient/serialization/json/get_node_info.c
+++ b/cclient/serialization/json/get_node_info.c
@@ -25,15 +25,13 @@ static char const *features = "features";
 static char const *coordinator_address = "coordinatorAddress";
 
 retcode_t json_get_node_info_serialize_request(char_buffer_t *out) {
-  retcode_t ret = RC_OK;
   char const *req_text = "{\"command\":\"getNodeInfo\"}";
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
-  ret = char_buffer_set(out, req_text);
-  return ret;
+  return char_buffer_set(out, req_text);
 }
 
 retcode_t json_get_node_info_serialize_response(get_node_info_res_t const *const obj, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
 
@@ -89,7 +87,7 @@ done:
 }
 
 retcode_t json_get_node_info_deserialize_response(char const *const obj, get_node_info_res_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/get_tips.c
+++ b/cclient/serialization/json/get_tips.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_get_tips_serialize_request(char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *req_text = "{\"command\":\"getTips\"}";
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   ret = char_buffer_allocate(out, strlen(req_text));
@@ -21,7 +21,7 @@ retcode_t json_get_tips_serialize_request(char_buffer_t *out) {
 }
 
 retcode_t json_get_tips_serialize_response(get_tips_res_t const *const res, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   cJSON *json_root = cJSON_CreateObject();
@@ -47,7 +47,7 @@ err:
 }
 
 retcode_t json_get_tips_deserialize_response(char const *const obj, get_tips_res_t *res) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/get_transactions_to_approve.c
+++ b/cclient/serialization/json/get_transactions_to_approve.c
@@ -11,7 +11,7 @@
 
 retcode_t json_get_transactions_to_approve_serialize_request(get_transactions_to_approve_req_t const *const obj,
                                                              char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -46,7 +46,7 @@ done:
 
 retcode_t json_get_transactions_to_approve_deserialize_request(char const *const obj,
                                                                get_transactions_to_approve_req_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 
@@ -72,7 +72,7 @@ end:
 
 retcode_t json_get_transactions_to_approve_serialize_response(get_transactions_to_approve_res_t const *const obj,
                                                               char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -105,7 +105,7 @@ done:
 
 retcode_t json_get_transactions_to_approve_deserialize_response(char const *const obj,
                                                                 get_transactions_to_approve_res_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/get_trytes.c
+++ b/cclient/serialization/json/get_trytes.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_get_trytes_serialize_request(get_trytes_req_t const *const req, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -39,7 +39,7 @@ done:
 }
 
 retcode_t json_get_trytes_deserialize_request(char const *const obj, get_trytes_req_t *const req) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 
@@ -53,7 +53,7 @@ retcode_t json_get_trytes_deserialize_request(char const *const obj, get_trytes_
 }
 
 retcode_t json_get_trytes_serialize_response(get_trytes_res_t const *const res, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
 
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -80,7 +80,7 @@ done:
 }
 
 retcode_t json_get_trytes_deserialize_response(char const *const obj, get_trytes_res_t *const res) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
 

--- a/cclient/serialization/json/helpers.c
+++ b/cclient/serialization/json/helpers.c
@@ -230,7 +230,7 @@ retcode_t json_get_uint64(cJSON const* const json_obj, char const* const obj_nam
 }
 
 retcode_t json_get_string(cJSON const* const json_obj, char const* const obj_name, char_buffer_t* const text) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   size_t str_len = 0;
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
   if (json_value == NULL) {
@@ -307,7 +307,7 @@ retcode_t hash243_stack_to_json_array(hash243_stack_t stack, cJSON* const json_r
 }
 
 retcode_t json_array_to_hash243_queue(cJSON const* const obj, char const* const obj_name, hash243_queue_t* queue) {
-  retcode_t ret_code = RC_OK;
+  retcode_t ret_code = RC_ERROR;
   flex_trit_t hash[FLEX_TRIT_SIZE_243] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (!json_item) {
@@ -334,7 +334,7 @@ retcode_t json_array_to_hash243_queue(cJSON const* const obj, char const* const 
 }
 
 retcode_t json_array_to_hash243_stack(cJSON const* const obj, char const* const obj_name, hash243_stack_t* stack) {
-  retcode_t ret_code = RC_OK;
+  retcode_t ret_code = RC_ERROR;
   flex_trit_t hash[FLEX_TRIT_SIZE_243] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (cJSON_IsArray(json_item)) {
@@ -384,7 +384,7 @@ retcode_t hash81_queue_to_json_array(hash81_queue_t queue, cJSON* const json_roo
 }
 
 retcode_t json_array_to_hash81_queue(cJSON const* const obj, char const* const obj_name, hash81_queue_t* queue) {
-  retcode_t ret_code = RC_OK;
+  retcode_t ret_code = RC_ERROR;
   flex_trit_t hash[FLEX_TRIT_SIZE_81] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (!json_item) {
@@ -411,7 +411,7 @@ retcode_t json_array_to_hash81_queue(cJSON const* const obj, char const* const o
 }
 
 retcode_t json_array_to_hash8019_queue(cJSON const* const obj, char const* const obj_name, hash8019_queue_t* queue) {
-  retcode_t ret_code = RC_OK;
+  retcode_t ret_code = RC_ERROR;
   flex_trit_t hash[FLEX_TRIT_SIZE_8019] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (cJSON_IsArray(json_item)) {
@@ -450,7 +450,6 @@ retcode_t flex_trits_to_json_string(cJSON* const json_obj, char const* const key
 }
 
 retcode_t json_string_hash_to_flex_trits(cJSON const* const json_obj, char const* const key, flex_trit_t* hash) {
-  retcode_t ret = RC_OK;
   size_t trit_len = 0;
   cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, key);
   if (json_value == NULL) {
@@ -463,11 +462,11 @@ retcode_t json_string_hash_to_flex_trits(cJSON const* const json_obj, char const
     if (!trit_len) {
       return RC_CCLIENT_FLEX_TRITS;
     }
+    return RC_OK;
   } else {
     log_error(json_logger_id, "[%s:%d] %s not string\n", __func__, __LINE__, STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
-  return ret;
 }
 
 retcode_t hash8019_queue_to_json_array(hash8019_queue_t queue, cJSON* const json_root, char const* const obj_name) {
@@ -558,7 +557,6 @@ retcode_t hash8019_array_to_json_array(hash8019_array_p array, cJSON* const json
 }
 
 retcode_t json_array_to_hash8019_array(cJSON const* const obj, char const* const obj_name, hash8019_array_p array) {
-  retcode_t ret_code = RC_OK;
   flex_trit_t hash[FLEX_TRIT_SIZE_8019] = {};
   cJSON* json_item = cJSON_GetObjectItemCaseSensitive(obj, obj_name);
   if (cJSON_IsArray(json_item)) {
@@ -574,5 +572,5 @@ retcode_t json_array_to_hash8019_array(cJSON const* const obj, char const* const
     log_error(json_logger_id, "[%s:%d] %s not array\n", __func__, __LINE__, STR_CCLIENT_JSON_PARSE);
     return RC_CCLIENT_JSON_PARSE;
   }
-  return ret_code;
+  return RC_OK;
 }

--- a/cclient/serialization/json/remove_neighbors.c
+++ b/cclient/serialization/json/remove_neighbors.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_remove_neighbors_serialize_request(remove_neighbors_req_t const *const req, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON *json_root = cJSON_CreateObject();
@@ -38,7 +38,7 @@ retcode_t json_remove_neighbors_serialize_request(remove_neighbors_req_t const *
 }
 
 retcode_t json_remove_neighbors_deserialize_request(char const *const obj, remove_neighbors_req_t *req) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
   log_debug(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
@@ -52,7 +52,7 @@ retcode_t json_remove_neighbors_deserialize_request(char const *const obj, remov
 }
 
 retcode_t json_remove_neighbors_serialize_response(remove_neighbors_res_t const *const res, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   char const *json_text = NULL;
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
   cJSON *json_root = cJSON_CreateObject();
@@ -74,7 +74,7 @@ retcode_t json_remove_neighbors_serialize_response(remove_neighbors_res_t const 
 }
 
 retcode_t json_remove_neighbors_deserialize_response(char const *const obj, remove_neighbors_res_t *res) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   cJSON *json_obj = cJSON_Parse(obj);
   cJSON *json_item = NULL;
   log_debug(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);

--- a/cclient/serialization/json/store_transactions.c
+++ b/cclient/serialization/json/store_transactions.c
@@ -10,7 +10,7 @@
 #include "cclient/serialization/json/logger.h"
 
 retcode_t json_store_transactions_serialize_request(store_transactions_req_t const *const req, char_buffer_t *out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
   const char *json_text = NULL;
 
   log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
@@ -39,7 +39,7 @@ retcode_t json_store_transactions_serialize_request(store_transactions_req_t con
 }
 
 retcode_t json_store_transactions_deserialize_request(char const *const obj, store_transactions_req_t *const out) {
-  retcode_t ret = RC_OK;
+  retcode_t ret = RC_ERROR;
 
   if (out->trytes == NULL) {
     return RC_NULL_PARAM;


### PR DESCRIPTION
The `iota_api_xxx` functions are already initialized ret_code to `RC_ERROR`,
thus this PR only modified functions in serialization folder.
Close #981 
# Test Plan:
Pass tests under `cclient/serialization/json`
