### PR TITLE
utils: fix warnings

### DIFF
--- a/utils/files.c
+++ b/utils/files.c
@@ -120,8 +120,8 @@ done:
 retcode_t iota_utils_read_file_into_buffer(char const *const file_path, char **const buffer) {
   retcode_t ret = RC_OK;
   FILE *fp = NULL;
-  size_t buffer_size = 0;
-  size_t offset = 0;
+  ssize_t buffer_size = 0;
+  ssize_t offset = 0;
 
   if (!iota_utils_file_exist(file_path)) {
     return RC_UTILS_FILE_DOES_NOT_EXITS;

--- a/utils/handles/socket.c
+++ b/utils/handles/socket.c
@@ -74,7 +74,12 @@ int tls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size) {
   return mbedtls_ssl_write(&ctx->ssl, (const unsigned char *)data, size);
 }
 
-int tls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size, uint64_t timeout) {
+int tls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size, uint32_t timeout) {
+  if (timeout != 0) {
+    mbedtls_ssl_config *ssl_conf = (mbedtls_ssl_config *)malloc(sizeof(mbedtls_ssl_config));
+    memcpy(ssl_conf, ctx->ssl.conf, sizeof(mbedtls_ssl_config));
+    mbedtls_ssl_conf_read_timeout(ssl_conf, timeout);
+  }
   return mbedtls_ssl_read(&ctx->ssl, (unsigned char *)data, size);
 }
 

--- a/utils/handles/socket.h
+++ b/utils/handles/socket.h
@@ -64,7 +64,7 @@ typedef struct mbedtls_ctx_s {
 int tls_socket_connect(mbedtls_ctx_t *tls_ctx, char const *host, uint16_t port, char const *ca_pem,
                        char const *client_cert_pem, char const *client_pk_pem, retcode_t *error);
 int tls_socket_send(mbedtls_ctx_t *ctx, char const *data, size_t size);
-int tls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size, uint64_t timeout);
+int tls_socket_recv(mbedtls_ctx_t *ctx, char *data, size_t size, uint32_t timeout);
 void tls_socket_close(mbedtls_ctx_t *tls_ctx);
 
 #ifdef __cplusplus

--- a/utils/signed_files.c
+++ b/utils/signed_files.c
@@ -64,7 +64,7 @@ static retcode_t validate_signature(char const *const signature_filename, flex_t
   iss_curl_address(sig_digests, root, sizeof(sig_digests), &curl);
   if ((read = getline(&line, &len, fp)) > 0) {
     line[--read] = '\0';
-    if (read != depth * HASH_LENGTH_TRYTE) {
+    if ((unsigned)read != depth * HASH_LENGTH_TRYTE) {
       ret = RC_UTILS_INVALID_SIG_FILE;
       goto done;
     }


### PR DESCRIPTION
Declaring variable `buffer_size` and `offset` in `ssize_t`
which solves the warning that comparison between signed and
unsigned number.

Decorate `read` in `/utils/singed_files.c` with `unsigned`
in if comparison to solve the warning that comparison
between signed and unsigned number.

Set timeout in `utils/handles/socket.c`.

Fixes #1222 