### PR TITLE
mam: shared library rule

### DIFF
--- a/mam/BUILD
+++ b/mam/BUILD
@@ -17,3 +17,9 @@ emcc_binary(
         "//mam/api",
     ],
 )
+
+cc_binary(
+    name = "libmam.so",
+    linkshared = True,
+    deps = ["//mam/api"],
+)


### PR DESCRIPTION
Needed for Go/Java bindings.