### PR TITLE
utils: fix inconsistent return type of system_cpu_available

### DIFF
--- a/common/helpers/pow.c
+++ b/common/helpers/pow.c
@@ -26,9 +26,13 @@ trit_t *do_pow(Curl *const curl, trit_t const *const trits_in, size_t const trit
   memcpy(curl->state, trits_in + trits_len - HASH_LENGTH_TRIT, HASH_LENGTH_TRIT);
 
   // FIXME(th0br0) deal with result value of `hashcash` call
-  hashcash(curl, HASH_LENGTH_TRIT - NONCE_LENGTH, HASH_LENGTH_TRIT, mwm);
-
-  memcpy(nonce_trits, curl->state + HASH_LENGTH_TRIT - NONCE_LENGTH, NONCE_LENGTH);
+  PearlDiverStatus status = hashcash(curl, HASH_LENGTH_TRIT - NONCE_LENGTH, HASH_LENGTH_TRIT, mwm);
+  if (PEARL_DIVER_SUCCESS == status) {
+    memcpy(nonce_trits, curl->state + HASH_LENGTH_TRIT - NONCE_LENGTH, NONCE_LENGTH);
+  } else {
+    free(nonce_trits);
+    nonce_trits = NULL;
+  }
 
   return nonce_trits;
 }

--- a/mam/prototype/mam.c
+++ b/mam/prototype/mam.c
@@ -79,7 +79,11 @@ int mam_create(trit_t *const payload, size_t const payload_length, trit_t const 
   Curl curl;
   curl.type = CURL_P_27;
   memcpy(curl.state, enc_curl->state, sizeof(enc_curl->state));
-  hamming(&curl, 0, HASH_LENGTH_TRYTE, security);
+  PearlDiverStatus status = hamming(&curl, 0, HASH_LENGTH_TRYTE, security);
+  if (PEARL_DIVER_SUCCESS != status) {
+    fprintf(stderr, "hamming PoW failed with status %d\n", (int)status);
+    return -1;
+  }
   mask(payload + offset, curl.state, HASH_LENGTH_TRYTE, enc_curl);
   offset += HASH_LENGTH_TRYTE;
 

--- a/utils/system.c
+++ b/utils/system.c
@@ -14,7 +14,7 @@
 #include <unistd.h>
 #endif
 
-int system_cpu_available() {
+size_t system_cpu_available() {
 #ifdef WIN32
   SYSTEM_INFO sysinfo;
   GetSystemInfo(&sysinfo);
@@ -22,7 +22,7 @@ int system_cpu_available() {
 #elif MACOS
   int nm[2];
   size_t len = 4;
-  uint32_t count;
+  uint32_t count = 0;
 
   nm[0] = CTL_HW;
   nm[1] = HW_AVAILCPU;
@@ -37,6 +37,7 @@ int system_cpu_available() {
   }
   return count;
 #else
-  return sysconf(_SC_NPROCESSORS_ONLN);
+  long count = sysconf(_SC_NPROCESSORS_ONLN);
+  return count < 1 ? 1 : count;
 #endif
 }


### PR DESCRIPTION
Fixes issue #1461, fixed return type of `system_cpu_available` to `size_t`, added additional checks for return values.