### PR TITLE
CClient: fixing is_unused_address.

### DIFF
--- a/cclient/api/extended/get_new_address.c
+++ b/cclient/api/extended/get_new_address.c
@@ -20,20 +20,20 @@ retcode_t is_unused_address(iota_client_service_t const* const serv, flex_trit_t
   were_addresses_spent_from_res_t* addr_spent_res = were_addresses_spent_from_res_new();
   if (!addr_spent_req || !addr_spent_res) {
     ret_code = RC_OOM;
-    log_error(client_extended_logger_id, "%s: create were_addresses_spent_from request or response failed: %s\n",
+    log_error(client_extended_logger_id, "%s: creating were_addresses_spent_from request or response failed: %s\n",
               __func__, error_2_string(ret_code));
     goto done;
   }
 
   if ((ret_code = were_addresses_spent_from_req_add(addr_spent_req, addr)) != RC_OK) {
-    log_error(client_extended_logger_id, "%s: adding address to requeest failed.: %s\n", __func__,
+    log_error(client_extended_logger_id, "%s: adding address to request failed.: %s\n", __func__,
               error_2_string(ret_code));
     goto done;
   }
 
   if ((ret_code = iota_client_were_addresses_spent_from(serv, addr_spent_req, addr_spent_res)) == RC_OK) {
     if (were_addresses_spent_from_res_states_at(addr_spent_res, 0)) {
-      log_debug(client_extended_logger_id, "the address were spent\n");
+      log_debug(client_extended_logger_id, "the address was spent from\n");
       *is_unused = false;
       goto done;
     }
@@ -49,14 +49,14 @@ retcode_t is_unused_address(iota_client_service_t const* const serv, flex_trit_t
 
   if (!find_tran_req || !find_tran_res) {
     ret_code = RC_OOM;
-    log_error(client_extended_logger_id, "%s: create find transactions request or response failed: %s\n", __func__,
+    log_error(client_extended_logger_id, "%s: creating find transactions request or response failed: %s\n", __func__,
               error_2_string(ret_code));
     goto done;
   }
 
   ret_code = hash243_queue_push(&find_tran_req->addresses, addr);
   if (ret_code) {
-    log_error(client_extended_logger_id, "%s: hahs queue push failed: %s\n", __func__, error_2_string(ret_code));
+    log_error(client_extended_logger_id, "%s: hash queue push failed: %s\n", __func__, error_2_string(ret_code));
     goto done;
   }
   ret_code = iota_client_find_transactions(serv, find_tran_req, find_tran_res);
@@ -65,7 +65,7 @@ retcode_t is_unused_address(iota_client_service_t const* const serv, flex_trit_t
       log_debug(client_extended_logger_id, "the address has transactions\n");
       *is_unused = false;
     } else {
-      log_debug(client_extended_logger_id, "the address has no transactions and was not spent\n");
+      log_debug(client_extended_logger_id, "the address has no transactions and was not spent from\n");
       *is_unused = true;
     }
   }

--- a/cclient/api/extended/get_new_address.c
+++ b/cclient/api/extended/get_new_address.c
@@ -4,22 +4,49 @@
  *
  * Refer to the LICENSE file for licensing information
  */
-#include "cclient/api/core/find_transactions.h"
-#include "common/helpers/sign.h"
-
 #include "cclient/api/extended/get_new_address.h"
+#include "cclient/api/core/find_transactions.h"
+#include "cclient/api/core/were_addresses_spent_from.h"
 #include "cclient/api/extended/logger.h"
+#include "common/helpers/sign.h"
 
 retcode_t is_unused_address(iota_client_service_t const* const serv, flex_trit_t const* const addr,
                             bool* const is_unused) {
   retcode_t ret_code = RC_ERROR;
-  size_t ret_num = 0;
-  find_transactions_req_t* find_tran_req = NULL;
-  find_transactions_res_t* find_tran_res = NULL;
-
   log_debug(client_extended_logger_id, "[%s:%d]\n", __func__, __LINE__);
-  find_tran_req = find_transactions_req_new();
-  find_tran_res = find_transactions_res_new();
+
+  // Is it a spent address?
+  were_addresses_spent_from_req_t* addr_spent_req = were_addresses_spent_from_req_new();
+  were_addresses_spent_from_res_t* addr_spent_res = were_addresses_spent_from_res_new();
+  if (!addr_spent_req || !addr_spent_res) {
+    ret_code = RC_OOM;
+    log_error(client_extended_logger_id, "%s: create were_addresses_spent_from request or response failed: %s\n",
+              __func__, error_2_string(ret_code));
+    goto done;
+  }
+
+  if ((ret_code = were_addresses_spent_from_req_add(addr_spent_req, addr)) != RC_OK) {
+    log_error(client_extended_logger_id, "%s: adding address to requeest failed.: %s\n", __func__,
+              error_2_string(ret_code));
+    goto done;
+  }
+
+  if ((ret_code = iota_client_were_addresses_spent_from(serv, addr_spent_req, addr_spent_res)) == RC_OK) {
+    if (were_addresses_spent_from_res_states_at(addr_spent_res, 0)) {
+      log_debug(client_extended_logger_id, "the address were spent\n");
+      *is_unused = false;
+      goto done;
+    }
+  } else {
+    log_error(client_extended_logger_id, "Error: %s\n", error_2_string(ret_code));
+    goto done;
+  }
+
+  // if it's not a spent address, does it have transactions?
+  size_t ret_num = 0;
+  find_transactions_req_t* find_tran_req = find_transactions_req_new();
+  find_transactions_res_t* find_tran_res = find_transactions_res_new();
+
   if (!find_tran_req || !find_tran_res) {
     ret_code = RC_OOM;
     log_error(client_extended_logger_id, "%s: create find transactions request or response failed: %s\n", __func__,
@@ -34,10 +61,17 @@ retcode_t is_unused_address(iota_client_service_t const* const serv, flex_trit_t
   }
   ret_code = iota_client_find_transactions(serv, find_tran_req, find_tran_res);
   if (ret_code == RC_OK) {
-    ret_num = hash243_queue_count(find_tran_res->hashes);
-    *is_unused = ret_num ? false : true;
+    if ((ret_num = hash243_queue_count(find_tran_res->hashes)) > 0) {
+      log_debug(client_extended_logger_id, "the address has transactions\n");
+      *is_unused = false;
+    } else {
+      log_debug(client_extended_logger_id, "the address has no transactions and was not spent\n");
+      *is_unused = true;
+    }
   }
 done:
+  were_addresses_spent_from_req_free(&addr_spent_req);
+  were_addresses_spent_from_res_free(&addr_spent_res);
   find_transactions_req_free(&find_tran_req);
   find_transactions_res_free(&find_tran_res);
   return ret_code;


### PR DESCRIPTION
Checks unused address using both `iota_client_were_addresses_spent_from` and `iota_client_find_transactions`. 

