### PR TITLE
router: do not print warning if write failed due to connection canceled or reset

### DIFF
--- a/ciri/node/network/router.c
+++ b/ciri/node/network/router.c
@@ -86,7 +86,7 @@ static void router_on_async(uv_async_t *const handle) {
 }
 
 static void router_on_write(uv_write_t *const req, int const status) {
-  if (status) {
+  if (status && status != UV_ECANCELED && status != UV_ECONNRESET) {
     log_warning(logger_id, "Writing data failed: %s\n", uv_strerror(status));
   }
   free(req->data);


### PR DESCRIPTION
If a connection is cancelled or reset, the write callback will still be called for each queued write in order to free them. We don't want to print an actual warning message in these cases since it's unnecessary spam.