### PR TITLE
fix warnings in gossip and ciri

### DIFF
--- a/ciri/conf.c
+++ b/ciri/conf.c
@@ -14,6 +14,8 @@
 #include "ciri/conf.h"
 #include "ciri/usage.h"
 
+static char* short_options = "c:d:hl:n:p:t:u:";
+
 /*
  * Private functions
  */

--- a/ciri/usage.h
+++ b/ciri/usage.h
@@ -202,8 +202,6 @@ static struct cli_argument_s {
 
 };
 
-static char* short_options = "c:d:hl:n:p:t:u:";
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/gossip/components/processor.c
+++ b/gossip/components/processor.c
@@ -43,7 +43,7 @@ static retcode_t process_transaction_bytes(processor_t const *const processor, t
                                            flex_trit_t const *const hash) {
   retcode_t ret = RC_OK;
   bool exists = false;
-  iota_transaction_t transaction = {.metadata.snapshot_index = 0, .metadata.solid = 0, .loaded_columns_mask = 0};
+  iota_transaction_t transaction = {.metadata = {.snapshot_index = 0, .solid = 0}, .loaded_columns_mask = {0}};
   flex_trit_t transaction_flex_trits[FLEX_TRIT_SIZE_8019];
 
   if (processor == NULL || neighbor == NULL || packet == NULL || hash == NULL) {

--- a/gossip/neighbor.c
+++ b/gossip/neighbor.c
@@ -61,7 +61,7 @@ retcode_t neighbor_send_packet(node_t *const node, neighbor_t *const neighbor, i
   }
 
   if (neighbor->endpoint.protocol == PROTOCOL_TCP) {
-    if (tcp_send(&node->receiver.tcp_service, &neighbor->endpoint, packet) == false) {
+    if (tcp_send(&neighbor->endpoint, packet) == false) {
       return RC_NEIGHBOR_FAILED_SEND;
     }
   } else if (neighbor->endpoint.protocol == PROTOCOL_UDP) {

--- a/gossip/services/tcp_sender.cc
+++ b/gossip/services/tcp_sender.cc
@@ -32,9 +32,13 @@ retcode_t tcp_sender_endpoint_init(endpoint_t *const endpoint) {
   return RC_OK;
 }
 
-retcode_t tcp_sender_endpoint_destroy(endpoint_t *const endpoint) { return RC_OK; }
+retcode_t tcp_sender_endpoint_destroy(endpoint_t *const endpoint) {
+  delete endpoint->opaque_inetaddr;
+  endpoint->opaque_inetaddr = NULL;
+  return RC_OK;
+}
 
-bool tcp_send(receiver_service_t *const service, endpoint_t *const endpoint, iota_packet_t const *const packet) {
+bool tcp_send(endpoint_t *const endpoint, iota_packet_t const *const packet) {
   if (endpoint == NULL) {
     return false;
   } else if (endpoint->opaque_inetaddr == NULL) {

--- a/gossip/services/tcp_sender.hpp
+++ b/gossip/services/tcp_sender.hpp
@@ -27,7 +27,7 @@ retcode_t tcp_sender_endpoint_destroy(endpoint_t *const endpoint);
  *
  * @return true if sending succeeded, false otherwise
  */
-bool tcp_send(receiver_service_t *const service, endpoint_t *const endpoint, iota_packet_t const *const packet);
+bool tcp_send(endpoint_t *const endpoint, iota_packet_t const *const packet);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I think that `static char* short_options`  would not be used outside `/ciri/conf.c`, so I move it to `/ciri/conf.c` from `/ciri/conf.h`

I removed  the arguemnt, `receiver_service_t *const service`, of `tcp_send()`.
And I free `endpoint->opaque_inetaddr` in `tcp_sender_endpoint_destroy()`

Fixes #1224 