### PR TITLE
infra: explicit tests timeout

### DIFF
--- a/cclient/http/tests/BUILD
+++ b/cclient/http/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_http",
+    timeout = "short",
     srcs = [
         "test_http.c",
     ],

--- a/cclient/serialization/json/tests/BUILD
+++ b/cclient/serialization/json/tests/BUILD
@@ -5,6 +5,7 @@ cc_library(
 
 cc_test(
     name = "add_neighbors",
+    timeout = "short",
     srcs = ["add_neighbors.c"],
     deps = [
         ":shared",
@@ -15,6 +16,7 @@ cc_test(
 
 cc_test(
     name = "attach_to_tangle",
+    timeout = "short",
     srcs = ["attach_to_tangle.c"],
     deps = [
         ":shared",
@@ -25,6 +27,7 @@ cc_test(
 
 cc_test(
     name = "broadcast_transactions",
+    timeout = "short",
     srcs = ["broadcast_transactions.c"],
     deps = [
         ":shared",
@@ -35,6 +38,7 @@ cc_test(
 
 cc_test(
     name = "check_consistency",
+    timeout = "short",
     srcs = ["check_consistency.c"],
     deps = [
         ":shared",
@@ -45,6 +49,7 @@ cc_test(
 
 cc_test(
     name = "error",
+    timeout = "short",
     srcs = ["error.c"],
     deps = [
         ":shared",
@@ -55,6 +60,7 @@ cc_test(
 
 cc_test(
     name = "find_transactions",
+    timeout = "short",
     srcs = ["find_transactions.c"],
     deps = [
         ":shared",
@@ -65,6 +71,7 @@ cc_test(
 
 cc_test(
     name = "get_balances",
+    timeout = "short",
     srcs = ["get_balances.c"],
     deps = [
         ":shared",
@@ -75,6 +82,7 @@ cc_test(
 
 cc_test(
     name = "get_inclusion_states",
+    timeout = "short",
     srcs = ["get_inclusion_states.c"],
     deps = [
         ":shared",
@@ -85,6 +93,7 @@ cc_test(
 
 cc_test(
     name = "get_missing_transactions",
+    timeout = "short",
     srcs = ["get_missing_transactions.c"],
     deps = [
         ":shared",
@@ -95,6 +104,7 @@ cc_test(
 
 cc_test(
     name = "get_neighbors",
+    timeout = "short",
     srcs = ["get_neighbors.c"],
     deps = [
         ":shared",
@@ -105,6 +115,7 @@ cc_test(
 
 cc_test(
     name = "get_node_info",
+    timeout = "short",
     srcs = ["get_node_info.c"],
     deps = [
         ":shared",
@@ -115,6 +126,7 @@ cc_test(
 
 cc_test(
     name = "get_tips",
+    timeout = "short",
     srcs = ["get_tips.c"],
     deps = [
         ":shared",
@@ -125,6 +137,7 @@ cc_test(
 
 cc_test(
     name = "get_transactions_to_approve",
+    timeout = "short",
     srcs = ["get_transactions_to_approve.c"],
     deps = [
         ":shared",
@@ -135,6 +148,7 @@ cc_test(
 
 cc_test(
     name = "get_trytes",
+    timeout = "short",
     srcs = ["get_trytes.c"],
     deps = [
         ":shared",
@@ -145,6 +159,7 @@ cc_test(
 
 cc_test(
     name = "remove_neighbors",
+    timeout = "short",
     srcs = ["remove_neighbors.c"],
     deps = [
         ":shared",
@@ -155,6 +170,7 @@ cc_test(
 
 cc_test(
     name = "store_transactions",
+    timeout = "short",
     srcs = ["store_transactions.c"],
     deps = [
         ":shared",

--- a/ciri/api/tests/BUILD
+++ b/ciri/api/tests/BUILD
@@ -16,6 +16,7 @@ genrule(
 
 cc_test(
     name = "test_add_neighbors",
+    timeout = "short",
     srcs = ["test_add_neighbors.c"],
     deps = [
         "//ciri/api",
@@ -25,6 +26,7 @@ cc_test(
 
 cc_test(
     name = "test_attach_to_tangle",
+    timeout = "short",
     srcs = ["test_attach_to_tangle.c"],
     deps = [
         "//ciri/api",
@@ -35,6 +37,7 @@ cc_test(
 
 cc_test(
     name = "test_broadcast_transactions",
+    timeout = "short",
     srcs = ["test_broadcast_transactions.c"],
     data = [":db_file"],
     deps = [
@@ -47,6 +50,7 @@ cc_test(
 
 cc_test(
     name = "test_check_consistency",
+    timeout = "moderate",
     srcs = ["test_check_consistency.c"],
     data = [":db_file"],
     deps = [
@@ -58,6 +62,7 @@ cc_test(
 
 cc_test(
     name = "test_find_transactions",
+    timeout = "moderate",
     srcs = ["test_find_transactions.c"],
     data = [":db_file"],
     deps = [
@@ -70,6 +75,7 @@ cc_test(
 
 cc_test(
     name = "test_get_missing_transactions",
+    timeout = "short",
     srcs = ["test_get_missing_transactions.c"],
     data = [":db_file"],
     deps = [
@@ -81,6 +87,7 @@ cc_test(
 
 cc_test(
     name = "test_get_neighbors",
+    timeout = "short",
     srcs = ["test_get_neighbors.c"],
     deps = [
         "//ciri/api",
@@ -90,6 +97,7 @@ cc_test(
 
 cc_test(
     name = "test_get_node_info",
+    timeout = "short",
     srcs = ["test_get_node_info.c"],
     data = [":db_file"],
     deps = [
@@ -101,6 +109,7 @@ cc_test(
 
 cc_test(
     name = "test_get_tips",
+    timeout = "short",
     srcs = ["test_get_tips.c"],
     deps = [
         "//ciri/api",
@@ -110,6 +119,7 @@ cc_test(
 
 cc_test(
     name = "test_get_transactions_to_approve",
+    timeout = "short",
     srcs = ["test_get_transactions_to_approve.c"],
     data = [":db_file"],
     deps = [
@@ -121,6 +131,7 @@ cc_test(
 
 cc_test(
     name = "test_get_trytes",
+    timeout = "short",
     srcs = ["test_get_trytes.c"],
     data = [":db_file"],
     deps = [
@@ -133,6 +144,7 @@ cc_test(
 
 cc_test(
     name = "test_remove_neighbors",
+    timeout = "short",
     srcs = ["test_remove_neighbors.c"],
     deps = [
         "//ciri/api",
@@ -142,6 +154,7 @@ cc_test(
 
 cc_test(
     name = "test_store_transactions",
+    timeout = "short",
     srcs = ["test_store_transactions.c"],
     data = [":db_file"],
     deps = [

--- a/common/crypto/curl-p/tests/BUILD
+++ b/common/crypto/curl-p/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_curlp",
+    timeout = "short",
     srcs = ["test_curlp.c"],
     deps = [
         "//common/crypto/curl-p:trit",
@@ -9,6 +10,7 @@ cc_test(
 
 cc_test(
     name = "test_curlp_bct",
+    timeout = "short",
     srcs = ["test_bct.c"],
     deps = [
         "//common/crypto/curl-p:bct",
@@ -18,6 +20,7 @@ cc_test(
 
 cc_test(
     name = "test_curlp_ptrit",
+    timeout = "short",
     srcs = [
         "test_curlp_ptrit.c",
         "test_curlp_ptrit.h",
@@ -30,6 +33,7 @@ cc_test(
 
 cc_test(
     name = "test_cpu_hashcash",
+    timeout = "short",
     srcs = [
         "test_cpu_hashcash.c",
     ],
@@ -43,6 +47,7 @@ cc_test(
 
 cc_test(
     name = "test_cpu_hamming",
+    timeout = "short",
     srcs = [
         "test_cpu_hamming.c",
     ],

--- a/common/crypto/ftroika/tests/BUILD
+++ b/common/crypto/ftroika/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_ftroika",
+    timeout = "short",
     srcs = ["test_ftroika.c"],
     deps = [
         "//common/crypto/ftroika",

--- a/common/crypto/iss/v1/tests/BUILD
+++ b/common/crypto/iss/v1/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_iss",
+    timeout = "short",
     srcs = [
         "test_iss.c",
     ],
@@ -13,6 +14,7 @@ cc_test(
 
 cc_test(
     name = "test_iss_curl",
+    timeout = "short",
     srcs = [
         "test_iss_curl.c",
     ],
@@ -25,6 +27,7 @@ cc_test(
 
 cc_test(
     name = "test_iss_kerl",
+    timeout = "short",
     srcs = [
         "test_iss_kerl.c",
     ],

--- a/common/crypto/iss/v2/tests/BUILD
+++ b/common/crypto/iss/v2/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_iss_curl",
+    timeout = "short",
     srcs = [
         "test_iss_curl.c",
     ],

--- a/common/crypto/kerl/tests/BUILD
+++ b/common/crypto/kerl/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_converter",
+    timeout = "short",
     srcs = ["test_converter.c"],
     deps = [
         "//common/crypto/kerl:converter",
@@ -10,6 +11,7 @@ cc_test(
 
 cc_test(
     name = "test_kerl",
+    timeout = "short",
     srcs = ["test_kerl.c"],
     deps = [
         "//common/crypto/kerl",

--- a/common/crypto/sponge/tests/BUILD
+++ b/common/crypto/sponge/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_sponge",
+    timeout = "short",
     srcs = ["test_sponge.c"],
     deps = [
         "//common/crypto/sponge",

--- a/common/model/tests/BUILD
+++ b/common/model/tests/BUILD
@@ -9,6 +9,7 @@ cc_library(
 
 cc_test(
     name = "test_bundle",
+    timeout = "short",
     srcs = ["test_bundle.c"],
     deps = [
         "//common/crypto/iss:normalize",
@@ -21,6 +22,7 @@ cc_test(
 
 cc_test(
     name = "test_transaction",
+    timeout = "short",
     srcs = ["test_transaction.c"],
     deps = [
         ":defs",
@@ -31,6 +33,7 @@ cc_test(
 
 cc_test(
     name = "test_tryte_transaction",
+    timeout = "short",
     srcs = ["test_tryte_transaction.cc"],
     deps = [
         ":defs",
@@ -42,6 +45,7 @@ cc_test(
 
 cc_test(
     name = "test_transfer",
+    timeout = "short",
     srcs = ["test_transfer.c"],
     deps = [
         ":defs",
@@ -54,6 +58,7 @@ cc_test(
 
 cc_test(
     name = "test_inputs",
+    timeout = "short",
     srcs = ["test_inputs.c"],
     deps = [
         ":defs",

--- a/common/storage/sql/sqlite3/tests/BUILD
+++ b/common/storage/sql/sqlite3/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_sqlite3",
+    timeout = "moderate",
     srcs = [
         "test_sqlite3.c",
     ],

--- a/common/trinary/tests/BUILD
+++ b/common/trinary/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_ptrit",
+    timeout = "short",
     srcs = ["test_trit_ptrit.c"],
     deps = [
         "//common/trinary:trit_ptrit",
@@ -9,6 +10,7 @@ cc_test(
 
 cc_test(
     name = "test_byte",
+    timeout = "short",
     srcs = ["test_trit_byte.c"],
     deps = [
         "//common/trinary:trit_byte",
@@ -18,6 +20,7 @@ cc_test(
 
 cc_test(
     name = "test_tryte",
+    timeout = "short",
     srcs = ["test_trit_tryte.c"],
     deps = [
         "//common/trinary:trit_tryte",
@@ -27,6 +30,7 @@ cc_test(
 
 cc_test(
     name = "test_long",
+    timeout = "short",
     srcs = ["test_trit_long.c"],
     deps = [
         "//common/trinary:trit_long",
@@ -36,6 +40,7 @@ cc_test(
 
 cc_test(
     name = "test_tryte_long",
+    timeout = "short",
     srcs = ["test_tryte_long.c"],
     deps = [
         "//common/trinary:tryte_long",
@@ -45,6 +50,7 @@ cc_test(
 
 cc_test(
     name = "test_tryte_ascii",
+    timeout = "short",
     srcs = ["test_tryte_ascii.c"],
     deps = [
         "//common/trinary:tryte_ascii",
@@ -54,6 +60,7 @@ cc_test(
 
 cc_test(
     name = "test_add",
+    timeout = "short",
     srcs = ["test_add.c"],
     deps = [
         "//common/trinary:add",
@@ -63,6 +70,7 @@ cc_test(
 
 cc_test(
     name = "test_flex_trit",
+    timeout = "short",
     srcs = ["test_flex_trit.c"],
     deps = [
         "//common/trinary:flex_trit",
@@ -72,6 +80,7 @@ cc_test(
 
 cc_test(
     name = "test_trit_array",
+    timeout = "short",
     srcs = ["test_trit_array.c"],
     deps = [
         "//common/trinary:trit_array",
@@ -81,6 +90,7 @@ cc_test(
 
 cc_test(
     name = "test_flex_trit_array",
+    timeout = "short",
     srcs = ["test_flex_trit_array.cc"],
     deps = [
         "//common/trinary:flex_trit_array",

--- a/consensus/bundle_validator/tests/BUILD
+++ b/consensus/bundle_validator/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "bundle_validator",
+    timeout = "moderate",
     srcs = [
         "bundle_validator.c",
     ],

--- a/consensus/entry_point_selector/tests/BUILD
+++ b/consensus/entry_point_selector/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_entry_point_selector",
+    timeout = "short",
     srcs = ["test_entry_point_selector.c"],
     data = [":db_file"],
     visibility = ["//visibility:public"],

--- a/consensus/exit_probability_randomizer/tests/BUILD
+++ b/consensus/exit_probability_randomizer/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_exit_probability_randomizer",
+    timeout = "short",
     srcs = [
         "test_exit_probability_randomizer.c",
     ],

--- a/consensus/exit_probability_validator/tests/BUILD
+++ b/consensus/exit_probability_validator/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_exit_probability_validator",
+    timeout = "short",
     srcs = [
         "exit_probability_validator.c",
     ],

--- a/consensus/milestone/tests/BUILD
+++ b/consensus/milestone/tests/BUILD
@@ -8,6 +8,7 @@ genrule(
 
 cc_test(
     name = "test_milestone_tracker",
+    timeout = "moderate",
     srcs = ["test_milestone_tracker.c"],
     data = [":db_file"],
     visibility = ["//visibility:public"],

--- a/consensus/snapshot/tests/BUILD
+++ b/consensus/snapshot/tests/BUILD
@@ -12,6 +12,7 @@ filegroup(
 
 cc_test(
     name = "test_snapshot",
+    timeout = "short",
     srcs = ["test_snapshot.c"],
     data = [
         ":snapshot_test_files",
@@ -26,6 +27,7 @@ cc_test(
 
 cc_test(
     name = "test_state_delta",
+    timeout = "short",
     srcs = ["test_state_delta.c"],
     data = [
         ":snapshot_test_files",
@@ -40,6 +42,7 @@ cc_test(
 
 cc_test(
     name = "test_snapshot_metadata",
+    timeout = "short",
     srcs = ["test_snapshot_metadata.c"],
     data = [
         ":snapshot_test_files",

--- a/consensus/tangle/tests/BUILD
+++ b/consensus/tangle/tests/BUILD
@@ -8,6 +8,7 @@ genrule(
 
 cc_test(
     name = "test_tangle",
+    timeout = "short",
     srcs = ["test_tangle.c"],
     data = [":db_file"],
     deps = [

--- a/cppclient/BUILD
+++ b/cppclient/BUILD
@@ -42,6 +42,7 @@ cc_library(
 
 cc_test(
     name = "tests",
+    timeout = "short",
     srcs = glob(["tests/**/*.cc"]),
     deps = [
         ":beast",

--- a/gossip/tests/BUILD
+++ b/gossip/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_tips_cache",
+    timeout = "short",
     srcs = ["test_tips_cache.c"],
     deps = [
         "//gossip:tips_cache",
@@ -9,6 +10,7 @@ cc_test(
 
 cc_test(
     name = "test_recent_seen_bytes_cache",
+    timeout = "short",
     srcs = ["test_recent_seen_bytes_cache.c"],
     deps = [
         "//consensus/test_utils",

--- a/mam/ntru/tests/BUILD
+++ b/mam/ntru/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_ntru",
+    timeout = "short",
     srcs = ["test_ntru.c"],
     deps = [
         "//mam/ntru",
@@ -9,6 +10,7 @@ cc_test(
 
 cc_test(
     name = "test_poly_mred_binary",
+    timeout = "short",
     srcs = ["test_poly.c"],
     deps = [
         "//mam/ntru:poly_mred_binary",
@@ -18,6 +20,7 @@ cc_test(
 
 cc_test(
     name = "test_poly_no_mred_binary",
+    timeout = "short",
     srcs = ["test_poly.c"],
     deps = [
         "//mam/ntru:poly_no_mred_binary",

--- a/mam/pb3/tests/BUILD
+++ b/mam/pb3/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_pb3",
+    timeout = "short",
     srcs = ["test_pb3.c"],
     deps = [
         "//mam/pb3",

--- a/mam/prng/tests/BUILD
+++ b/mam/prng/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_prng",
+    timeout = "short",
     srcs = ["test_prng.c"],
     visibility = ["//visibility:private"],
     deps = [

--- a/mam/prototype/tests/BUILD
+++ b/mam/prototype/tests/BUILD
@@ -13,6 +13,7 @@ cc_test(
 
 cc_test(
     name = "test_mask",
+    timeout = "short",
     srcs = ["test_mask.c"],
     deps =
         [

--- a/mam/psk/tests/BUILD
+++ b/mam/psk/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_psk",
+    timeout = "short",
     srcs = ["test_psk.c"],
     visibility = ["//visibility:private"],
     deps = [

--- a/mam/sponge/tests/BUILD
+++ b/mam/sponge/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_sponge",
+    timeout = "short",
     srcs = ["test_sponge.c"],
     deps = [
         "//mam/sponge",
@@ -9,6 +10,7 @@ cc_test(
 
 cc_test(
     name = "test_spongos",
+    timeout = "short",
     srcs = ["test_spongos.c"],
     deps = [
         "//mam/sponge:spongos",

--- a/mam/trits/tests/BUILD
+++ b/mam/trits/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_trits",
+    timeout = "short",
     srcs = ["test_trits.c"],
     deps = [
         "//mam/trits",

--- a/mam/troika/tests/BUILD
+++ b/mam/troika/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_troika",
+    timeout = "short",
     srcs = ["test_troika.c"],
     deps = [
         "//common/trinary:trit_tryte",

--- a/mam/wots/tests/BUILD
+++ b/mam/wots/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_wots",
+    timeout = "short",
     srcs = ["test_wots.c"],
     visibility = ["//visibility:private"],
     deps = [

--- a/tanglescope/common/BUILD
+++ b/tanglescope/common/BUILD
@@ -25,6 +25,7 @@ cc_library(
 
 cc_test(
     name = "common_test",
+    timeout = "short",
     srcs = ["tests/iri.cpp"],
     deps = [
         ":common",

--- a/tanglescope/statscollector/BUILD
+++ b/tanglescope/statscollector/BUILD
@@ -21,6 +21,7 @@ cc_library(
 
 cc_test(
     name = "tests",
+    timeout = "short",
     srcs = glob([
         "tests/**/*.cpp",
         "**/*.hpp",

--- a/utils/containers/hash/tests/BUILD
+++ b/utils/containers/hash/tests/BUILD
@@ -6,6 +6,7 @@ cc_library(
 
 cc_test(
     name = "test_hash_queue",
+    timeout = "short",
     srcs = ["test_hash_queue.c"],
     deps = [
         ":defs",
@@ -16,6 +17,7 @@ cc_test(
 
 cc_test(
     name = "test_hash_stack",
+    timeout = "short",
     srcs = ["test_hash_stack.c"],
     deps = [
         ":defs",
@@ -26,6 +28,7 @@ cc_test(
 
 cc_test(
     name = "test_hash_array",
+    timeout = "short",
     srcs = ["test_hash_array.c"],
     deps = [
         ":defs",
@@ -36,6 +39,7 @@ cc_test(
 
 cc_test(
     name = "test_hash_map",
+    timeout = "short",
     srcs = ["test_hash_map.c"],
     deps = [
         ":defs",

--- a/utils/containers/lists/test/BUILD
+++ b/utils/containers/lists/test/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_concurrent_list",
+    timeout = "short",
     srcs = ["test_concurrent_list.c"],
     deps = [
         "//utils/containers/lists:concurrent_list",

--- a/utils/containers/queues/test/BUILD
+++ b/utils/containers/queues/test/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_concurrent_queue",
+    timeout = "short",
     srcs = ["test_concurrent_queue.c"],
     deps = [
         "//utils/containers/queues:concurrent_queue",

--- a/utils/containers/tests/BUILD
+++ b/utils/containers/tests/BUILD
@@ -1,5 +1,6 @@
 cc_test(
     name = "test_map",
+    timeout = "short",
     srcs = ["test_map.c"],
     deps = [
         "//utils/containers:person_example_t_to_int_map",
@@ -10,6 +11,7 @@ cc_test(
 
 cc_test(
     name = "test_set",
+    timeout = "short",
     srcs = ["test_set.c"],
     deps = [
         "//utils/containers:int_set",

--- a/utils/tests/BUILD
+++ b/utils/tests/BUILD
@@ -2,6 +2,7 @@ load("//consensus:conf.bzl", "CONSENSUS_MAINNET_VARIABLES")
 
 cc_test(
     name = "test_merkle",
+    timeout = "moderate",
     srcs = ["test_merkle.c"],
     deps =
         [


### PR DESCRIPTION
Bazel complains that our tests are outside of default range of timeout because we don't explicitly set a timeout.