### PR TITLE
utils/bundle_miner: use mining threshold as a power of 3

### DIFF
--- a/utils/bundle_miner.c
+++ b/utils/bundle_miner.c
@@ -42,6 +42,7 @@ static void *bundle_miner_mine_routine(void *const param) {
   byte_t candidate_normalized[NORMALIZED_BUNDLE_LENGTH];
   byte_t candidate_normalized_max[NORMALIZED_BUNDLE_LENGTH];
   bundle_miner_ctx_t *ctx = (bundle_miner_ctx_t *)param;
+  uint64_t num_trials_mining_threshold = pow(3, ctx->mining_threshold);
 
   kerl_init(&kerl);
 
@@ -61,7 +62,7 @@ static void *bundle_miner_mine_routine(void *const param) {
       if (probability < ctx->probability) {
         ctx->probability = probability;
         ctx->optimal_index = ctx->index;
-        if ((uint32_t)(1 / probability) >= ctx->mining_threshold) {
+        if (num_trials_mining_threshold > 1 && (uint64_t)(1 / probability) >= num_trials_mining_threshold) {
           break;
         }
       }

--- a/utils/bundle_miner.c
+++ b/utils/bundle_miner.c
@@ -62,7 +62,7 @@ static void *bundle_miner_mine_routine(void *const param) {
       if (probability < ctx->probability) {
         ctx->probability = probability;
         ctx->optimal_index = ctx->index;
-        if (num_trials_mining_threshold > 1 && (uint64_t)(1 / probability) >= num_trials_mining_threshold) {
+        if (num_trials_mining_threshold > 1 && (uint64_t)(1.0L / probability) >= num_trials_mining_threshold) {
           break;
         }
       }


### PR DESCRIPTION
- Use mining_threshold as a power of 3
- proivding mininig_threshold = 0 will lead to exhaustive mining