### PR TITLE
ciri: check if file exists before closing it

### DIFF
--- a/ciri/conf.c
+++ b/ciri/conf.c
@@ -486,7 +486,9 @@ done:
   }
   yaml_token_delete(&token);
   yaml_parser_delete(&parser);
-  fclose(file);
+  if (file) {
+    fclose(file);
+  }
   free(long_options);
 
   return ret;

--- a/mam/api/api.c
+++ b/mam/api/api.c
@@ -843,7 +843,9 @@ retcode_t mam_api_save(mam_api_t const *const api, char const *const filename, t
 done:
   free(trits_buffer);
   free(bytes);
-  fclose(file);
+  if (file) {
+    fclose(file);
+  }
 
   return ret;
 }
@@ -895,7 +897,9 @@ retcode_t mam_api_load(char const *const filename, mam_api_t *const api, tryte_t
 done:
   free(bytes);
   free(trits_buffer);
-  fclose(file);
+  if (file) {
+    fclose(file);
+  }
 
   return ret;
 }


### PR DESCRIPTION
A segment fault encountered when start running cIRI if conf.yml doesn't
exist. Adding file check to fclose resolves this situation.

# Test Plan:
Pass CI