### PR TITLE
common: test and fix flex pow

### DIFF
--- a/common/helpers/tests/test_pow.c
+++ b/common/helpers/tests/test_pow.c
@@ -70,14 +70,14 @@ static void test_flex_pow(void) {
   flex_trits_from_trytes(tx, NUM_TRITS_SERIALIZED_TRANSACTION, (tryte_t *)TX_TRYTES, NUM_TRYTES_SERIALIZED_TRANSACTION,
                          NUM_TRYTES_SERIALIZED_TRANSACTION);
 
-  flex_trit_t *nonce = iota_pow_flex(tx, FLEX_TRIT_SIZE_8019, 9);
+  flex_trit_t *nonce = iota_pow_flex(tx, NUM_TRITS_SERIALIZED_TRANSACTION, 9);
 
   flex_trits_insert_from_pos(tx, NUM_TRITS_SERIALIZED_TRANSACTION, nonce, NUM_TRITS_NONCE, 0,
                              NUM_TRITS_SERIALIZED_TRANSACTION - NUM_TRITS_NONCE, NUM_TRITS_NONCE);
-  flex_trit_t *fhash = iota_flex_digest(tx, FLEX_TRIT_SIZE_8019);
+  flex_trit_t *fhash = iota_flex_digest(tx, NUM_TRITS_SERIALIZED_TRANSACTION);
 
   tryte_t hash[NUM_TRYTES_HASH] = {0};
-  flex_trits_to_trytes(hash, NUM_TRYTES_HASH, fhash, FLEX_TRIT_SIZE_243, FLEX_TRIT_SIZE_243);
+  flex_trits_to_trytes(hash, NUM_TRYTES_HASH, fhash, HASH_LENGTH_TRIT, HASH_LENGTH_TRIT);
 
   TEST_ASSERT_EQUAL_MEMORY(hash + HASH_LENGTH_TRYTE - 3, "999", 3);
 

--- a/common/trinary/flex_trit.c
+++ b/common/trinary/flex_trit.c
@@ -167,17 +167,19 @@ size_t flex_trits_insert_from_pos(flex_trit_t *const dst_trits, size_t const dst
   if (num_trits >= NUM_TRITS_PER_FLEX_TRIT &&
       (src_start_pos % NUM_TRITS_PER_FLEX_TRIT) == (dst_start_pos % NUM_TRITS_PER_FLEX_TRIT)) {
     // Handle head
-    size_t const head_num_trits = NUM_TRITS_PER_FLEX_TRIT - (src_start_pos % NUM_TRITS_PER_FLEX_TRIT);
+    size_t const head_num_trits =
+        (NUM_TRITS_PER_FLEX_TRIT - (src_start_pos % NUM_TRITS_PER_FLEX_TRIT)) % NUM_TRITS_PER_FLEX_TRIT;
     for (size_t i = 0; i < head_num_trits; i++) {
       trit_t t = flex_trits_at(src_trits, src_len, src_start_pos + i);
       flex_trits_set_at(dst_trits, dst_len, dst_start_pos + i, t);
     }
     // Copy flex trits as bytes
-    size_t const body_num_bytes = (num_trits - head_num_trits) / NUM_TRITS_PER_FLEX_TRIT;
-    memcpy(dst_trits + (dst_start_pos + NUM_TRITS_PER_FLEX_TRIT - 1) / NUM_TRITS_PER_FLEX_TRIT,
-           src_trits + (src_start_pos + NUM_TRITS_PER_FLEX_TRIT - 1) / NUM_TRITS_PER_FLEX_TRIT, body_num_bytes);
+    size_t const body_num_bytes = (num_trits - head_num_trits) / NUM_TRITS_PER_FLEX_TRIT * sizeof(flex_trit_t);
+    memcpy(dst_trits + (dst_start_pos + head_num_trits) / NUM_TRITS_PER_FLEX_TRIT,
+           src_trits + (src_start_pos + head_num_trits) / NUM_TRITS_PER_FLEX_TRIT, body_num_bytes);
     // Handle tail
-    for (size_t i = head_num_trits + body_num_bytes * NUM_TRITS_PER_FLEX_TRIT; i < num_trits; i++) {
+    for (size_t i = head_num_trits + body_num_bytes * NUM_TRITS_PER_FLEX_TRIT / sizeof(flex_trit_t); i < num_trits;
+         i++) {
       trit_t t = flex_trits_at(src_trits, src_len, src_start_pos + i);
       flex_trits_set_at(dst_trits, dst_len, dst_start_pos + i, t);
     }


### PR DESCRIPTION
This PR fixes issue with incorrect handling of head trits in `flex_trits_insert_from_pos`. It affects `iota_pow_flex`.

Also, fixed the test case for `iota_pow_flex` as it used sizes in flex trits instead of trits which results in invalid behaviour of `iota_pow_flex`, `iota_flex_digest` and `flex_trits_to_trytes` in the test case.
