### PR TITLE
Implement bundle_transactions_t object renew function

### DIFF
--- a/common/model/bundle.h
+++ b/common/model/bundle.h
@@ -97,6 +97,13 @@ static inline size_t bundle_transactions_size(bundle_transactions_t const *const
 }
 
 /**
+ * @brief Clear the bundle_transactions_t object to empty.
+ *
+ * @param[in] bundle The pointer of bundle object.
+ */
+static inline void bundle_transactions_clear(bundle_transactions_t *bundle) { utarray_clear(bundle); }
+
+/**
  * @brief Get bundle hash from a bundle transaction object
  *
  * @param[in] bundle The bundle transaction object

--- a/mam/api/tests/test_api.c
+++ b/mam/api/tests/test_api.c
@@ -540,8 +540,7 @@ static void test_api_trust() {
   free(payload);
   payload = NULL;
 
-  bundle_transactions_free(&bundle);
-  bundle_transactions_new(&bundle);
+  bundle_transactions_clear(bundle);
 
   // We check that the read fails due to the endpoint not being trusted
   TEST_ASSERT(mam_api_bundle_write_header_on_endpoint(&sender_api, ch_id, ep_id, NULL, NULL, bundle, msg_id) == RC_OK);
@@ -550,15 +549,13 @@ static void test_api_trust() {
   TEST_ASSERT(mam_api_bundle_read(&receiver_api, bundle, &payload, &payload_size, &is_last_packet) ==
               RC_MAM_ENDPOINT_NOT_TRUSTED);
 
-  bundle_transactions_free(&bundle);
-  bundle_transactions_new(&bundle);
+  bundle_transactions_clear(bundle);
 
   // We trust the endpoint by announcing it
   TEST_ASSERT(mam_api_bundle_announce_endpoint(&sender_api, ch_id, ep_id, NULL, NULL, bundle, msg_id) == RC_OK);
   TEST_ASSERT(mam_api_bundle_read(&receiver_api, bundle, &payload, &payload_size, &is_last_packet) == RC_OK);
 
-  bundle_transactions_free(&bundle);
-  bundle_transactions_new(&bundle);
+  bundle_transactions_clear(bundle);
 
   // The test now succeeds
   TEST_ASSERT(mam_api_bundle_write_header_on_endpoint(&sender_api, ch_id, ep_id, NULL, NULL, bundle, msg_id) == RC_OK);
@@ -568,8 +565,7 @@ static void test_api_trust() {
   free(payload);
   payload = NULL;
 
-  bundle_transactions_free(&bundle);
-  bundle_transactions_new(&bundle);
+  bundle_transactions_clear(bundle);
 
   // We check that the read fails due to the channel not being trusted
   TEST_ASSERT(mam_api_bundle_write_header_on_channel(&sender_api, ch1_id, NULL, NULL, bundle, msg_id) == RC_OK);
@@ -578,15 +574,13 @@ static void test_api_trust() {
   TEST_ASSERT(mam_api_bundle_read(&receiver_api, bundle, &payload, &payload_size, &is_last_packet) ==
               RC_MAM_CHANNEL_NOT_TRUSTED);
 
-  bundle_transactions_free(&bundle);
-  bundle_transactions_new(&bundle);
+  bundle_transactions_clear(bundle);
 
   // We trust the channel by announcing it
   TEST_ASSERT(mam_api_bundle_announce_channel(&sender_api, ch_id, ch1_id, NULL, NULL, bundle, msg_id) == RC_OK);
   TEST_ASSERT(mam_api_bundle_read(&receiver_api, bundle, &payload, &payload_size, &is_last_packet) == RC_OK);
 
-  bundle_transactions_free(&bundle);
-  bundle_transactions_new(&bundle);
+  bundle_transactions_clear(bundle);
 
   // The test now succeeds
   TEST_ASSERT(mam_api_bundle_write_header_on_channel(&sender_api, ch1_id, NULL, NULL, bundle, msg_id) == RC_OK);

--- a/mam/examples/send-header.c
+++ b/mam/examples/send-header.c
@@ -80,8 +80,7 @@ int main(int ac, char **av) {
         return EXIT_FAILURE;
       }
 
-      bundle_transactions_free(&bundle);
-      bundle_transactions_new(&bundle);
+      bundle_transactions_clear(bundle);
       if ((ret = mam_example_write_header_on_endpoint(&api, channel_id, new_endpoint_id, bundle, msg_id)) != RC_OK) {
         fprintf(stderr, "mam_example_write_header_on_endpoint failed with err %d\n", ret);
         return EXIT_FAILURE;
@@ -90,8 +89,7 @@ int main(int ac, char **av) {
     } else if (msg_pubkey == MAM_MSG_PUBKEY_EPID1) {
       tryte_t new_endpoint_id[MAM_ENDPOINT_ID_TRYTE_SIZE];
 
-      bundle_transactions_free(&bundle);
-      bundle_transactions_new(&bundle);
+      bundle_transactions_clear(bundle);
       if ((ret = mam_example_announce_endpoint(&api, channel_id, bundle, msg_id, new_endpoint_id)) != RC_OK) {
         fprintf(stderr, "mam_example_announce_endpoint failed with err %d\n", ret);
         return EXIT_FAILURE;
@@ -109,8 +107,7 @@ int main(int ac, char **av) {
         return EXIT_FAILURE;
       }
 
-      bundle_transactions_free(&bundle);
-      bundle_transactions_new(&bundle);
+      bundle_transactions_clear(bundle);
       if ((ret = mam_example_write_header_on_channel(&api, new_channel_id, bundle, msg_id)) != RC_OK) {
         fprintf(stderr, "mam_example_write_header failed with err %d\n", ret);
         return EXIT_FAILURE;


### PR DESCRIPTION
Renewing bundle transaction object is used in MAM and MAM
related implementation. This bundle renew function would
enhance the readability of the codes and make them more clear.
