### PR TITLE
CClient: update example_node_info.

### DIFF
--- a/cclient/api/examples/example_node_info.c
+++ b/cclient/api/examples/example_node_info.c
@@ -36,6 +36,20 @@ void example_node_info(iota_client_service_t *s) {
     printf("time %" PRIu64 " \n", node_res->time);
     printf("tips %d \n", node_res->tips);
     printf("transactionsToRequest %d \n", node_res->transactions_to_request);
+
+    // print out features
+    printf("features: ");
+    size_t num_features = get_node_info_req_features_num(node_res);
+    for (; num_features > 0; num_features--) {
+      printf("%s, ", get_node_info_res_features_at(node_res, num_features - 1));
+    }
+    printf("\n");
+
+    // print out the coordinator address
+    printf("coordinatorAddress: ");
+    flex_trit_print(node_res->coordinator_address, NUM_TRITS_ADDRESS);
+    printf("\n");
+
   } else {
     printf("Error: %s", error_2_string(ret));
   }

--- a/cclient/api/tests/test_get_node_info.c
+++ b/cclient/api/tests/test_get_node_info.c
@@ -24,7 +24,7 @@ static void test_get_node_info(void) {
   TEST_ASSERT(node_res->latest_solid_subtangle_milestone_index > STARTING_MILESTONE_INDEX);
   TEST_ASSERT(node_res->time > OLDER_TIMESTAMP);
   TEST_ASSERT(!flex_trits_are_null(get_node_info_res_coordinator_address(node_res), NUM_FLEX_TRITS_HASH));
-  TEST_ASSERT(get_node_info_req_features_len(node_res) > 0);
+  TEST_ASSERT(get_node_info_req_features_num(node_res) > 0);
 
   get_node_info_res_free(&node_res);
   TEST_ASSERT_NULL(node_res);

--- a/cclient/response/get_node_info.h
+++ b/cclient/response/get_node_info.h
@@ -241,19 +241,41 @@ static inline retcode_t get_node_info_res_coordinator_address_set(get_node_info_
   memcpy(res->coordinator_address, hash, FLEX_TRIT_SIZE_243);
   return RC_OK;
 }
+
+/**
+ * @brief Gets the coordinator address
+ *
+ * @param[in] res The response object.
+ * @return The coordinator address.
+ */
 static inline flex_trit_t const* get_node_info_res_coordinator_address(get_node_info_res_t const* const res) {
   if (!res) {
     return NULL;
   }
   return res->coordinator_address;
 }
+
+/**
+ * @brief Gets a feature from index.
+ *
+ * @param[in] res The response object.
+ * @param[in] idx The feature index.
+ * @return A string of a feature.
+ */
 static inline char const* get_node_info_res_features_at(get_node_info_res_t* res, size_t idx) {
   if (!res) {
     return NULL;
   }
   return *(const char**)utarray_eltptr(res->features, idx);
 }
-static inline size_t get_node_info_req_features_len(get_node_info_res_t* res) {
+
+/**
+ * @brief Gets the number of features.
+ *
+ * @param[in] res The response object.
+ * @return The number of features.
+ */
+static inline size_t get_node_info_req_features_num(get_node_info_res_t* res) {
   if (!res) {
     return 0;
   }


### PR DESCRIPTION
Updated the example of `iota_client_get_node_info`, prints out features and the coordinator address on the console.

