### PR TITLE
mam: api remaining sks functions

### DIFF
--- a/mam/api/api.c
+++ b/mam/api/api.c
@@ -374,6 +374,10 @@ retcode_t mam_api_create_channel(mam_api_t *const api, size_t const height, tryt
   return ret;
 }
 
+size_t mam_api_channel_remaining_sks(mam_api_t *const api, tryte_t const *const channel_id) {
+  return mam_channel_remaining_sks(mam_api_get_channel(api, channel_id));
+}
+
 retcode_t mam_api_create_endpoint(mam_api_t *const api, size_t const height, tryte_t const *const channel_id,
                                   tryte_t *const endpoint_id) {
   retcode_t ret = RC_OK;
@@ -405,6 +409,11 @@ retcode_t mam_api_create_endpoint(mam_api_t *const api, size_t const height, try
   channel->endpoint_ord++;
 
   return ret;
+}
+
+size_t mam_api_endpoint_remaining_sks(mam_api_t *const api, tryte_t const *const channel_id,
+                                      tryte_t const *const endpoint_id) {
+  return mam_endpoint_remaining_sks(mam_api_get_endpoint(api, channel_id, endpoint_id));
 }
 
 void mam_api_write_tag(trit_t *const tag, trit_t const *const msg_id, trint18_t const ord) {

--- a/mam/api/api.h
+++ b/mam/api/api.h
@@ -128,6 +128,16 @@ retcode_t mam_api_add_psk(mam_api_t *const api, mam_psk_t const *const psk);
 retcode_t mam_api_create_channel(mam_api_t *const api, size_t const height, tryte_t *const channel_id);
 
 /**
+ * Returns the number of remaining secret keys of a channel
+ *
+ * @param api - The API [in]
+ * @param channel_id - The channel id [in]
+ *
+ * @return the number of remaining secret keys of the channel
+ */
+size_t mam_api_channel_remaining_sks(mam_api_t *const api, tryte_t const *const channel_id);
+
+/**
  * Creates and adds an endpoint to the API
  *
  * @param api - The API [in, out]
@@ -139,6 +149,18 @@ retcode_t mam_api_create_channel(mam_api_t *const api, size_t const height, tryt
  */
 retcode_t mam_api_create_endpoint(mam_api_t *const api, size_t const height, tryte_t const *const channel_id,
                                   tryte_t *const endpoint_id);
+
+/**
+ * Returns the number of remaining secret keys of an endpoint
+ *
+ * @param api - The API [in]
+ * @param channel_id - The associated channel id [in]
+ * @param endpoint_id - The endpoint id [in]
+ *
+ * @return the number of remaining secret keys of the endpoint
+ */
+size_t mam_api_endpoint_remaining_sks(mam_api_t *const api, tryte_t const *const channel_id,
+                                      tryte_t const *const endpoint_id);
 
 /**
  * Creates a MAM tag that can be used in IOTA transactions

--- a/mam/api/api.h
+++ b/mam/api/api.h
@@ -130,8 +130,8 @@ retcode_t mam_api_create_channel(mam_api_t *const api, size_t const height, tryt
 /**
  * Returns the number of remaining secret keys of a channel
  *
- * @param api - The API [in]
- * @param channel_id - The channel id [in]
+ * @param[in] api - The API
+ * @param[in] channel_id - The channel id
  *
  * @return the number of remaining secret keys of the channel
  */
@@ -153,9 +153,9 @@ retcode_t mam_api_create_endpoint(mam_api_t *const api, size_t const height, try
 /**
  * Returns the number of remaining secret keys of an endpoint
  *
- * @param api - The API [in]
- * @param channel_id - The associated channel id [in]
- * @param endpoint_id - The endpoint id [in]
+ * @param[in] api - The API
+ * @param[in] channel_id - The associated channel id
+ * @param[in] endpoint_id - The endpoint id
  *
  * @return the number of remaining secret keys of the endpoint
  */

--- a/mam/api/tests/test_api.c
+++ b/mam/api/tests/test_api.c
@@ -312,13 +312,13 @@ static void test_api_create_channels(mam_api_t *api, mss_mt_height_t depth) {
   mss_mt_height_t d = depth;
 
   TEST_ASSERT(mam_api_create_channel(api, d, ch_id) == RC_OK);
-  TEST_ASSERT_EQUAL_INT(mam_api_channel_remaining_sks(api, ch_id), MAM_MSS_MAX_SKN(d));
+  TEST_ASSERT_EQUAL_INT(mam_api_channel_remaining_sks(api, ch_id), MAM_MSS_MAX_SKN(d) + 1);
   TEST_ASSERT(mam_api_create_endpoint(api, d, ch_id, ep_id) == RC_OK);
-  TEST_ASSERT_EQUAL_INT(mam_api_endpoint_remaining_sks(api, ch_id, ep_id), MAM_MSS_MAX_SKN(d));
+  TEST_ASSERT_EQUAL_INT(mam_api_endpoint_remaining_sks(api, ch_id, ep_id), MAM_MSS_MAX_SKN(d) + 1);
   TEST_ASSERT(mam_api_create_endpoint(api, d, ch_id, ep1_id) == RC_OK);
-  TEST_ASSERT_EQUAL_INT(mam_api_endpoint_remaining_sks(api, ch_id, ep1_id), MAM_MSS_MAX_SKN(d));
+  TEST_ASSERT_EQUAL_INT(mam_api_endpoint_remaining_sks(api, ch_id, ep1_id), MAM_MSS_MAX_SKN(d) + 1);
   TEST_ASSERT(mam_api_create_channel(api, d, ch1_id) == RC_OK);
-  TEST_ASSERT_EQUAL_INT(mam_api_channel_remaining_sks(api, ch1_id), MAM_MSS_MAX_SKN(d));
+  TEST_ASSERT_EQUAL_INT(mam_api_channel_remaining_sks(api, ch1_id), MAM_MSS_MAX_SKN(d) + 1);
 }
 
 static void test_api_generic() {

--- a/mam/api/tests/test_api.c
+++ b/mam/api/tests/test_api.c
@@ -398,7 +398,6 @@ static void test_api_multiple_packets_run(mam_api_t *const param_api, size_t con
   tryte_t *payload_out = NULL;
   size_t payload_out_size = 0;
   bool is_last_packet;
-  size_t remaining_sks;
 
   // write and read header
   {
@@ -412,8 +411,9 @@ static void test_api_multiple_packets_run(mam_api_t *const param_api, size_t con
 
   // write and read packets
   for (size_t i = 0; i < num_packets; i++) {
+    size_t remaining_sks = mam_api_channel_remaining_sks(param_api, ch_id);
+
     bundle_transactions_new(&bundle);
-    remaining_sks = mam_api_channel_remaining_sks(param_api, ch_id);
     TEST_ASSERT(mam_api_bundle_write_packet(param_api, msg_id, payload_in, payload_in_size, (mam_msg_checksum_t)(i % 3),
                                             i == (num_packets - 1) ? true : false, bundle) == RC_OK);
     if (i == (int)MAM_MSG_CHECKSUM_SIG) {

--- a/mam/mam/channel.c
+++ b/mam/mam/channel.c
@@ -62,10 +62,6 @@ done:
   return ret;
 }
 
-size_t mam_channel_num_remaining_sks(mam_channel_t const *const channel) {
-  return mam_mss_num_remaining_sks(&channel->mss);
-}
-
 void mam_channel_destroy(mam_channel_t *const channel) {
   MAM_ASSERT(channel);
 

--- a/mam/mam/channel.h
+++ b/mam/mam/channel.h
@@ -109,7 +109,9 @@ retcode_t mam_channel_create(mam_prng_t *const prng, mss_mt_height_t const heigh
  *
  * @return number of remaining secret keys
  */
-size_t mam_channel_num_remaining_sks(mam_channel_t const *const channel);
+static inline size_t mam_channel_remaining_sks(mam_channel_t const *const channel) {
+  return channel ? mam_mss_remaining_sks(&channel->mss) : 0;
+}
 
 /**
  * Deallocates memory for internal objects

--- a/mam/mam/endpoint.c
+++ b/mam/mam/endpoint.c
@@ -57,10 +57,6 @@ done:
   return ret;
 }
 
-size_t mam_endpoint_num_remaining_sks(mam_endpoint_t const *const endpoint) {
-  return mam_mss_num_remaining_sks(&endpoint->mss);
-}
-
 void mam_endpoint_destroy(mam_endpoint_t *const endpoint) {
   MAM_ASSERT(endpoint);
   trits_free(endpoint->name_size);

--- a/mam/mam/endpoint.h
+++ b/mam/mam/endpoint.h
@@ -90,7 +90,9 @@ retcode_t mam_endpoint_create(mam_prng_t *const prng, mss_mt_height_t const heig
  *
  * @return number of remaining secret keys
  */
-size_t mam_endpoint_num_remaining_sks(mam_endpoint_t const *const endpoint);
+static inline size_t mam_endpoint_remaining_sks(mam_endpoint_t const *const endpoint) {
+  return endpoint ? mam_mss_remaining_sks(&endpoint->mss) : 0;
+}
 
 /**
  * Deallocates memory for internal objects

--- a/mam/mss/mss_classic.c
+++ b/mam/mss/mss_classic.c
@@ -79,7 +79,7 @@ void mam_mss_auth_path(mam_mss_t *mss, mss_mt_idx_t skn, trits_t path) {
 }
 
 bool mam_mss_next(mam_mss_t *mss) {
-  if (mam_mss_num_remaining_sks(mss) == 0) {
+  if (mam_mss_remaining_sks(mss) == 0) {
     return false;
   }
 

--- a/mam/mss/mss_common.c
+++ b/mam/mss/mss_common.c
@@ -155,7 +155,7 @@ void mss_fold_auth_path(mam_spongos_t *spongos, mss_mt_idx_t skn, trits_t auth_p
   }
 }
 
-size_t mam_mss_num_remaining_sks(mam_mss_t const *const mss) {
+size_t mam_mss_remaining_sks(mam_mss_t const *const mss) {
   if (mss->skn > MAM_MSS_MAX_SKN(mss->height)) {
     return 0;
   }

--- a/mam/mss/mss_common.c
+++ b/mam/mss/mss_common.c
@@ -44,7 +44,7 @@ retcode_t mam_mss_sign(mam_mss_t *mss, trits_t hash, trits_t sig) {
   mam_sponge_t sponge;
   MAM_ASSERT(trits_size(sig) == MAM_MSS_SIG_SIZE(mss->height));
 
-  if (mam_mss_num_remaining_sks(mss) == 0) {
+  if (mam_mss_remaining_sks(mss) == 0) {
     return RC_MAM_MSS_EXHAUSTED;
   }
 

--- a/mam/mss/mss_common.h
+++ b/mam/mss/mss_common.h
@@ -156,9 +156,9 @@ bool mam_mss_next(mam_mss_t *mss);
  *
  * @param mss [in] MSS interface
  *
- * @return The number of remaining signatures
+ * @return The number of remaining secret keys
  */
-size_t mam_mss_num_remaining_sks(mam_mss_t const *const mss);
+size_t mam_mss_remaining_sks(mam_mss_t const *const mss);
 
 /**
  * Verifies MSS signature.

--- a/mam/mss/mss_traversal.c
+++ b/mam/mss/mss_traversal.c
@@ -346,7 +346,7 @@ void mam_mss_auth_path(mam_mss_t *mss, mss_mt_idx_t skn, trits_t path) {
 }
 
 bool mam_mss_next(mam_mss_t *mss) {
-  size_t sks = mam_mss_num_remaining_sks(mss);
+  size_t sks = mam_mss_remaining_sks(mss);
 
   if (sks == 0) {
     return false;

--- a/mam/mss/tests/test_mss.c
+++ b/mam/mss/tests/test_mss.c
@@ -47,7 +47,7 @@ static void mss_store_test(mam_mss_t *mss1, mam_mss_t *mss2, mam_prng_t *prng, m
     mam_mss_init(mss2, prng, curr_height, nonce, trits_null(), trits_null(), trits_null());
     mam_mss_gen(mss1);
 
-    while (mam_mss_num_remaining_sks(mss1) > 0) {
+    while (mam_mss_remaining_sks(mss1) > 0) {
       store = trits_take(store_, mam_mss_serialized_size(mss1));
       mam_mss_serialize(mss1, &store);
       store = trits_pickup_all(store);

--- a/mam/mss/tests/test_mss.c
+++ b/mam/mss/tests/test_mss.c
@@ -60,7 +60,7 @@ static void mss_store_test(mam_mss_t *mss1, mam_mss_t *mss2, mam_prng_t *prng, m
     }
 
     TEST_ASSERT_EQUAL_INT(sks, 1 << curr_height);
-    TEST_ASSERT_EQUAL_INT(mam_mss_num_remaining_sks(mss1), 0);
+    TEST_ASSERT_EQUAL_INT(mam_mss_remaining_sks(mss1), 0);
     TEST_ASSERT(mam_mss_sign_and_next(mss1, hash, sig) == RC_MAM_MSS_EXHAUSTED);
     TEST_ASSERT(mam_mss_sign_and_next(mss2, hash, sig2) == RC_MAM_MSS_EXHAUSTED);
 
@@ -107,7 +107,7 @@ static void mss_test(mam_mss_t *mss, mam_prng_t *prng, mam_spongos_t *spongos, m
 
     trits_t pk = trits_from_rep(MAM_MSS_PK_SIZE, mss->root);
 
-    while (mam_mss_num_remaining_sks(mss) > 0) {
+    while (mam_mss_remaining_sks(mss) > 0) {
       TEST_ASSERT(mam_mss_sign_and_next(mss, hash, sig) == RC_OK);
 
       TEST_ASSERT_TRUE(mam_mss_verify(spongos, hash, sig, pk));
@@ -141,7 +141,7 @@ static void mss_test(mam_mss_t *mss, mam_prng_t *prng, mam_spongos_t *spongos, m
     }
 
     TEST_ASSERT_EQUAL_INT(sks, 1 << curr_height);
-    TEST_ASSERT_EQUAL_INT(mam_mss_num_remaining_sks(mss), 0);
+    TEST_ASSERT_EQUAL_INT(mam_mss_remaining_sks(mss), 0);
     TEST_ASSERT(mam_mss_sign_and_next(mss, hash, sig) == RC_MAM_MSS_EXHAUSTED);
 
     mam_mss_destroy(mss);


### PR DESCRIPTION
There was functions to retrieve remaining sks on channels/endpoints but users don't have direct access to them through the API so they weren't actually usable. This PR adds new API-level functions to retrieve them and add tests.