### PR TITLE
flex_trits_slice: use memcpy for aligned buffers

### DIFF
--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -14,7 +14,7 @@
 #include "utils/macros.h"
 
 #if defined(FLEX_TRIT_ENCODING_4_TRITS_PER_BYTE)
-static flex_trit_t flex_trit_set_residual(flex_trit_t flex_trit, size_t residual) {
+static uint8_t flex_trit_set_residual(uint8_t flex_trit, size_t residual) {
   // residual <= 4
   size_t shift = (4 - residual) << 1U;
   flex_trit <<= shift;


### PR DESCRIPTION
Use `memcpy` in `flex_trits_slice` when buffers are aligned, i.e. `start` is on the boundary of `flex_trit_t`.

# Test Plan:
The changes in the code are similar for TE3, TE4, and TE5; the difference is in handling tails.
`test_flex_trits_slice` in tests seem to cover edge cases and succeed for `trit_encoding` equal 3, 4, and 5.
Simple benchmark works as expected: 10M transaction deserializations work in 7 seconds.