### PR TITLE
mobile/ios: Abstract away uint8_t parameter conversion

### DIFF
--- a/mobile/ios/Demo/Demo/ViewController.m
+++ b/mobile/ios/Demo/Demo/ViewController.m
@@ -28,7 +28,7 @@
       iota_ios_pow_bundle:bundle
                     trunk:@"HYDAVPDGIIFDZVDYRRKGKFEOYOMGE9AQMKTN9XFYWOHGUWLAVFONTBAFFAXFMACGBSLDHPVKIC9WZ9999"
                    branch:@"RLACKHIZIJPGPK9JRXOGJNPGVIXHDJWQSDZDNMVPZVXKHAFVVWJRHHVMPKQHKSMNVQBNANTDOEBY99999"
-                      mwm:14];
+                      mwm:@14];
   NSLog(@"Attached bundle: %@", attachedBundle);
   NSDate* endBundlePoW = [NSDate date];
   NSTimeInterval durationBundlePoW = [endBundlePoW timeIntervalSinceDate:startBundlePoW] * 1000;
@@ -37,7 +37,7 @@
   // PoW
   NSLog(@"Starting PoW");
   NSDate* startPoW = [NSDate date];
-  NSString* nonce = [EntangledIOSBindings iota_ios_pow_trytes:TX_TRYTES mwm:14];
+  NSString* nonce = [EntangledIOSBindings iota_ios_pow_trytes:TX_TRYTES mwm:@14];
   NSLog(@"Received nonce: %@ ", nonce);
   NSDate* endPoW = [NSDate date];
   NSTimeInterval durationPoW = [endPoW timeIntervalSinceDate:startPoW] * 1000;

--- a/mobile/ios/Interface.h
+++ b/mobile/ios/Interface.h
@@ -15,13 +15,13 @@
 @interface EntangledIOSBindings : NSObject
 
 + (NSString*)iota_ios_digest:(NSString*)trytes;
-+ (NSString*)iota_ios_pow_trytes:(NSString*)trytes mwm:(uint8_t)mwm;
++ (NSString*)iota_ios_pow_trytes:(NSString*)trytes mwm:(NSNumber*)mwm;
 + (int8_t*)iota_ios_sign_address_gen_trits:(int8_t*)seed index:(const int)index security:(const int)security;
 + (int8_t*)iota_ios_sign_signature_gen_trits:(int8_t*)seed
                                        index:(const int)index
                                     security:(const int)security
                                   bundleHash:(int8_t*)bundleHash;
-+ (NSArray*)iota_ios_pow_bundle:(NSArray*)txsTrytes trunk:(NSString*)trunk branch:(NSString*)branch mwm:(uint8_t)mwm;
++ (NSArray*)iota_ios_pow_bundle:(NSArray*)txsTrytes trunk:(NSString*)trunk branch:(NSString*)branch mwm:(NSNumber*)mwm;
 
 @end
 

--- a/mobile/ios/Interface.mm
+++ b/mobile/ios/Interface.mm
@@ -26,10 +26,11 @@
   return outputDigest;
 }
 
-+ (NSString*)iota_ios_pow_trytes:(NSString*)trytes mwm:(uint8_t)mwm {
++ (NSString*)iota_ios_pow_trytes:(NSString*)trytes mwm:(NSNumber*)mwm {
   const char* ctrytes = [trytes cStringUsingEncoding:NSUTF8StringEncoding];
+  uint8_t cmwm = (uint8_t)[mwm unsignedCharValue];
   char* foundNonce = NULL;
-  if ((foundNonce = iota_pow_trytes(ctrytes, mwm)) == NULL) {
+  if ((foundNonce = iota_pow_trytes(ctrytes, cmwm)) == NULL) {
     return NULL;
   }
   NSString* outputNonce = [NSString stringWithFormat:@"%s", foundNonce];
@@ -52,7 +53,7 @@
   return (int8_t*)signature;
 }
 
-+ (NSArray*)iota_ios_pow_bundle:(NSArray*)txsTrytes trunk:(NSString*)trunk branch:(NSString*)branch mwm:(uint8_t)mwm {
++ (NSArray*)iota_ios_pow_bundle:(NSArray*)txsTrytes trunk:(NSString*)trunk branch:(NSString*)branch mwm:(NSNumber*)mwm {
   bundle_transactions_t* bundle = NULL;
   iota_transaction_t tx;
   iota_transaction_t* curTx = NULL;
@@ -62,6 +63,7 @@
   flex_trit_t flexBranch[FLEX_TRIT_SIZE_243];
   NSMutableArray* outputTxsTrytes = [NSMutableArray array];
   NSMutableString* outputTxsTrytesSerialized = [NSMutableString string];
+  uint8_t cmwm = (uint8_t)[mwm unsignedCharValue];
 
   flex_trits_from_trytes(flexTrunk, NUM_TRITS_TRUNK, (tryte_t*)[trunk cStringUsingEncoding:NSUTF8StringEncoding],
                          NUM_TRYTES_TRUNK, NUM_TRYTES_TRUNK);
@@ -77,7 +79,7 @@
     bundle_transactions_add(bundle, &tx);
   }
 
-  if (iota_pow_bundle(bundle, flexTrunk, flexBranch, mwm) != RC_OK) {
+  if (iota_pow_bundle(bundle, flexTrunk, flexBranch, cmwm) != RC_OK) {
     goto done;
   }
 


### PR DESCRIPTION
To make the API a bit more user friendly for iOS developers, `iota_ios_pow_trytes` and `iota_ios_pow_bundle` should accept an `NSNumber` instead of `uint8_t` for `mwm`. The conversion to `uint8_t` is done inside the function by [converting `mwm` to `unsigned char`](https://developer.apple.com/documentation/foundation/nsnumber/1409016-unsignedcharvalue?language=objc) and then casting it to `uint8_t`. 

# Test Plan:
Tested in demo app
