### PR TITLE
CClient:  added iota_client_get_node_api_conf API.

### DIFF
--- a/cclient/CMakeLists.txt
+++ b/cclient/CMakeLists.txt
@@ -22,6 +22,7 @@ set(API_CORE_SRC
   ${API_CORE_DIR}/get_balances.c
   ${API_CORE_DIR}/get_inclusion_states.c
   ${API_CORE_DIR}/get_neighbors.c
+  ${API_CORE_DIR}/get_node_api_conf.c
   ${API_CORE_DIR}/get_node_info.c
   ${API_CORE_DIR}/get_tips.c
   ${API_CORE_DIR}/get_transactions_to_approve.c
@@ -103,6 +104,7 @@ set(JSON_SERIALIZER_SRC
   ${JSON_SERIALIZER_DIR}/get_inclusion_states.c
   ${JSON_SERIALIZER_DIR}/get_missing_transactions.c
   ${JSON_SERIALIZER_DIR}/get_neighbors.c
+  ${JSON_SERIALIZER_DIR}/get_node_api_conf.c
   ${JSON_SERIALIZER_DIR}/get_node_info.c
   ${JSON_SERIALIZER_DIR}/get_tips.c
   ${JSON_SERIALIZER_DIR}/get_transactions_to_approve.c
@@ -173,6 +175,7 @@ if(${CCLIENT_TEST})
   add_cclient_test("test_get_balances.c" "test_get_balances")
   add_cclient_test("test_get_inclusion_states.c" "test_get_inclusion_states")
   add_cclient_test("test_get_neighbors.c" "test_get_neighbors")
+  add_cclient_test("test_get_node_api_conf.c" "test_get_node_api_conf")
   add_cclient_test("test_get_node_info.c" "test_get_node_info")
   add_cclient_test("test_get_tips.c" "test_get_tips")
   add_cclient_test("test_get_transactions_to_approve.c" "test_get_transactions_to_approve")

--- a/cclient/README.md
+++ b/cclient/README.md
@@ -83,6 +83,7 @@ C Client API consists of two API sets:
 * iota_client_get_balances()
 * iota_client_get_inclusion_states()
 * iota_client_get_neighbors()
+* iota_client_get_node_api_conf()
 * iota_client_get_node_info()
 * iota_client_get_tips()
 * iota_client_get_transactions_to_approve()

--- a/cclient/api/core/core_api.h
+++ b/cclient/api/core/core_api.h
@@ -17,6 +17,7 @@
 #include "cclient/api/core/get_balances.h"
 #include "cclient/api/core/get_inclusion_states.h"
 #include "cclient/api/core/get_neighbors.h"
+#include "cclient/api/core/get_node_api_conf.h"
 #include "cclient/api/core/get_node_info.h"
 #include "cclient/api/core/get_tips.h"
 #include "cclient/api/core/get_transactions_to_approve.h"

--- a/cclient/api/core/doxy.txt
+++ b/cclient/api/core/doxy.txt
@@ -28,6 +28,7 @@
  * - #iota_client_get_balances
  * - #iota_client_get_inclusion_states
  * - #iota_client_get_neighbors
+ * - #iota_client_get_node_api_conf
  * - #iota_client_get_node_info
  * - #iota_client_get_tips
  * - #iota_client_get_transactions_to_approve

--- a/cclient/api/core/get_node_api_conf.c
+++ b/cclient/api/core/get_node_api_conf.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "cclient/api/core/get_node_api_conf.h"
+#include "cclient/api/core/logger.h"
+
+retcode_t iota_client_get_node_api_conf(iota_client_service_t const* const service, get_node_api_conf_res_t* res) {
+  log_debug(client_core_logger_id, "[%s:%d]\n", __func__, __LINE__);
+  retcode_t result = RC_ERROR;
+
+  if (!service || !res) {
+    log_error(client_core_logger_id, "[%s:%d] %s\n", __func__, __LINE__, error_2_string(RC_NULL_PARAM));
+    return RC_NULL_PARAM;
+  }
+
+  char_buffer_t* req_buff = char_buffer_new();
+  char_buffer_t* res_buff = char_buffer_new();
+  if (req_buff == NULL || res_buff == NULL) {
+    log_critical(client_core_logger_id, "[%s:%d] %s\n", __func__, __LINE__, STR_CCLIENT_OOM);
+    result = RC_OOM;
+    goto done;
+  }
+
+  if ((result = service->serializer.vtable.get_node_api_conf_serialize_request(req_buff)) != RC_OK) {
+    log_error(client_core_logger_id, "[%s:%d] %s\n", __func__, __LINE__, error_2_string(result));
+    goto done;
+  }
+
+  if ((result = iota_service_query(service, req_buff, res_buff)) != RC_OK) {
+    log_error(client_core_logger_id, "[%s:%d] %s\n", __func__, __LINE__, error_2_string(result));
+    goto done;
+  }
+
+  result = service->serializer.vtable.get_node_api_conf_deserialize_response(res_buff->data, res);
+
+done:
+  char_buffer_free(req_buff);
+  char_buffer_free(res_buff);
+  return result;
+}

--- a/cclient/api/core/get_node_api_conf.h
+++ b/cclient/api/core/get_node_api_conf.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+/**
+ * @ingroup cclient_core
+ *
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ */
+#ifndef CCLIENT_API_GET_NODE_API_CONF_H
+#define CCLIENT_API_GET_NODE_API_CONF_H
+
+#include "cclient/http/http.h"
+#include "cclient/response/get_node_api_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Returns configuration of the connected node.
+ *
+ * @param[in] service client service
+ * @param[out] res node configuration
+ * @return #retcode_t
+ */
+retcode_t iota_client_get_node_api_conf(iota_client_service_t const* const service, get_node_api_conf_res_t* res);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CCLIENT_API_GET_NODE_API_CONF_H
+
+/** @} */

--- a/cclient/api/examples/cclient_examples.c
+++ b/cclient/api/examples/cclient_examples.c
@@ -85,6 +85,7 @@ int main() {
   // example_get_tips(&serv);
   // example_get_transactions_to_approve(&serv);
   // example_get_trytes(&serv);
+  // example_node_api_conf(&serv);
   example_node_info(&serv);
   // example_prepare_transfer(&serv);
   // example_store_transactions(&serv);

--- a/cclient/api/examples/cclient_examples.h
+++ b/cclient/api/examples/cclient_examples.h
@@ -33,6 +33,7 @@ void example_get_inclusion_states(iota_client_service_t *s);
 void example_get_tips(iota_client_service_t *s);
 void example_get_transactions_to_approve(iota_client_service_t *s);
 void example_get_trytes(iota_client_service_t *s);
+void example_node_api_conf(iota_client_service_t *s);
 void example_node_info(iota_client_service_t *s);
 void example_prepare_transfer(iota_client_service_t *s);
 void example_store_transactions(iota_client_service_t *s);

--- a/cclient/api/examples/example_node_api_conf.c
+++ b/cclient/api/examples/example_node_api_conf.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "cclient/api/examples/cclient_examples.h"
+
+void example_node_api_conf(iota_client_service_t *s) {
+  printf("\n[%s]\n", __FUNCTION__);
+  retcode_t ret = RC_ERROR;
+  get_node_api_conf_res_t node_conf = {};
+
+  if ((ret = iota_client_get_node_api_conf(s, &node_conf)) == RC_OK) {
+    printf("maxFindTransactions: %" PRIu32 " \n", node_conf.max_find_transactions);
+    printf("maxRequestsList: %" PRIu32 " \n", node_conf.max_requests_list);
+    printf("maxGetTrytes: %" PRIu32 " \n", node_conf.max_get_trytes);
+    printf("maxBodyLength: %" PRIu32 " \n", node_conf.max_body_length);
+    printf("milestoneStartIndex: %" PRIu32 " \n", node_conf.milestone_start_index);
+    printf("testNet: %s\n", node_conf.test_net ? "true" : "false");
+
+  } else {
+    printf("Error: %s", error_2_string(ret));
+  }
+}

--- a/cclient/api/tests/BUILD
+++ b/cclient/api/tests/BUILD
@@ -207,3 +207,17 @@ cc_test(
         "@unity",
     ],
 )
+
+cc_test(
+    name = "test_get_node_api_conf",
+    timeout = "short",
+    srcs = [
+        "cclient_service_init.c",
+        "cclient_test_defs.h",
+        "test_get_node_api_conf.c",
+    ],
+    deps = [
+        "//cclient/api",
+        "@unity",
+    ],
+)

--- a/cclient/api/tests/test_get_node_api_conf.c
+++ b/cclient/api/tests/test_get_node_api_conf.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "cclient/api/tests/cclient_test_defs.h"
+
+static iota_client_service_t g_serv;
+
+static void test_get_node_api_conf(void) {
+  get_node_api_conf_res_t node_conf = {};
+  TEST_ASSERT(node_conf.max_find_transactions == 0);
+  TEST_ASSERT(node_conf.max_requests_list == 0);
+  TEST_ASSERT(node_conf.max_get_trytes == 0);
+  TEST_ASSERT(node_conf.max_body_length == 0);
+  TEST_ASSERT(node_conf.milestone_start_index == 0);
+  TEST_ASSERT(node_conf.test_net == 0);
+
+  TEST_ASSERT_EQUAL_INT16(RC_OK, iota_client_get_node_api_conf(&g_serv, &node_conf));
+
+  TEST_ASSERT(node_conf.max_find_transactions > 0);
+  TEST_ASSERT(node_conf.max_requests_list > 0);
+  TEST_ASSERT(node_conf.max_get_trytes > 0);
+  TEST_ASSERT(node_conf.max_body_length > 0);
+  TEST_ASSERT(node_conf.milestone_start_index > 0);
+  TEST_ASSERT(node_conf.test_net > 0);
+}
+
+int main() {
+  UNITY_BEGIN();
+
+  cclient_service_setup(&g_serv);
+
+  RUN_TEST(test_get_node_api_conf);
+
+  cclient_service_cleanup(&g_serv);
+
+  return UNITY_END();
+}

--- a/cclient/response/get_node_api_conf.h
+++ b/cclient/response/get_node_api_conf.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+/**
+ * @ingroup response
+ *
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ */
+#ifndef CCLIENT_RESPONSE_GET_NODE_CONF_H
+#define CCLIENT_RESPONSE_GET_NODE_CONF_H
+
+#include "common/errors.h"
+#include "common/trinary/flex_trit.h"
+#include "utarray.h"
+#include "utils/char_buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The data structure of the get node configuration response.
+ *
+ */
+typedef struct get_node_api_conf_res_s {
+  /**
+   * The maximum number of transactions that may be returned.
+   */
+  uint32_t max_find_transactions;
+
+  /**
+   * The maximum number of parameters in an API call.
+   */
+  uint32_t max_requests_list;
+
+  /**
+   * a maximum number of trytes that may be returned by the #iota_client_get_trytes.
+   */
+  uint32_t max_get_trytes;
+
+  /**
+   * The maximum number of characters that the body of an API call may contain.
+   */
+  uint32_t max_body_length;
+
+  /**
+   * The starting milestone index that the node uses to validate and confirm transactions.
+   */
+  uint32_t milestone_start_index;
+
+  /**
+   * The type of this node, True runs on testnet else mainnet.
+   */
+  bool test_net;
+
+} get_node_api_conf_res_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CCLIENT_RESPONSE_GET_NODE_CONF_H
+
+/** @} */

--- a/cclient/response/get_node_api_conf.h
+++ b/cclient/response/get_node_api_conf.h
@@ -42,7 +42,7 @@ typedef struct get_node_api_conf_res_s {
   uint32_t max_requests_list;
 
   /**
-   * a maximum number of trytes that may be returned by the #iota_client_get_trytes.
+   * The maximum number of trytes that may be returned by the #iota_client_get_trytes.
    */
   uint32_t max_get_trytes;
 

--- a/cclient/response/responses.h
+++ b/cclient/response/responses.h
@@ -17,6 +17,7 @@
 #include "cclient/response/get_inclusion_states.h"
 #include "cclient/response/get_missing_transactions.h"
 #include "cclient/response/get_neighbors.h"
+#include "cclient/response/get_node_api_conf.h"
 #include "cclient/response/get_node_info.h"
 #include "cclient/response/get_tips.h"
 #include "cclient/response/get_transactions_to_approve.h"

--- a/cclient/serialization/json/get_node_api_conf.c
+++ b/cclient/serialization/json/get_node_api_conf.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+#include "cclient/serialization/json/get_node_api_conf.h"
+
+#include "cclient/serialization/json/helpers.h"
+#include "cclient/serialization/json/logger.h"
+
+static char const *max_find_transactions = "maxFindTransactions";
+static char const *max_requests_list = "maxRequestsList";
+static char const *max_get_trytes = "maxGetTrytes";
+static char const *max_body_length = "maxBodyLength";
+static char const *milestone_start_index = "milestoneStartIndex";
+static char const *test_net = "testNet";
+
+retcode_t json_get_node_api_conf_serialize_request(char_buffer_t *out) {
+  char const *req_text = "{\"command\":\"getNodeAPIConfiguration\"}";
+  log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
+  if (!out) {
+    log_error(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, error_2_string(RC_NULL_PARAM));
+    return RC_NULL_PARAM;
+  }
+  return char_buffer_set(out, req_text);
+}
+
+retcode_t json_get_node_api_conf_serialize_response(get_node_api_conf_res_t const *const obj, char_buffer_t *out) {
+  log_debug(json_logger_id, "[%s:%d]\n", __func__, __LINE__);
+
+  if (!obj || !out) {
+    log_error(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, error_2_string(RC_NULL_PARAM));
+    return RC_NULL_PARAM;
+  }
+
+  cJSON *json_root = cJSON_CreateObject();
+  if (json_root == NULL) {
+    log_critical(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, STR_CCLIENT_JSON_CREATE);
+    return RC_CCLIENT_JSON_CREATE;
+  }
+
+  cJSON_AddNumberToObject(json_root, max_find_transactions, obj->max_find_transactions);
+  cJSON_AddNumberToObject(json_root, max_requests_list, obj->max_requests_list);
+  cJSON_AddNumberToObject(json_root, max_get_trytes, obj->max_get_trytes);
+  cJSON_AddNumberToObject(json_root, max_body_length, obj->max_body_length);
+  cJSON_AddNumberToObject(json_root, milestone_start_index, obj->milestone_start_index);
+  cJSON_AddBoolToObject(json_root, test_net, obj->test_net);
+
+  char const *json_text = cJSON_PrintUnformatted(json_root);
+  if (json_text) {
+    char_buffer_set(out, json_text);
+    cJSON_free((void *)json_text);
+  }
+
+  cJSON_Delete(json_root);
+  return RC_OK;
+}
+
+retcode_t json_get_node_api_conf_deserialize_response(char const *const obj, get_node_api_conf_res_t *out) {
+  retcode_t ret = RC_ERROR;
+  log_debug(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, obj);
+
+  if (!obj || !out) {
+    log_error(json_logger_id, "[%s:%d] %s\n", __func__, __LINE__, error_2_string(RC_NULL_PARAM));
+    return RC_NULL_PARAM;
+  }
+
+  cJSON *json_obj = cJSON_Parse(obj);
+  cJSON *json_item = NULL;
+
+  JSON_CHECK_ERROR(json_obj, json_item, json_logger_id);
+
+  if ((ret = json_get_uint32(json_obj, max_find_transactions, &out->max_find_transactions)) != RC_OK) {
+    goto end;
+  }
+
+  if ((ret = json_get_uint32(json_obj, max_requests_list, &out->max_requests_list)) != RC_OK) {
+    goto end;
+  }
+
+  if ((ret = json_get_uint32(json_obj, max_get_trytes, &out->max_get_trytes)) != RC_OK) {
+    goto end;
+  }
+
+  if ((ret = json_get_uint32(json_obj, max_body_length, &out->max_body_length)) != RC_OK) {
+    goto end;
+  }
+
+  if ((ret = json_get_uint32(json_obj, milestone_start_index, &out->milestone_start_index)) != RC_OK) {
+    goto end;
+  }
+
+  if ((ret = json_get_boolean(json_obj, test_net, &out->test_net)) != RC_OK) {
+    goto end;
+  }
+
+end:
+  cJSON_Delete(json_obj);
+  return ret;
+}

--- a/cclient/serialization/json/get_node_api_conf.h
+++ b/cclient/serialization/json/get_node_api_conf.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+/**
+ * @ingroup serialization_json
+ *
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ */
+#ifndef CCLIENT_SERIALIZATION_JSON_GET_NODE_CONF_H
+#define CCLIENT_SERIALIZATION_JSON_GET_NODE_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "common/errors.h"
+
+#include "cclient/response/get_node_api_conf.h"
+#include "cclient/serialization/serializer.h"
+
+/**
+ * @brief Converts a get node configuration request into a JSON string.
+ *
+ * @param[in] obj A get node configuration request object.
+ * @return #retcode_t
+ */
+retcode_t json_get_node_api_conf_serialize_request(char_buffer_t* out);
+
+/**
+ * @brief Converts a get node configuration response into a JSON string.
+ *
+ * @param[in] obj A get node configuration response object.
+ * @param[out] out A JSON string.
+ * @return #retcode_t
+ */
+retcode_t json_get_node_api_conf_serialize_response(get_node_api_conf_res_t const* const obj, char_buffer_t* out);
+
+/**
+ * @brief Converts a JSON string to a get node configuration response.
+ *
+ * @param[in] obj A JSON string.
+ * @param[out] res A get node configuration response object.
+ * @return #retcode_t
+ */
+retcode_t json_get_node_api_conf_deserialize_response(char const* const obj, get_node_api_conf_res_t* const res);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CCLIENT_SERIALIZATION_JSON_GET_NODE_CONF_H
+
+/** @} */

--- a/cclient/serialization/json/get_node_api_conf.h
+++ b/cclient/serialization/json/get_node_api_conf.h
@@ -29,7 +29,7 @@ extern "C" {
 /**
  * @brief Converts a get node configuration request into a JSON string.
  *
- * @param[in] obj A get node configuration request object.
+ * @param[out] out A JSON string of the getNodeAPIConfiguration command.
  * @return #retcode_t
  */
 retcode_t json_get_node_api_conf_serialize_request(char_buffer_t* out);

--- a/cclient/serialization/json/helpers.c
+++ b/cclient/serialization/json/helpers.c
@@ -251,6 +251,22 @@ retcode_t json_get_string(cJSON const* const json_obj, char const* const obj_nam
   return ret;
 }
 
+retcode_t json_get_boolean(cJSON const* const json_obj, char const* const obj_name, bool* const boolean) {
+  cJSON* json_value = cJSON_GetObjectItemCaseSensitive(json_obj, obj_name);
+  if (json_value == NULL) {
+    log_error(json_logger_id, "[%s:%d] %s %s.\n", __func__, __LINE__, STR_CCLIENT_JSON_KEY, obj_name);
+    return RC_CCLIENT_JSON_KEY;
+  }
+
+  if (cJSON_IsBool(json_value)) {
+    *boolean = cJSON_IsTrue(json_value);
+  } else {
+    log_error(json_logger_id, "[%s:%d] %s not bool\n", __func__, __LINE__, STR_CCLIENT_JSON_PARSE);
+    return RC_CCLIENT_JSON_PARSE;
+  }
+  return RC_OK;
+}
+
 retcode_t hash243_queue_to_json_array(hash243_queue_t queue, cJSON* const json_root, char const* const obj_name) {
   size_t array_count;
   cJSON* array_obj = NULL;

--- a/cclient/serialization/json/helpers.h
+++ b/cclient/serialization/json/helpers.h
@@ -182,6 +182,16 @@ retcode_t json_get_uint64(cJSON const *const json_obj, char const *const obj_nam
 retcode_t json_get_string(cJSON const *const json_obj, char const *const obj_name, char_buffer_t *const text);
 
 /**
+ * @brief Gets a boolean value from a JSON object.
+ *
+ * @param[in] json_obj A JSON object.
+ * @param[in] obj_name A key of a JSON element.
+ * @param[out] boolean bool.
+ * @return #retcode_t
+ */
+retcode_t json_get_boolean(cJSON const *const json_obj, char const *const obj_name, bool *const boolean);
+
+/**
  * @brief Converts a hash243 queue to a JSON array.
  *
  * @param[in] queue A hash243 queue object.

--- a/cclient/serialization/json/json_serializer.c
+++ b/cclient/serialization/json/json_serializer.c
@@ -24,6 +24,7 @@
 #include "cclient/serialization/json/get_inclusion_states.h"
 #include "cclient/serialization/json/get_missing_transactions.h"
 #include "cclient/serialization/json/get_neighbors.h"
+#include "cclient/serialization/json/get_node_api_conf.h"
 #include "cclient/serialization/json/get_node_info.h"
 #include "cclient/serialization/json/get_tips.h"
 #include "cclient/serialization/json/get_transactions_to_approve.h"
@@ -73,6 +74,10 @@ static serializer_vtable json_vtable = {
     .get_neighbors_serialize_request = json_get_neighbors_serialize_request,
     .get_neighbors_serialize_response = json_get_neighbors_serialize_response,
     .get_neighbors_deserialize_response = json_get_neighbors_deserialize_response,
+
+    .get_node_api_conf_serialize_request = json_get_node_api_conf_serialize_request,
+    .get_node_api_conf_serialize_response = json_get_node_api_conf_serialize_response,
+    .get_node_api_conf_deserialize_response = json_get_node_api_conf_deserialize_response,
 
     .get_node_info_serialize_request = json_get_node_info_serialize_request,
     .get_node_info_serialize_response = json_get_node_info_serialize_response,

--- a/cclient/serialization/json/tests/BUILD
+++ b/cclient/serialization/json/tests/BUILD
@@ -189,3 +189,14 @@ cc_test(
         "@unity",
     ],
 )
+
+cc_test(
+    name = "get_node_api_conf",
+    timeout = "short",
+    srcs = ["get_node_api_conf.c"],
+    deps = [
+        ":shared",
+        "//cclient/serialization:serializer_json",
+        "@unity",
+    ],
+)

--- a/cclient/serialization/json/tests/get_node_api_conf.c
+++ b/cclient/serialization/json/tests/get_node_api_conf.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/entangled
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "cclient/serialization/json/tests/shared.h"
+
+static void test_serialize_get_node_api_conf_request(void) {
+  serializer_t serializer;
+  char const* json_text = "{\"command\":\"getNodeAPIConfiguration\"}";
+
+  char_buffer_t* serializer_out = char_buffer_new();
+  init_json_serializer(&serializer);
+
+  serializer.vtable.get_node_api_conf_serialize_request(serializer_out);
+
+  TEST_ASSERT_EQUAL_STRING(json_text, serializer_out->data);
+
+  char_buffer_free(serializer_out);
+}
+
+static void test_deserialize_get_node_api_conf_response(void) {
+  serializer_t serializer;
+  char_buffer_t* serializer_out = char_buffer_new();
+
+  init_json_serializer(&serializer);
+  char const* json_text =
+      "{"
+        "\"maxFindTransactions\":" STR(TEST_NODE_CONF_MAX_TX) ","
+        "\"maxRequestsList\":" STR(TEST_NODE_CONF_MAX_REQ_LIST) ","
+        "\"maxGetTrytes\":" STR(TEST_NODE_CONF_MAX_TRYTES) ","
+        "\"maxBodyLength\":" STR(TEST_NODE_CONF_MAX_BODY_LEN) ","
+        "\"milestoneStartIndex\":" STR(TEST_NODE_CONF_MS_IDX) ","
+        "\"testNet\":false"
+      "}";
+
+  get_node_api_conf_res_t node_conf = {};
+
+  serializer.vtable.get_node_api_conf_deserialize_response(json_text, &node_conf);
+
+  TEST_ASSERT_EQUAL_UINT32(TEST_NODE_CONF_MAX_TX, node_conf.max_find_transactions);
+  TEST_ASSERT_EQUAL_UINT32(TEST_NODE_CONF_MAX_REQ_LIST, node_conf.max_requests_list);
+  TEST_ASSERT_EQUAL_UINT32(TEST_NODE_CONF_MAX_TRYTES, node_conf.max_get_trytes);
+  TEST_ASSERT_EQUAL_UINT32(TEST_NODE_CONF_MAX_BODY_LEN, node_conf.max_body_length);
+  TEST_ASSERT_EQUAL_UINT32(TEST_NODE_CONF_MS_IDX, node_conf.milestone_start_index);
+  TEST_ASSERT_EQUAL_UINT32(TEST_NODE_CONF_MS_IDX, node_conf.milestone_start_index);
+  TEST_ASSERT_EQUAL_INT(0, node_conf.test_net);
+
+  serializer.vtable.get_node_api_conf_serialize_response(&node_conf, serializer_out);
+  TEST_ASSERT_EQUAL_STRING(json_text, serializer_out->data);
+
+  char_buffer_free(serializer_out);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_serialize_get_node_api_conf_request);
+  RUN_TEST(test_deserialize_get_node_api_conf_response);
+  return UNITY_END();
+}

--- a/cclient/serialization/json/tests/shared.h
+++ b/cclient/serialization/json/tests/shared.h
@@ -65,6 +65,12 @@ extern "C" {
 #define TEST_BALANCES_MILESTONEINDEX 128
 #define TEST_TRANSACTION_TO_APPROVE_DEPTH 15
 
+#define TEST_NODE_CONF_MAX_TX 100000
+#define TEST_NODE_CONF_MAX_REQ_LIST 1000
+#define TEST_NODE_CONF_MAX_TRYTES 10000
+#define TEST_NODE_CONF_MAX_BODY_LEN 1000000
+#define TEST_NODE_CONF_MS_IDX 1950000
+
 #define CONSISTENCY_INFO                                                  \
   "tails are not consistent (would lead to inconsistent ledger state or " \
   "below max depth)"

--- a/cclient/serialization/serializer.h
+++ b/cclient/serialization/serializer.h
@@ -81,6 +81,10 @@ typedef struct {
   retcode_t (*get_neighbors_serialize_response)(get_neighbors_res_t const* const obj, char_buffer_t* out);
   retcode_t (*get_neighbors_deserialize_response)(char const* const obj, get_neighbors_res_t* out);
 
+  retcode_t (*get_node_api_conf_serialize_request)(char_buffer_t* out);
+  retcode_t (*get_node_api_conf_deserialize_response)(const char* const obj, get_node_api_conf_res_t* out);
+  retcode_t (*get_node_api_conf_serialize_response)(const get_node_api_conf_res_t* const obj, char_buffer_t* out);
+
   retcode_t (*get_node_info_serialize_request)(char_buffer_t* out);
   retcode_t (*get_node_info_deserialize_response)(const char* const obj, get_node_info_res_t* out);
   retcode_t (*get_node_info_serialize_response)(const get_node_info_res_t* const obj, char_buffer_t* out);


### PR DESCRIPTION
This PR implemented basic API: [getNodeAPIConfiguration](https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference#getnodeapiconfiguration)