### PR TITLE
Update gen_hash_container.sh

### DIFF
--- a/cmake/gen_hash_container.sh
+++ b/cmake/gen_hash_container.sh
@@ -2,7 +2,7 @@
 HASH_SIZE_LIST=("27" "81" "243" "6561" "8019")
 TYPE_LIST=("queue" "stack")
 
-HASH_TEMPLATE_DIR="./utils/containers/hash"
+HASH_TEMPLATE_DIR="../utils/containers/hash"
 for HASH_TYPE in ${TYPE_LIST[@]}; do
     for HASH_FILE in ${HASH_TEMPLATE_DIR}/hash_${HASH_TYPE}*.tpl; do
         FILE_NAME=$(basename "${HASH_FILE}" .tpl)


### PR DESCRIPTION
The path of the hash_template_dir had a typo.

<<Describe the changes>>
A point was missing in the path. I added it so the file can be executed properly. 

