### PR TITLE
fix: Fix undefine behavior

### DIFF
--- a/common/model/bundle.c
+++ b/common/model/bundle.c
@@ -103,7 +103,9 @@ void bundle_transactions_free(bundle_transactions_t **const bundle) {
 }
 
 void bundle_transactions_add(bundle_transactions_t *const bundle, iota_transaction_t const *const transaction) {
-  utarray_push_back(bundle, transaction);
+  if (transaction) {
+    utarray_push_back(bundle, transaction);
+  }
 }
 
 void bundle_calculate_hash(bundle_transactions_t *bundle, Kerl *const kerl, flex_trit_t *out) {


### PR DESCRIPTION

When transaction is equals to NULL, then it would cause undefine
behavior. See the description in C99 7.1.4
