### PR TITLE
common: non VLA flex_trit_print

### DIFF
--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -428,10 +428,17 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len, const by
   return num_trits;
 }
 
-void flex_trit_print(flex_trit_t const *const flex_trits, size_t trits_len) {
-  size_t tryte_len = trits_len / 3;
-  tryte_t tryte_buff[tryte_len + 1];
-  flex_trits_to_trytes(tryte_buff, tryte_len, flex_trits, trits_len, trits_len);
-  tryte_buff[tryte_len] = '\0';
-  printf("%s", tryte_buff);
+void flex_trit_print(flex_trit_t const *flex_trits, size_t trits_len) {
+  #define TRYTE_BUFF_SIZE 729
+  tryte_t tryte_buff[TRYTE_BUFF_SIZE + 1];
+  for(; 0 < trits_len;) {
+    size_t chunk_trits_len = (trits_len < 3 * TRYTE_BUFF_SIZE) ? trits_len : (3 * TRYTE_BUFF_SIZE);
+    size_t chunk_tryte_len = chunk_trits_len / 3;
+    // last incomplete tryte is ignored
+    flex_trits_to_trytes(tryte_buff, chunk_tryte_len, flex_trits, chunk_trits_len, chunk_trits_len);
+    tryte_buff[chunk_tryte_len] = '\0';
+    printf("%s", tryte_buff);
+    trits_len -= chunk_trits_len;
+    flex_trits += chunk_trits_len;
+  }
 }

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -429,7 +429,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len, const by
 }
 
 void flex_trit_print(flex_trit_t const *flex_trits, size_t trits_len) {
-  #define TRYTE_BUFF_SIZE 729
+#define TRYTE_BUFF_SIZE (243 * NUM_TRITS_PER_FLEX_TRIT)
   tryte_t tryte_buff[TRYTE_BUFF_SIZE + 1];
   for(; 0 < trits_len;) {
     size_t chunk_trits_len = (trits_len < 3 * TRYTE_BUFF_SIZE) ? trits_len : (3 * TRYTE_BUFF_SIZE);
@@ -439,6 +439,6 @@ void flex_trit_print(flex_trit_t const *flex_trits, size_t trits_len) {
     tryte_buff[chunk_tryte_len] = '\0';
     printf("%s", tryte_buff);
     trits_len -= chunk_trits_len;
-    flex_trits += chunk_trits_len;
+    flex_trits += chunk_trits_len / NUM_TRITS_PER_FLEX_TRIT;
   }
 }

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -431,7 +431,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len, const by
 void flex_trit_print(flex_trit_t const *flex_trits, size_t trits_len) {
 #define TRYTE_BUFF_SIZE (243 * NUM_TRITS_PER_FLEX_TRIT)
   tryte_t tryte_buff[TRYTE_BUFF_SIZE + 1];
-  for(; 0 < trits_len;) {
+  for (; 0 < trits_len;) {
     size_t chunk_trits_len = (trits_len < 3 * TRYTE_BUFF_SIZE) ? trits_len : (3 * TRYTE_BUFF_SIZE);
     size_t chunk_tryte_len = chunk_trits_len / 3;
     // last incomplete tryte is ignored

--- a/common/trinary/flex_trit.h
+++ b/common/trinary/flex_trit.h
@@ -264,7 +264,7 @@ size_t flex_trits_from_bytes(flex_trit_t *to_flex_trits, size_t to_len, const by
  * @param trits A pointer to flex trits
  * @param trits_len Number of trit
  */
-void flex_trit_print(flex_trit_t const *const trits, size_t trits_len);
+void flex_trit_print(flex_trit_t const *trits, size_t trits_len);
 
 #endif
 #ifdef __cplusplus


### PR DESCRIPTION
flex_trit_print: print trytes by chunks, not using VLA. It only fixes one msvc compile error in common. There are some more errors however.
`flex_trit_print` can be moved out into a separate file (or even removed) as it's only used in debug output and tests.