### PR TITLE
mobile: always link libraries on android builds

### DIFF
--- a/mobile/android/BUILD
+++ b/mobile/android/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//utils:bundle_miner",
         "//utils:memset_safe",
     ],
+    alwayslink = True,
 )
 
 android_binary(


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/7362