### PR TITLE
CIRI: fixing libmicrohttpd on ARM toolchain.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "rules_iota",
-    commit = "73f598ad1ce3ba79ff22d747f723d6d5cbf351e1",
+    commit = "896627184c7472b0065724a5807c12692e9d997c",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 


### PR DESCRIPTION
fixing #1391.
